### PR TITLE
feat: integrate FortyGuard application domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,24 @@ jobs:
       - name: Audit repository tooling
         run: npm audit --audit-level=high
 
-  # Python and frontend lint, type, test, build, and fixture-startup jobs are
-  # added with their application scaffolds. CI must remain offline: provider
-  # smoke tests belong to explicit fixture-acquisition workflows, not PR checks.
+  python-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install Python quality tooling
+        run: python -m pip install mypy==1.20.2 pytest==9.0.3 ruff==0.15.12
+
+      - name: Lint Python
+        run: python -m ruff check app tests
+
+      - name: Type-check Python
+        run: python -m mypy app tests
+
+      - name: Test Python
+        run: python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           cache: pip
 
       - name: Install Python quality tooling
-        run: python -m pip install . mypy==1.20.2 pytest==9.0.3 ruff==0.15.12
+        run: python -m pip install ".[test]" mypy==1.20.2 pytest==9.0.3 ruff==0.15.12
 
       - name: Lint Python
         run: python -m ruff check app tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           cache: pip
 
       - name: Install Python quality tooling
-        run: python -m pip install mypy==1.20.2 pytest==9.0.3 ruff==0.15.12
+        run: python -m pip install . mypy==1.20.2 pytest==9.0.3 ruff==0.15.12
 
       - name: Lint Python
         run: python -m ruff check app tests

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,4 @@
 {
-  "*": "prettier --ignore-unknown --write"
+  "*": "prettier --ignore-unknown --write",
+  "*.py": ["python -m ruff check", "python -m pytest -q"]
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
 {
   "*": "prettier --ignore-unknown --write",
-  "*.py": ["python -m ruff check", "python -m pytest -q"]
+  "*.py": "python -m ruff check"
 }

--- a/README.md
+++ b/README.md
@@ -26,14 +26,17 @@ application scaffold lands.
 
 ## Repository Checks
 
-Node tooling currently provides formatting and dependency audit checks:
+Repository tooling provides offline Python tests, lint/type checks, formatting,
+and dependency audit checks:
 
 ```bash
 npm install
 npm run format:check
+npm run python:lint
+npm run python:typecheck
+npm run python:test
 npm audit --audit-level=high
 ```
 
-Python and frontend lint, type, test, build, and fixture-startup checks will be
-added with the application scaffold. Live FortyGuard and Overpass calls are
-never required by CI.
+Live FortyGuard and Overpass calls are never required by CI. Frontend checks will
+be added with the React/Vite scaffold.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application integration and domain contracts."""

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import Mapping, Sequence
 
 from pyproj import CRS, Transformer
@@ -39,7 +40,7 @@ def extract_exposure(
     valid_from = payload.get("valid_from")
     valid_to = payload.get("valid_to")
     fresh_at = payload.get("fresh_at")
-    if not isinstance(value, (int, float)) or not isinstance(valid_from, str) or not isinstance(valid_to, str):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or not isinstance(valid_from, str) or not isinstance(valid_to, str):
         raise ValueError("exposure response is missing value or date window")
     if not isinstance(fresh_at, str):
         raise ValueError("exposure response is missing freshness")

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -1,0 +1,91 @@
+"""Local extraction and spatial adapter contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class ExposureSummary:
+    metric: str
+    value: float
+    unit: str
+    threshold_celsius: float
+    direction: str
+    source: str
+    forecast: bool
+    valid_from: str
+    valid_to: str
+
+
+def extract_exposure(
+    payload: Mapping[str, object],
+    *,
+    metric: str,
+    threshold_celsius: float,
+    direction: str,
+    source: str,
+    forecast: bool,
+) -> ExposureSummary:
+    value = payload.get("value")
+    valid_from = payload.get("valid_from")
+    valid_to = payload.get("valid_to")
+    if not isinstance(value, (int, float)) or not isinstance(valid_from, str) or not isinstance(valid_to, str):
+        raise ValueError("exposure response is missing value or date window")
+    if payload.get("unit") != "C":
+        raise ValueError("exposure must use Celsius")
+    return ExposureSummary(metric, float(value), "C", threshold_celsius, direction, source, forecast, valid_from, valid_to)
+
+
+@dataclass(frozen=True)
+class SpatialMatch:
+    value: float | None
+    coverage: float
+    quality: str
+    projected_crs: str
+
+
+def polygon_join_contract(
+    tile_values: Sequence[tuple[float, float]],
+    *,
+    coverage: float,
+    projected_crs: str,
+) -> SpatialMatch:
+    """Represent results from a projected, area-weighted join supplied by the geospatial adapter."""
+    if not projected_crs or projected_crs.upper() in {"EPSG:4326", "WGS84"}:
+        raise ValueError("polygon joins require a projected CRS")
+    if not 0 <= coverage <= 1:
+        raise ValueError("coverage must be between 0 and 1")
+    if not tile_values or coverage == 0:
+        return SpatialMatch(None, coverage, "no_overlap", projected_crs)
+    total_weight = sum(weight for _, weight in tile_values)
+    if total_weight <= 0:
+        raise ValueError("tile overlap weights must be positive")
+    value = sum(tile_value * weight for tile_value, weight in tile_values) / total_weight
+    quality = "complete" if coverage >= 0.95 else "partial"
+    return SpatialMatch(value, coverage, quality, projected_crs)
+
+
+@dataclass(frozen=True)
+class PointMatch:
+    value: float | None
+    quality: str
+    distance_m: float | None
+
+
+def point_join_contract(
+    *,
+    containing_value: float | None,
+    boundary: bool,
+    outside_aoi: bool,
+    nearest_value: float | None = None,
+    nearest_distance_m: float | None = None,
+) -> PointMatch:
+    if outside_aoi and nearest_value is None:
+        return PointMatch(None, "outside_aoi", None)
+    if containing_value is not None:
+        return PointMatch(containing_value, "boundary" if boundary else "containing_tile", 0.0)
+    if nearest_value is not None and nearest_distance_m is not None:
+        return PointMatch(nearest_value, "nearest_fallback", nearest_distance_m)
+    return PointMatch(None, "no_match", None)

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -45,9 +45,10 @@ def extract_exposure(
         raise ValueError("exposure response is missing freshness")
     if forecast:
         raise ValueError("historical exposure context cannot be forecast")
-    if payload.get("unit") != "C":
-        raise ValueError("exposure must use Celsius")
-    return ExposureSummary(metric, float(value), "C", threshold_celsius, direction, source, forecast, valid_from, valid_to, fresh_at)
+    expected_unit = "C" if metric == "tcm" else "hours"
+    if payload.get("unit") != expected_unit:
+        raise ValueError(f"{metric} exposure must use {expected_unit}")
+    return ExposureSummary(metric, float(value), expected_unit, threshold_celsius, direction, source, forecast, valid_from, valid_to, fresh_at)
 
 
 @dataclass(frozen=True)

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Mapping, Sequence
 
+from pyproj import CRS, Transformer
+from shapely import transform
+from shapely.geometry import LineString, Point
+from shapely.geometry.base import BaseGeometry
+
 
 @dataclass(frozen=True)
 class ExposureSummary:
@@ -74,6 +79,13 @@ class PointMatch:
     distance_m: float | None
 
 
+@dataclass(frozen=True)
+class TileGeometry:
+    identity: str
+    geometry: BaseGeometry
+    value: float
+
+
 def point_join_contract(
     *,
     containing_value: float | None,
@@ -89,3 +101,74 @@ def point_join_contract(
     if nearest_value is not None and nearest_distance_m is not None:
         return PointMatch(nearest_value, "nearest_fallback", nearest_distance_m)
     return PointMatch(None, "no_match", None)
+
+
+def _local_crs(geometry: BaseGeometry) -> CRS:
+    centroid = geometry.centroid
+    zone = int((centroid.x + 180) // 6) + 1
+    epsg = (32600 if centroid.y >= 0 else 32700) + zone
+    return CRS.from_epsg(epsg)
+
+
+def _project(geometry: BaseGeometry, crs: CRS) -> BaseGeometry:
+    transformer = Transformer.from_crs("EPSG:4326", crs, always_xy=True)
+    return transform(geometry, transformer.transform, interleaved=False)
+
+
+def join_polygon_to_tiles(target: BaseGeometry, tiles: Sequence[TileGeometry]) -> SpatialMatch:
+    if not target.is_valid or target.is_empty or target.area == 0:
+        raise ValueError("target geometry is invalid")
+    crs = _local_crs(target)
+    projected_target = _project(target, crs)
+    weighted_value = 0.0
+    overlap_area = 0.0
+    for tile in tiles:
+        if not tile.geometry.is_valid or tile.geometry.is_empty:
+            raise ValueError(f"tile {tile.identity} geometry is invalid")
+        intersection_area = projected_target.intersection(_project(tile.geometry, crs)).area
+        if intersection_area > 0:
+            weighted_value += tile.value * intersection_area
+            overlap_area += intersection_area
+    if overlap_area == 0:
+        return SpatialMatch(None, 0.0, "no_overlap", crs.to_string())
+    coverage = min(1.0, overlap_area / projected_target.area)
+    quality = "complete" if coverage >= 0.95 else "partial"
+    return SpatialMatch(weighted_value / overlap_area, coverage, quality, crs.to_string())
+
+
+def join_point_to_tiles(
+    point: Point,
+    tiles: Sequence[TileGeometry],
+    *,
+    nearest_max_distance_m: float | None = None,
+) -> PointMatch:
+    if not point.is_valid or point.is_empty:
+        raise ValueError("point geometry is invalid")
+    for tile in tiles:
+        if not tile.geometry.is_valid:
+            raise ValueError(f"tile {tile.identity} geometry is invalid")
+        if tile.geometry.boundary.covers(point):
+            return PointMatch(tile.value, "boundary", 0.0)
+        if tile.geometry.contains(point):
+            return PointMatch(tile.value, "containing_tile", 0.0)
+    if nearest_max_distance_m is None or not tiles:
+        return PointMatch(None, "outside_aoi", None)
+    crs = _local_crs(point)
+    projected_point = _project(point, crs)
+    nearest_tile, distance = min(
+        ((tile, projected_point.distance(_project(tile.geometry, crs))) for tile in tiles),
+        key=lambda match: match[1],
+    )
+    if distance <= nearest_max_distance_m:
+        return PointMatch(nearest_tile.value, "nearest_fallback", distance)
+    return PointMatch(None, "outside_aoi", distance)
+
+
+def build_aoi(points: Sequence[Point], *, buffer_m: float, corridor: bool = False) -> BaseGeometry:
+    if not points or buffer_m <= 0:
+        raise ValueError("AOI requires points and a positive buffer")
+    source: BaseGeometry = LineString(points) if corridor else LineString(points).convex_hull
+    crs = _local_crs(source)
+    projected = _project(source, crs).buffer(buffer_m)
+    inverse = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+    return transform(projected, inverse.transform, interleaved=False)

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -22,6 +22,8 @@ class ExposureSummary:
     forecast: bool
     valid_from: str
     valid_to: str
+    fresh_at: str
+    role: str = "supporting_context"
 
 
 def extract_exposure(
@@ -36,11 +38,16 @@ def extract_exposure(
     value = payload.get("value")
     valid_from = payload.get("valid_from")
     valid_to = payload.get("valid_to")
+    fresh_at = payload.get("fresh_at")
     if not isinstance(value, (int, float)) or not isinstance(valid_from, str) or not isinstance(valid_to, str):
         raise ValueError("exposure response is missing value or date window")
+    if not isinstance(fresh_at, str):
+        raise ValueError("exposure response is missing freshness")
+    if forecast:
+        raise ValueError("historical exposure context cannot be forecast")
     if payload.get("unit") != "C":
         raise ValueError("exposure must use Celsius")
-    return ExposureSummary(metric, float(value), "C", threshold_celsius, direction, source, forecast, valid_from, valid_to)
+    return ExposureSummary(metric, float(value), "C", threshold_celsius, direction, source, forecast, valid_from, valid_to, fresh_at)
 
 
 @dataclass(frozen=True)

--- a/app/api.py
+++ b/app/api.py
@@ -48,6 +48,8 @@ def create_fixture_server(
             try:
                 length = int(self.headers.get("Content-Length", "0"))
                 body = json.loads(self.rfile.read(length))
+                if not isinstance(body, dict):
+                    raise ValueError("request body must be a JSON object")
                 if path == "/api/trip/analyze":
                     response = json.dumps(_trip_result(body), default=_json_default).encode()
                     self.send_response(200)

--- a/app/api.py
+++ b/app/api.py
@@ -37,7 +37,7 @@ def create_fixture_server(
     *,
     execution: HeatmapExecution | None = None,
 ) -> ThreadingHTTPServer:
-    execution = execution or HeatmapExecution(fixture_path=fixture_path)
+    configured_execution: HeatmapExecution = execution or HeatmapExecution(fixture_path=fixture_path)
 
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self) -> None:
@@ -68,9 +68,9 @@ def create_fixture_server(
                 live = body.get("execution_mode", "fixture") == "live"
                 if body.get("execution_mode", "fixture") not in {"fixture", "live"}:
                     raise ValueError("execution_mode must be fixture or live")
-                response = json.dumps(_result_json(execution.run(request, live=live)), default=_json_default).encode()
+                response = json.dumps(_result_json(configured_execution.run(request, live=live)), default=_json_default).encode()
                 self.send_response(200)
-            except (KeyError, TypeError, ValueError, OSError, json.JSONDecodeError) as error:
+            except (KeyError, TypeError, ValueError, OSError, RuntimeError, json.JSONDecodeError) as error:
                 response = json.dumps({"error": str(error), "status": "unavailable"}).encode()
                 self.send_response(400)
             self.send_header("Content-Type", "application/json")
@@ -99,12 +99,30 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
         raise ValueError("trip analysis requires hotels, routes, and shade data")
     candidates = tuple(HotelCandidate(item["identity"], item["components"]) for item in hotels)
     route_candidates = tuple(RouteCandidate(item["identity"], item["distance_m"], item["duration_s"]) for item in routes)
-    building_coverage = float(body.get("building_coverage", 0))
+    heat_metric = body.get("heat_metric", "tcm")
+    if heat_metric != "tcm":
+        raise ValueError("trip analysis currently accepts the tcm provider metric only")
+    building_coverage_value = body.get("building_coverage", 0)
+    heat_value = body.get("heat_value")
+    heat_threshold = body.get("heat_threshold")
+    corridor_values = body.get("corridor_heat_values", [])
+    if (
+        isinstance(building_coverage_value, bool)
+        or not isinstance(building_coverage_value, (int, float))
+        or isinstance(heat_value, bool)
+        or not isinstance(heat_value, (int, float))
+        or isinstance(heat_threshold, bool)
+        or not isinstance(heat_threshold, (int, float))
+        or not isinstance(corridor_values, list)
+        or any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in corridor_values)
+    ):
+        raise ValueError("trip heat and coverage values must be numeric")
+    building_coverage = float(building_coverage_value)
     route_result = RouteComparator().compare(
         lambda: route_candidates,
-        heat_value=float(body["heat_value"]),
-        heat_values=tuple(float(value) for value in body.get("corridor_heat_values", [])),
-        heat_threshold=float(body["heat_threshold"]),
+        heat_value=float(heat_value),
+        heat_values=tuple(float(value) for value in corridor_values),
+        heat_threshold=float(heat_threshold),
         shade=lambda route: float(shade[route.identity]),
         building_coverage=building_coverage,
     )
@@ -113,11 +131,11 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
         "route": {
             **asdict(route_result),
             "routes": [asdict(route) for route in route_candidates],
-            "heat_metric": body.get("heat_metric", "tcm"),
-            "heat_status": "elevated" if route_result.corridor_heat_value > float(body["heat_threshold"]) else "not_elevated",
+            "heat_metric": heat_metric,
+            "heat_status": "elevated" if route_result.corridor_heat_value > float(heat_threshold) else "not_elevated",
             "coverage": building_coverage,
             "confidence": "sufficient" if building_coverage >= 0.7 else "insufficient",
             "comparison_scope": "returned alternatives",
         },
-        "provenance": body.get("provenance", {"source": "fixture", "stale": False}),
+        "provenance": {"source": "fixture", "stale": False},
     }

--- a/app/api.py
+++ b/app/api.py
@@ -32,8 +32,12 @@ def _json_default(value: object) -> object:
     raise TypeError(f"cannot serialize {type(value).__name__}")
 
 
-def create_fixture_server(fixture_path: Path) -> ThreadingHTTPServer:
-    execution = HeatmapExecution(fixture_path=fixture_path)
+def create_fixture_server(
+    fixture_path: Path,
+    *,
+    execution: HeatmapExecution | None = None,
+) -> ThreadingHTTPServer:
+    execution = execution or HeatmapExecution(fixture_path=fixture_path)
 
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self) -> None:
@@ -61,7 +65,10 @@ def create_fixture_server(fixture_path: Path) -> ThreadingHTTPServer:
                     body.get("threshold_celsius"),
                     body.get("direction"),
                 )
-                response = json.dumps(_result_json(execution.run(request)), default=_json_default).encode()
+                live = body.get("execution_mode", "fixture") == "live"
+                if body.get("execution_mode", "fixture") not in {"fixture", "live"}:
+                    raise ValueError("execution_mode must be fixture or live")
+                response = json.dumps(_result_json(execution.run(request, live=live)), default=_json_default).encode()
                 self.send_response(200)
             except (KeyError, TypeError, ValueError, OSError, json.JSONDecodeError) as error:
                 response = json.dumps({"error": str(error), "status": "unavailable"}).encode()
@@ -101,5 +108,14 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
     )
     return {
         "hotels": [asdict(hotel) for hotel in HotelRanker().rank(candidates)],
-        "route": asdict(route_result),
+        "route": {
+            **asdict(route_result),
+            "routes": [asdict(route) for route in route_candidates],
+            "heat_metric": body.get("heat_metric", "tcm"),
+            "heat_status": "elevated" if route_result.corridor_heat_value > float(body["heat_threshold"]) else "not_elevated",
+            "coverage": float(body.get("building_coverage", 0)),
+            "confidence": "sufficient" if float(body.get("building_coverage", 0)) >= 0.7 else "insufficient",
+            "comparison_scope": "returned alternatives",
+        },
+        "provenance": body.get("provenance", {"source": "fixture", "stale": False}),
     }

--- a/app/api.py
+++ b/app/api.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from app.execution import HeatmapExecution
-from app.fortyguard import AnalyticType, HeatmapRequest
+from app.fortyguard import AnalyticType, HeatmapRequest, ProviderError
 from app.trip import HotelCandidate, HotelRanker, RouteCandidate, RouteComparator
 
 
@@ -73,7 +73,7 @@ def create_fixture_server(
                     raise ValueError("execution_mode must be fixture or live")
                 response = json.dumps(_result_json(configured_execution.run(request, live=live)), default=_json_default).encode()
                 self.send_response(200)
-            except (KeyError, TypeError, ValueError, OSError, RuntimeError, json.JSONDecodeError) as error:
+            except (KeyError, TypeError, ValueError, OSError, RuntimeError, ProviderError, json.JSONDecodeError) as error:
                 response = json.dumps({"error": str(error), "status": "unavailable"}).encode()
                 self.send_response(400)
             self.send_header("Content-Type", "application/json")

--- a/app/api.py
+++ b/app/api.py
@@ -6,6 +6,7 @@ from dataclasses import asdict
 from datetime import date
 from datetime import datetime
 from enum import Enum
+import math
 import json
 from pathlib import Path
 from typing import Any
@@ -116,7 +117,11 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
         or isinstance(heat_threshold, bool)
         or not isinstance(heat_threshold, (int, float))
         or not isinstance(corridor_values, list)
-        or any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in corridor_values)
+        or any(isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) for value in corridor_values)
+        or not math.isfinite(float(building_coverage_value))
+        or not 0 <= float(building_coverage_value) <= 1
+        or not math.isfinite(float(heat_value))
+        or not math.isfinite(float(heat_threshold))
     ):
         raise ValueError("trip heat and coverage values must be numeric")
     building_coverage = float(building_coverage_value)
@@ -125,7 +130,7 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
         heat_value=float(heat_value),
         heat_values=tuple(float(value) for value in corridor_values),
         heat_threshold=float(heat_threshold),
-        shade=lambda route: float(shade[route.identity]),
+        shade=lambda route: _finite_number(shade[route.identity], "shade"),
         building_coverage=building_coverage,
     )
     return {
@@ -141,3 +146,9 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
         },
         "provenance": {"source": "fixture", "stale": False},
     }
+
+
+def _finite_number(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"{field} must be finite numeric")
+    return float(value)

--- a/app/api.py
+++ b/app/api.py
@@ -62,15 +62,7 @@ def create_fixture_server(
                     self.end_headers()
                     self.wfile.write(response)
                     return
-                request = HeatmapRequest(
-                    AnalyticType(body["analytic_type"]),
-                    float(body["latitude"]),
-                    float(body["longitude"]),
-                    date.fromisoformat(body["start_date"]),
-                    _required_bool(body, "forecast", default=True),
-                    body.get("threshold_celsius"),
-                    body.get("direction"),
-                )
+                request = _heatmap_request(body)
                 live = body.get("execution_mode", "fixture") == "live"
                 if body.get("execution_mode", "fixture") not in {"fixture", "live"}:
                     raise ValueError("execution_mode must be fixture or live")

--- a/app/api.py
+++ b/app/api.py
@@ -103,6 +103,7 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
     route_result = RouteComparator().compare(
         lambda: route_candidates,
         heat_value=float(body["heat_value"]),
+        heat_values=tuple(float(value) for value in body.get("corridor_heat_values", [])),
         heat_threshold=float(body["heat_threshold"]),
         shade=lambda route: float(shade[route.identity]),
         building_coverage=building_coverage,

--- a/app/api.py
+++ b/app/api.py
@@ -47,13 +47,13 @@ def create_fixture_server(fixture_path: Path) -> ThreadingHTTPServer:
                     float(body["latitude"]),
                     float(body["longitude"]),
                     date.fromisoformat(body["start_date"]),
-                    bool(body.get("forecast", True)),
+                    _required_bool(body, "forecast", default=True),
                     body.get("threshold_celsius"),
                     body.get("direction"),
                 )
                 response = json.dumps(_result_json(execution.run(request)), default=_json_default).encode()
                 self.send_response(200)
-            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            except (KeyError, TypeError, ValueError, OSError, json.JSONDecodeError) as error:
                 response = json.dumps({"error": str(error), "status": "unavailable"}).encode()
                 self.send_response(400)
             self.send_header("Content-Type", "application/json")
@@ -65,3 +65,10 @@ def create_fixture_server(fixture_path: Path) -> ThreadingHTTPServer:
             return
 
     return ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+
+
+def _required_bool(body: dict[str, object], field: str, *, default: bool) -> bool:
+    value = body.get(field, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a boolean")
+    return value

--- a/app/api.py
+++ b/app/api.py
@@ -37,6 +37,7 @@ def create_fixture_server(
     fixture_path: Path,
     *,
     execution: HeatmapExecution | None = None,
+    allow_live: bool = False,
 ) -> ThreadingHTTPServer:
     configured_execution: HeatmapExecution = execution or HeatmapExecution(fixture_path=fixture_path)
 
@@ -71,6 +72,8 @@ def create_fixture_server(
                 live = body.get("execution_mode", "fixture") == "live"
                 if body.get("execution_mode", "fixture") not in {"fixture", "live"}:
                     raise ValueError("execution_mode must be fixture or live")
+                if live and not allow_live:
+                    raise ValueError("live execution is not enabled for this server")
                 response = json.dumps(_result_json(configured_execution.run(request, live=live)), default=_json_default).encode()
                 self.send_response(200)
             except (KeyError, TypeError, ValueError, OSError, RuntimeError, ProviderError, json.JSONDecodeError) as error:

--- a/app/api.py
+++ b/app/api.py
@@ -13,6 +13,8 @@ from typing import Any
 from urllib.parse import urlparse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+from fastapi import FastAPI, HTTPException
+
 from app.execution import HeatmapExecution
 from app.fortyguard import AnalyticType, HeatmapRequest, ProviderError
 from app.trip import HotelCandidate, HotelRanker, RouteCandidate, RouteComparator
@@ -90,11 +92,65 @@ def create_fixture_server(
     return ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 
 
+def create_app(
+    fixture_path: Path,
+    *,
+    execution: HeatmapExecution | None = None,
+    allow_live: bool = False,
+) -> FastAPI:
+    """Create the server-owned product API used by deployment."""
+    configured_execution: HeatmapExecution = execution or HeatmapExecution(fixture_path=fixture_path)
+    app = FastAPI(title="Heat-Aware Tourism Guide")
+
+    @app.post("/api/heatmap")
+    def heatmap(body: dict[str, object]) -> dict[str, object]:
+        try:
+            request = _heatmap_request(body)
+            mode = body.get("execution_mode", "fixture")
+            if mode not in {"fixture", "live"} or mode == "live" and not allow_live:
+                raise ValueError("requested execution mode is unavailable")
+            return _result_json(configured_execution.run(request, live=mode == "live"))
+        except (KeyError, TypeError, ValueError, OSError, RuntimeError, ProviderError) as error:
+            raise HTTPException(status_code=400, detail={"status": "unavailable", "error": str(error)}) from error
+
+    @app.post("/api/trip/analyze")
+    def trip_analyze(body: dict[str, object]) -> dict[str, object]:
+        try:
+            return _trip_result(body)
+        except (KeyError, TypeError, ValueError) as error:
+            raise HTTPException(status_code=400, detail={"status": "unavailable", "error": str(error)}) from error
+
+    return app
+
+
 def _required_bool(body: dict[str, object], field: str, *, default: bool) -> bool:
     value = body.get(field, default)
     if not isinstance(value, bool):
         raise ValueError(f"{field} must be a boolean")
     return value
+
+
+def _heatmap_request(body: dict[str, object]) -> HeatmapRequest:
+    latitude = _finite_number(body.get("latitude"), "latitude")
+    longitude = _finite_number(body.get("longitude"), "longitude")
+    start_date = body.get("start_date")
+    if not isinstance(start_date, str):
+        raise ValueError("start_date must be a date string")
+    threshold = body.get("threshold_celsius")
+    if threshold is not None:
+        threshold = _finite_number(threshold, "threshold_celsius")
+    direction = body.get("direction")
+    if direction is not None and not isinstance(direction, str):
+        raise ValueError("direction must be a string")
+    return HeatmapRequest(
+        AnalyticType(body["analytic_type"]),
+        latitude,
+        longitude,
+        date.fromisoformat(start_date),
+        _required_bool(body, "forecast", default=True),
+        threshold,
+        direction,
+    )
 
 
 def _trip_result(body: dict[str, object]) -> dict[str, object]:

--- a/app/api.py
+++ b/app/api.py
@@ -99,12 +99,13 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
         raise ValueError("trip analysis requires hotels, routes, and shade data")
     candidates = tuple(HotelCandidate(item["identity"], item["components"]) for item in hotels)
     route_candidates = tuple(RouteCandidate(item["identity"], item["distance_m"], item["duration_s"]) for item in routes)
+    building_coverage = float(body.get("building_coverage", 0))
     route_result = RouteComparator().compare(
         lambda: route_candidates,
         heat_value=float(body["heat_value"]),
         heat_threshold=float(body["heat_threshold"]),
         shade=lambda route: float(shade[route.identity]),
-        building_coverage=float(body.get("building_coverage", 0)),
+        building_coverage=building_coverage,
     )
     return {
         "hotels": [asdict(hotel) for hotel in HotelRanker().rank(candidates)],
@@ -113,8 +114,8 @@ def _trip_result(body: dict[str, object]) -> dict[str, object]:
             "routes": [asdict(route) for route in route_candidates],
             "heat_metric": body.get("heat_metric", "tcm"),
             "heat_status": "elevated" if route_result.corridor_heat_value > float(body["heat_threshold"]) else "not_elevated",
-            "coverage": float(body.get("building_coverage", 0)),
-            "confidence": "sufficient" if float(body.get("building_coverage", 0)) >= 0.7 else "insufficient",
+            "coverage": building_coverage,
+            "confidence": "sufficient" if building_coverage >= 0.7 else "insufficient",
             "comparison_scope": "returned alternatives",
         },
         "provenance": body.get("provenance", {"source": "fixture", "stale": False}),

--- a/app/api.py
+++ b/app/api.py
@@ -14,6 +14,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from app.execution import HeatmapExecution
 from app.fortyguard import AnalyticType, HeatmapRequest
+from app.trip import HotelCandidate, HotelRanker, RouteCandidate, RouteComparator
 
 
 def _result_json(result: Any) -> dict[str, object]:
@@ -36,12 +37,21 @@ def create_fixture_server(fixture_path: Path) -> ThreadingHTTPServer:
 
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self) -> None:
-            if urlparse(self.path).path != "/api/heatmap":
+            path = urlparse(self.path).path
+            if path not in {"/api/heatmap", "/api/trip/analyze"}:
                 self.send_error(404)
                 return
             try:
                 length = int(self.headers.get("Content-Length", "0"))
                 body = json.loads(self.rfile.read(length))
+                if path == "/api/trip/analyze":
+                    response = json.dumps(_trip_result(body), default=_json_default).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(response)))
+                    self.end_headers()
+                    self.wfile.write(response)
+                    return
                 request = HeatmapRequest(
                     AnalyticType(body["analytic_type"]),
                     float(body["latitude"]),
@@ -72,3 +82,24 @@ def _required_bool(body: dict[str, object], field: str, *, default: bool) -> boo
     if not isinstance(value, bool):
         raise ValueError(f"{field} must be a boolean")
     return value
+
+
+def _trip_result(body: dict[str, object]) -> dict[str, object]:
+    hotels = body.get("hotels")
+    routes = body.get("routes")
+    shade = body.get("shade")
+    if not isinstance(hotels, list) or not isinstance(routes, list) or not isinstance(shade, dict):
+        raise ValueError("trip analysis requires hotels, routes, and shade data")
+    candidates = tuple(HotelCandidate(item["identity"], item["components"]) for item in hotels)
+    route_candidates = tuple(RouteCandidate(item["identity"], item["distance_m"], item["duration_s"]) for item in routes)
+    route_result = RouteComparator().compare(
+        lambda: route_candidates,
+        heat_value=float(body["heat_value"]),
+        heat_threshold=float(body["heat_threshold"]),
+        shade=lambda route: float(shade[route.identity]),
+        building_coverage=float(body.get("building_coverage", 0)),
+    )
+    return {
+        "hotels": [asdict(hotel) for hotel in HotelRanker().rank(candidates)],
+        "route": asdict(route_result),
+    }

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,67 @@
+"""Minimal product-facing HTTP boundary for fixture-backed analysis."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import date
+from datetime import datetime
+from enum import Enum
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from app.execution import HeatmapExecution
+from app.fortyguard import AnalyticType, HeatmapRequest
+
+
+def _result_json(result: Any) -> dict[str, object]:
+    return {
+        "tiles": [asdict(tile) for tile in result.tiles],
+        "provenance": asdict(result.provenance),
+    }
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    raise TypeError(f"cannot serialize {type(value).__name__}")
+
+
+def create_fixture_server(fixture_path: Path) -> ThreadingHTTPServer:
+    execution = HeatmapExecution(fixture_path=fixture_path)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            if urlparse(self.path).path != "/api/heatmap":
+                self.send_error(404)
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+                body = json.loads(self.rfile.read(length))
+                request = HeatmapRequest(
+                    AnalyticType(body["analytic_type"]),
+                    float(body["latitude"]),
+                    float(body["longitude"]),
+                    date.fromisoformat(body["start_date"]),
+                    bool(body.get("forecast", True)),
+                    body.get("threshold_celsius"),
+                    body.get("direction"),
+                )
+                response = json.dumps(_result_json(execution.run(request)), default=_json_default).encode()
+                self.send_response(200)
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+                response = json.dumps({"error": str(error), "status": "unavailable"}).encode()
+                self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    return ThreadingHTTPServer(("127.0.0.1", 0), Handler)

--- a/app/cache.py
+++ b/app/cache.py
@@ -30,12 +30,13 @@ class CacheService:
         retrieved_at: datetime,
         data_date: str,
         activity_id: str | None = None,
+        forecast: bool = False,
     ) -> CacheKey:
         key = CacheKey.create(endpoint, schema_version, request_payload)
         sanitized = _sanitize(response_payload)
         self._entries[key.value] = CacheEntry(
             sanitized,
-            Provenance("provider", retrieved_at, data_date, False, False, activity_id, sanitized),
+            Provenance("provider", retrieved_at, data_date, False, forecast, activity_id, sanitized),
         )
         return key
 

--- a/app/cache.py
+++ b/app/cache.py
@@ -1,0 +1,65 @@
+"""Small cache contract that keeps replayed data visibly distinct from live data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
+import re
+
+from app.domain import CacheKey, Provenance
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    payload: Mapping[str, Any]
+    provenance: Provenance
+
+
+class CacheService:
+    def __init__(self) -> None:
+        self._entries: dict[str, CacheEntry] = {}
+
+    def put(
+        self,
+        endpoint: str,
+        schema_version: str,
+        request_payload: dict[str, Any],
+        response_payload: Mapping[str, Any],
+        *,
+        retrieved_at: datetime,
+        data_date: str,
+        activity_id: str | None = None,
+    ) -> CacheKey:
+        key = CacheKey.create(endpoint, schema_version, request_payload)
+        sanitized = _sanitize(response_payload)
+        self._entries[key.value] = CacheEntry(
+            sanitized,
+            Provenance("provider", retrieved_at, data_date, False, False, activity_id, sanitized),
+        )
+        return key
+
+    def get(self, key: CacheKey) -> CacheEntry | None:
+        entry = self._entries.get(key.value)
+        if entry is None:
+            return None
+        return CacheEntry(entry.payload, Provenance.cached(
+            retrieved_at=entry.provenance.retrieved_at,
+            data_date=entry.provenance.data_date,
+            activity_id=entry.provenance.activity_id,
+            raw_payload=entry.provenance.raw_payload,
+            forecast=entry.provenance.forecast,
+        ))
+
+
+def _sanitize(value: object) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): "[redacted]" if re.search(r"(?i)(api[_ -]?key|authorization|token)", str(key)) else _sanitize(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    if not isinstance(value, (str, int, float, bool, type(None))):
+        raise ValueError("cached response must be an object")
+    return value

--- a/app/cache.py
+++ b/app/cache.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Mapping
-import re
 
 from app.domain import CacheKey, Provenance
+from app.security import sanitize_payload
 
 
 @dataclass(frozen=True)
@@ -33,7 +33,7 @@ class CacheService:
         forecast: bool = False,
     ) -> CacheKey:
         key = CacheKey.create(endpoint, schema_version, request_payload)
-        sanitized = _sanitize(response_payload)
+        sanitized = sanitize_payload(response_payload)
         self._entries[key.value] = CacheEntry(
             sanitized,
             Provenance("provider", retrieved_at, data_date, False, forecast, activity_id, sanitized),
@@ -51,16 +51,3 @@ class CacheService:
             raw_payload=entry.provenance.raw_payload,
             forecast=entry.provenance.forecast,
         ))
-
-
-def _sanitize(value: object) -> Any:
-    if isinstance(value, Mapping):
-        return {
-            str(key): "[redacted]" if re.search(r"(?i)(api[_ -]?key|authorization|token)", str(key)) else _sanitize(item)
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [_sanitize(item) for item in value]
-    if not isinstance(value, (str, int, float, bool, type(None))):
-        raise ValueError("cached response must be an object")
-    return value

--- a/app/domain.py
+++ b/app/domain.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import hashlib
 import json
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 
 @dataclass(frozen=True)
@@ -60,6 +60,14 @@ class EnrichmentPlan:
     base_result_preserved: bool
 
 
+@dataclass(frozen=True)
+class EnrichmentResult:
+    base_ranking: tuple[str, ...]
+    enriched: dict[str, Any]
+    failures: dict[str, str]
+    remaining_credits: int
+
+
 class EnrichmentPlanner:
     def __init__(self, credits: int) -> None:
         self.credits = max(0, credits)
@@ -73,6 +81,23 @@ class EnrichmentPlanner:
             count = min(request.top_n, len(candidates), self.credits // request.credits_per_item)
         used = count * request.credits_per_item
         return EnrichmentPlan(tuple(candidates[:count]), self.credits - used, True)
+
+    def execute(
+        self,
+        candidates: Sequence[str],
+        request: EnrichmentRequest,
+        loader: Callable[[str], Any],
+    ) -> EnrichmentResult:
+        plan = self.plan(candidates, request)
+        enriched: dict[str, Any] = {}
+        failures: dict[str, str] = {}
+        for candidate in plan.selected:
+            try:
+                enriched[candidate] = loader(candidate)
+            except Exception as error:
+                failures[candidate] = str(error)
+        self.credits = plan.remaining_credits
+        return EnrichmentResult(tuple(candidates), enriched, failures, self.credits)
 
 
 @dataclass(frozen=True)

--- a/app/domain.py
+++ b/app/domain.py
@@ -8,6 +8,8 @@ import hashlib
 import json
 from typing import Any, Callable, Sequence
 
+from app.ledger import CreditLedger
+
 
 @dataclass(frozen=True)
 class CacheKey:
@@ -87,11 +89,14 @@ class EnrichmentPlanner:
         candidates: Sequence[str],
         request: EnrichmentRequest,
         loader: Callable[[str], Any],
+        ledger: CreditLedger | None = None,
     ) -> EnrichmentResult:
         plan = self.plan(candidates, request)
         enriched: dict[str, Any] = {}
         failures: dict[str, str] = {}
         for candidate in plan.selected:
+            if ledger is not None:
+                ledger.plan_optional(candidate, request.credits_per_item)
             try:
                 enriched[candidate] = loader(candidate)
             except Exception as error:

--- a/app/domain.py
+++ b/app/domain.py
@@ -1,0 +1,101 @@
+"""Product-domain contracts shared by live and fixture execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    value: str
+
+    @classmethod
+    def create(cls, endpoint: str, schema_version: str, payload: dict[str, Any]) -> "CacheKey":
+        canonical = json.dumps(
+            {"endpoint": endpoint, "schema_version": schema_version, "payload": payload},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest = hashlib.sha256(canonical.encode()).hexdigest()
+        return cls(digest)
+
+
+@dataclass(frozen=True)
+class Provenance:
+    source: str
+    retrieved_at: datetime
+    data_date: str
+    stale: bool
+    forecast: bool
+    activity_id: str | None = None
+    raw_payload: dict[str, Any] | None = None
+
+    @classmethod
+    def cached(
+        cls,
+        *,
+        retrieved_at: datetime,
+        data_date: str,
+        activity_id: str | None = None,
+        raw_payload: dict[str, Any] | None = None,
+        forecast: bool = False,
+    ) -> "Provenance":
+        return cls("cache", retrieved_at, data_date, True, forecast, activity_id, raw_payload)
+
+
+@dataclass(frozen=True)
+class EnrichmentRequest:
+    top_n: int
+    credits_per_item: int
+
+
+@dataclass(frozen=True)
+class EnrichmentPlan:
+    selected: tuple[str, ...]
+    remaining_credits: int
+    base_result_preserved: bool
+
+
+class EnrichmentPlanner:
+    def __init__(self, credits: int) -> None:
+        self.credits = max(0, credits)
+
+    def plan(self, candidates: Sequence[str], request: EnrichmentRequest) -> EnrichmentPlan:
+        if request.top_n < 0 or request.credits_per_item < 0:
+            raise ValueError("enrichment limits must be non-negative")
+        if request.credits_per_item == 0:
+            count = min(request.top_n, len(candidates))
+        else:
+            count = min(request.top_n, len(candidates), self.credits // request.credits_per_item)
+        used = count * request.credits_per_item
+        return EnrichmentPlan(tuple(candidates[:count]), self.credits - used, True)
+
+
+@dataclass(frozen=True)
+class ReadinessInput:
+    heat_celsius: float
+    threshold_celsius: float
+    coverage: float
+    forecast: bool
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    priority: str
+    reason_codes: tuple[str, ...]
+
+
+def readiness(value: ReadinessInput) -> ReadinessResult:
+    reasons: list[str] = []
+    if value.heat_celsius > value.threshold_celsius:
+        reasons.append("HEAT_THRESHOLD_EXCEEDED")
+    if value.coverage < 0.7:
+        reasons.append("LOW_DATA_COVERAGE")
+    if not value.forecast:
+        reasons.append("HISTORICAL_CONTEXT")
+    priority = "high" if "HEAT_THRESHOLD_EXCEEDED" in reasons else "medium" if reasons else "low"
+    return ReadinessResult(priority, tuple(reasons))

--- a/app/domain.py
+++ b/app/domain.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import hashlib
 import json
 from typing import Any, Callable, Sequence
 
-from app.ledger import CreditLedger
+from app.ledger import CreditLedger, UsageRecord
 
 
 @dataclass(frozen=True)
@@ -70,6 +70,14 @@ class EnrichmentResult:
     remaining_credits: int
 
 
+@dataclass(frozen=True)
+class EnrichmentOutcome:
+    payload: Any
+    activity_id: str
+    credits_used: int
+    endpoint: str
+
+
 class EnrichmentPlanner:
     def __init__(self, credits: int) -> None:
         self.credits = max(0, credits)
@@ -98,7 +106,21 @@ class EnrichmentPlanner:
             if ledger is not None:
                 ledger.plan_optional(candidate, request.credits_per_item)
             try:
-                enriched[candidate] = loader(candidate)
+                outcome = loader(candidate)
+                if isinstance(outcome, EnrichmentOutcome):
+                    enriched[candidate] = outcome.payload
+                    if ledger is not None:
+                        ledger.record(
+                            UsageRecord(
+                                outcome.activity_id,
+                                outcome.endpoint,
+                                outcome.credits_used,
+                                datetime.now(timezone.utc),
+                                "completed",
+                            )
+                        )
+                else:
+                    enriched[candidate] = outcome
             except Exception as error:
                 failures[candidate] = str(error)
         self.credits = plan.remaining_credits

--- a/app/execution.py
+++ b/app/execution.py
@@ -71,6 +71,11 @@ class HeatmapExecution:
         expected_mode = "forecast" if request.forecast else "historical"
         if payload.get("mode") != expected_mode:
             raise ValueError("fixture forecast/historical mode does not match request")
+        fixture_request = payload.get("request")
+        if isinstance(fixture_request, Mapping):
+            expected_request = _request_payload(request)
+            if any(fixture_request.get(key) != expected_request.get(key) for key in expected_request):
+                raise ValueError("fixture request does not match requested scenario")
         return normalize_heatmap_response(
             payload, request=request, retrieved_at=datetime.now().astimezone(), source="fixture"
         )

--- a/app/execution.py
+++ b/app/execution.py
@@ -1,0 +1,37 @@
+"""Shared fixture/live execution path for normalized heatmap results."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Callable, Mapping
+
+from app.fortyguard import HeatmapRequest, HeatmapResult, normalize_heatmap_response
+
+
+class HeatmapExecution:
+    def __init__(
+        self,
+        *,
+        fixture_path: Path,
+        live_loader: Callable[[HeatmapRequest], Mapping[str, object]] | None = None,
+    ) -> None:
+        self.fixture_path = fixture_path
+        self.live_loader = live_loader
+
+    def run(self, request: HeatmapRequest, *, live: bool = False) -> HeatmapResult:
+        if live:
+            if self.live_loader is None:
+                raise RuntimeError("live execution is not configured")
+            payload = self.live_loader(request)
+            return normalize_heatmap_response(
+                payload, request=request, retrieved_at=datetime.now().astimezone(), source="provider"
+            )
+        with self.fixture_path.open(encoding="utf-8") as fixture:
+            payload = json.load(fixture)
+        if not isinstance(payload, Mapping):
+            raise ValueError("fixture must contain a JSON object")
+        return normalize_heatmap_response(
+            payload, request=request, retrieved_at=datetime.now().astimezone(), source="fixture"
+        )

--- a/app/execution.py
+++ b/app/execution.py
@@ -6,10 +6,17 @@ from datetime import datetime
 import json
 from pathlib import Path
 from typing import Callable, Mapping
+from dataclasses import dataclass
 
 from app.cache import CacheService
 from app.domain import CacheKey
 from app.fortyguard import HeatmapRequest, HeatmapResult, ProviderError, normalize_heatmap_response
+
+
+@dataclass(frozen=True)
+class LiveHeatmapPayload:
+    payload: Mapping[str, object]
+    activity_id: str | None = None
 
 
 class HeatmapExecution:
@@ -17,7 +24,7 @@ class HeatmapExecution:
         self,
         *,
         fixture_path: Path,
-        live_loader: Callable[[HeatmapRequest], Mapping[str, object]] | None = None,
+        live_loader: Callable[[HeatmapRequest], Mapping[str, object] | LiveHeatmapPayload] | None = None,
         cache: CacheService | None = None,
         endpoint: str = "/v1/heatmap",
         schema_version: str = "v1",
@@ -34,8 +41,17 @@ class HeatmapExecution:
                 raise RuntimeError("live execution is not configured")
             request_payload = _request_payload(request)
             try:
-                payload = self.live_loader(request)
-            except (ConnectionError, OSError, ProviderError, TimeoutError):
+                loaded = self.live_loader(request)
+                payload = loaded.payload if isinstance(loaded, LiveHeatmapPayload) else loaded
+                activity_id = loaded.activity_id if isinstance(loaded, LiveHeatmapPayload) else None
+                result = normalize_heatmap_response(
+                    payload,
+                    request=request,
+                    retrieved_at=datetime.now().astimezone(),
+                    activity_id=activity_id,
+                    source="provider",
+                )
+            except (ConnectionError, OSError, ProviderError, TimeoutError, ValueError):
                 if self.cache is None:
                     raise
                 cached = self.cache.get(CacheKey.create(self.endpoint, self.schema_version, request_payload))
@@ -49,9 +65,6 @@ class HeatmapExecution:
                     source="cache",
                     data_date=cached.provenance.data_date,
                 )
-            result = normalize_heatmap_response(
-                payload, request=request, retrieved_at=datetime.now().astimezone(), source="provider"
-            )
             if self.cache is not None:
                 self.cache.put(
                     self.endpoint,
@@ -77,7 +90,11 @@ class HeatmapExecution:
             if any(fixture_request.get(key) != expected_request.get(key) for key in expected_request):
                 raise ValueError("fixture request does not match requested scenario")
         return normalize_heatmap_response(
-            payload, request=request, retrieved_at=datetime.now().astimezone(), source="fixture"
+            payload,
+            request=request,
+            retrieved_at=datetime.now().astimezone(),
+            source="fixture",
+            data_date=_fixture_data_date(payload),
         )
 
 
@@ -91,3 +108,15 @@ def _request_payload(request: HeatmapRequest) -> dict[str, object]:
         "threshold_celsius": request.threshold_celsius,
         "direction": request.direction,
     }
+
+
+def _fixture_data_date(payload: Mapping[str, object]) -> str:
+    data_date = payload.get("data_date")
+    if isinstance(data_date, str):
+        return data_date
+    features = payload.get("features")
+    if isinstance(features, list) and features and isinstance(features[0], Mapping):
+        properties = features[0].get("properties")
+        if isinstance(properties, Mapping) and isinstance(properties.get("valid_time"), str):
+            return properties["valid_time"][:10]
+    raise ValueError("fixture is missing data date freshness metadata")

--- a/app/execution.py
+++ b/app/execution.py
@@ -50,6 +50,7 @@ class HeatmapExecution:
                     retrieved_at=datetime.now().astimezone(),
                     activity_id=activity_id,
                     source="provider",
+                    data_date=_fixture_data_date(payload),
                 )
             except (ConnectionError, OSError, ProviderError, TimeoutError, ValueError):
                 if self.cache is None:

--- a/app/execution.py
+++ b/app/execution.py
@@ -32,6 +32,9 @@ class HeatmapExecution:
             payload = json.load(fixture)
         if not isinstance(payload, Mapping):
             raise ValueError("fixture must contain a JSON object")
+        expected_mode = "forecast" if request.forecast else "historical"
+        if payload.get("mode") != expected_mode:
+            raise ValueError("fixture forecast/historical mode does not match request")
         return normalize_heatmap_response(
             payload, request=request, retrieved_at=datetime.now().astimezone(), source="fixture"
         )

--- a/app/execution.py
+++ b/app/execution.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from typing import Callable, Mapping
 
+from app.cache import CacheService
+from app.domain import CacheKey
 from app.fortyguard import HeatmapRequest, HeatmapResult, normalize_heatmap_response
 
 
@@ -16,18 +18,52 @@ class HeatmapExecution:
         *,
         fixture_path: Path,
         live_loader: Callable[[HeatmapRequest], Mapping[str, object]] | None = None,
+        cache: CacheService | None = None,
+        endpoint: str = "/v1/heatmap",
+        schema_version: str = "v1",
     ) -> None:
         self.fixture_path = fixture_path
         self.live_loader = live_loader
+        self.cache = cache
+        self.endpoint = endpoint
+        self.schema_version = schema_version
 
     def run(self, request: HeatmapRequest, *, live: bool = False) -> HeatmapResult:
         if live:
             if self.live_loader is None:
                 raise RuntimeError("live execution is not configured")
-            payload = self.live_loader(request)
-            return normalize_heatmap_response(
+            request_payload = _request_payload(request)
+            try:
+                payload = self.live_loader(request)
+            except Exception:
+                if self.cache is None:
+                    raise
+                cached = self.cache.get(CacheKey.create(self.endpoint, self.schema_version, request_payload))
+                if cached is None:
+                    raise
+                return normalize_heatmap_response(
+                    cached.payload,
+                    request=request,
+                    retrieved_at=cached.provenance.retrieved_at,
+                    activity_id=cached.provenance.activity_id,
+                    source="cache",
+                    data_date=cached.provenance.data_date,
+                )
+            result = normalize_heatmap_response(
                 payload, request=request, retrieved_at=datetime.now().astimezone(), source="provider"
             )
+            if self.cache is not None:
+                self.cache.put(
+                    self.endpoint,
+                    self.schema_version,
+                    request_payload,
+                    payload,
+                    retrieved_at=result.provenance.retrieved_at,
+                    data_date=result.provenance.data_date,
+                    activity_id=result.provenance.activity_id,
+                    forecast=request.forecast,
+                )
+            return result
         with self.fixture_path.open(encoding="utf-8") as fixture:
             payload = json.load(fixture)
         if not isinstance(payload, Mapping):
@@ -38,3 +74,15 @@ class HeatmapExecution:
         return normalize_heatmap_response(
             payload, request=request, retrieved_at=datetime.now().astimezone(), source="fixture"
         )
+
+
+def _request_payload(request: HeatmapRequest) -> dict[str, object]:
+    return {
+        "analytic_type": request.analytic_type.value,
+        "latitude": request.latitude,
+        "longitude": request.longitude,
+        "start_date": request.start_date.isoformat(),
+        "forecast": request.forecast,
+        "threshold_celsius": request.threshold_celsius,
+        "direction": request.direction,
+    }

--- a/app/execution.py
+++ b/app/execution.py
@@ -9,7 +9,7 @@ from typing import Callable, Mapping
 
 from app.cache import CacheService
 from app.domain import CacheKey
-from app.fortyguard import HeatmapRequest, HeatmapResult, normalize_heatmap_response
+from app.fortyguard import HeatmapRequest, HeatmapResult, ProviderError, normalize_heatmap_response
 
 
 class HeatmapExecution:
@@ -35,7 +35,7 @@ class HeatmapExecution:
             request_payload = _request_payload(request)
             try:
                 payload = self.live_loader(request)
-            except Exception:
+            except (ConnectionError, OSError, ProviderError, TimeoutError):
                 if self.cache is None:
                     raise
                 cached = self.cache.get(CacheKey.create(self.endpoint, self.schema_version, request_payload))

--- a/app/execution.py
+++ b/app/execution.py
@@ -118,5 +118,7 @@ def _fixture_data_date(payload: Mapping[str, object]) -> str:
     if isinstance(features, list) and features and isinstance(features[0], Mapping):
         properties = features[0].get("properties")
         if isinstance(properties, Mapping) and isinstance(properties.get("valid_time"), str):
-            return properties["valid_time"][:10]
+            valid_time = properties["valid_time"]
+            if isinstance(valid_time, str):
+                return valid_time[:10]
     raise ValueError("fixture is missing data date freshness metadata")

--- a/app/execution.py
+++ b/app/execution.py
@@ -86,10 +86,11 @@ class HeatmapExecution:
         if payload.get("mode") != expected_mode:
             raise ValueError("fixture forecast/historical mode does not match request")
         fixture_request = payload.get("request")
-        if isinstance(fixture_request, Mapping):
-            expected_request = _request_payload(request)
-            if any(fixture_request.get(key) != expected_request.get(key) for key in expected_request):
-                raise ValueError("fixture request does not match requested scenario")
+        if not isinstance(fixture_request, Mapping):
+            raise ValueError("fixture is missing request scenario metadata")
+        expected_request = _request_payload(request)
+        if any(fixture_request.get(key) != expected_request.get(key) for key in expected_request):
+            raise ValueError("fixture request does not match requested scenario")
         return normalize_heatmap_response(
             payload,
             request=request,

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -37,8 +37,7 @@ class HeatmapRequest:
     def __post_init__(self) -> None:
         if not isinstance(self.analytic_type, AnalyticType):
             raise ValueError("unknown analytic type")
-        if not math.isfinite(self.latitude) or not math.isfinite(self.longitude) or not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
-            raise ValueError("coordinates must be within the supported US extent")
+        _validate_us_coordinates(self.latitude, self.longitude)
         if self.forecast and not date.today() <= self.start_date <= date.today() + timedelta(days=1):
             raise ValueError("forecast start date must be today or tomorrow")
         if self.analytic_type in (AnalyticType.EXCEEDANCE, AnalyticType.PERSISTENCE):
@@ -75,8 +74,7 @@ class EnvParamsRequest:
     is_real_forecast: bool = False
 
     def __post_init__(self) -> None:
-        if not math.isfinite(self.latitude) or not math.isfinite(self.longitude) or not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
-            raise ValueError("coordinates must be within the supported US extent")
+        _validate_us_coordinates(self.latitude, self.longitude)
         if self.temperature_anchor_celsius is None or isinstance(self.temperature_anchor_celsius, bool) or not isinstance(self.temperature_anchor_celsius, (int, float)) or not math.isfinite(self.temperature_anchor_celsius):
             raise ValueError("caller-supplied temperature anchor is required")
         if self.is_real_forecast:
@@ -102,7 +100,7 @@ class AreaHeatmapRequest:
     unit_source: str
 
     def __post_init__(self) -> None:
-        if self.geometry.get("type") not in {"Polygon", "MultiPolygon"} or not self.geometry.get("coordinates"):
+        if self.geometry.get("type") not in {"Polygon", "MultiPolygon"} or not _valid_geometry_coordinates(self.geometry):
             raise ValueError("area heatmap requires polygon geometry")
         if not self.analytic_types:
             raise ValueError("at least one analytic type is required")
@@ -509,4 +507,29 @@ def _valid_geometry_coordinates(geometry: Mapping[str, object]) -> bool:
         )
     if not isinstance(coordinates, list) or not coordinates:
         return False
-    return all(isinstance(ring, list) and len(ring) >= 4 for ring in coordinates)
+
+    def valid_ring(ring: object) -> bool:
+        return (
+            isinstance(ring, list)
+            and len(ring) >= 4
+            and all(
+                isinstance(position, list)
+                and len(position) >= 2
+                and all(
+                    isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                    and math.isfinite(value)
+                    for value in position[:2]
+                )
+                for position in ring
+            )
+        )
+
+    if geometry.get("type") == "Polygon":
+        return all(valid_ring(ring) for ring in coordinates)
+    return all(isinstance(polygon, list) and polygon and all(valid_ring(ring) for ring in polygon) for polygon in coordinates)
+
+
+def _validate_us_coordinates(latitude: float, longitude: float) -> None:
+    if not math.isfinite(latitude) or not math.isfinite(longitude) or not 24 <= latitude <= 50 or not -125 <= longitude <= -66:
+        raise ValueError("coordinates must be within the supported US extent")

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from enum import Enum
+import math
 import re
 import json
 from time import sleep as default_sleep
@@ -41,7 +42,11 @@ class HeatmapRequest:
         if self.forecast and not date.today() <= self.start_date <= date.today() + timedelta(days=1):
             raise ValueError("forecast start date must be today or tomorrow")
         if self.analytic_type in (AnalyticType.EXCEEDANCE, AnalyticType.PERSISTENCE):
-            if self.threshold_celsius is None:
+            if (
+                isinstance(self.threshold_celsius, bool)
+                or not isinstance(self.threshold_celsius, (int, float))
+                or not math.isfinite(self.threshold_celsius)
+            ):
                 raise ValueError("threshold is required for this analytic type")
             if self.direction not in ("above", "below"):
                 raise ValueError("direction must be above or below")

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -14,6 +14,7 @@ from urllib.request import Request, urlopen
 
 from app.domain import Provenance
 from app.ledger import CreditLedger, UsageRecord
+from app.security import sanitize_payload
 
 
 class AnalyticType(str, Enum):
@@ -235,7 +236,8 @@ class HttpFortyGuardTransport:
                 return {"status_code": error.code}
             raise classify_provider_error(error.code, "provider HTTP request failed") from None
         except (TimeoutError, URLError, OSError) as error:
-            raise ProviderError(ProviderErrorKind.SERVER, detail=type(error).__name__) from None
+            kind = ProviderErrorKind.TIMEOUT if isinstance(error, TimeoutError) else ProviderErrorKind.SERVER
+            raise ProviderError(kind, detail=type(error).__name__) from None
         except (json.JSONDecodeError, UnicodeDecodeError):
             raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="invalid JSON response") from None
         if not isinstance(parsed, Mapping):
@@ -291,7 +293,7 @@ class FortyGuardClient:
         submitted_at = self._clock()
         self._emit(
             "fortyguard.submitted",
-            {"activity_id": activity_id, "endpoint": endpoint, "request": _sanitize_payload(payload)},
+            {"activity_id": activity_id, "endpoint": endpoint, "request": sanitize_payload(payload)},
         )
         transitions: list[str] = []
 
@@ -417,17 +419,6 @@ def _parse_datetime(value: object) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
-def _sanitize_payload(value: object) -> object:
-    if isinstance(value, Mapping):
-        return {
-            str(key): "[redacted]" if re.search(r"(?i)(api[_ -]?key|authorization|token)", str(key)) else _sanitize_payload(item)
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [_sanitize_payload(item) for item in value]
-    return value
-
-
 def normalize_heatmap_response(
     payload: Mapping[str, object],
     *,
@@ -469,7 +460,7 @@ def normalize_heatmap_response(
         tiles.append(Tile(str(properties.get("id", index)), geometry, request.analytic_type, numeric_value if request.analytic_type is AnalyticType.TCM else None, numeric_value, unit, source, valid_time, request.forecast, request.threshold_celsius, request.direction, activity_id))
     if len(units) != 1:
         raise ValueError("mixed or unsupported units")
-    sanitized_payload = _sanitize_payload(payload)
+    sanitized_payload = sanitize_payload(payload)
     if not isinstance(sanitized_payload, dict):
         raise ValueError("malformed heatmap payload")
     return HeatmapResult(

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -37,7 +37,7 @@ class HeatmapRequest:
     def __post_init__(self) -> None:
         if not isinstance(self.analytic_type, AnalyticType):
             raise ValueError("unknown analytic type")
-        if not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
+        if not math.isfinite(self.latitude) or not math.isfinite(self.longitude) or not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
             raise ValueError("coordinates must be within the supported US extent")
         if self.forecast and not date.today() <= self.start_date <= date.today() + timedelta(days=1):
             raise ValueError("forecast start date must be today or tomorrow")
@@ -75,9 +75,9 @@ class EnvParamsRequest:
     is_real_forecast: bool = False
 
     def __post_init__(self) -> None:
-        if not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
+        if not math.isfinite(self.latitude) or not math.isfinite(self.longitude) or not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
             raise ValueError("coordinates must be within the supported US extent")
-        if self.temperature_anchor_celsius is None:
+        if self.temperature_anchor_celsius is None or isinstance(self.temperature_anchor_celsius, bool) or not isinstance(self.temperature_anchor_celsius, (int, float)) or not math.isfinite(self.temperature_anchor_celsius):
             raise ValueError("caller-supplied temperature anchor is required")
         if self.is_real_forecast:
             raise ValueError("fixed-anchor env_params cannot be a real forecast")
@@ -136,9 +136,9 @@ def normalize_env_params_response(
     heat_index = payload.get("heat_index_celsius")
     humidity = payload.get("humidity_percent")
     valid_time = payload.get("valid_time")
-    if isinstance(heat_index, bool) or (heat_index is not None and not isinstance(heat_index, (int, float))):
+    if isinstance(heat_index, bool) or (heat_index is not None and (not isinstance(heat_index, (int, float)) or not math.isfinite(heat_index))):
         raise ValueError("invalid heat index")
-    if isinstance(humidity, bool) or (humidity is not None and not isinstance(humidity, (int, float))):
+    if isinstance(humidity, bool) or (humidity is not None and (not isinstance(humidity, (int, float)) or not math.isfinite(humidity))):
         raise ValueError("invalid humidity")
     if not isinstance(valid_time, str):
         raise ValueError("missing freshness metadata")

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -1,0 +1,255 @@
+"""Offline-safe contracts for the asynchronous FortyGuard API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from enum import Enum
+import re
+from time import sleep as default_sleep
+from typing import Callable, Mapping, Protocol, Sequence
+
+from app.domain import Provenance
+
+
+class AnalyticType(str, Enum):
+    TCM = "tcm"
+    EXCEEDANCE = "exceedance"
+    PERSISTENCE = "persistence"
+
+
+@dataclass(frozen=True)
+class HeatmapRequest:
+    analytic_type: AnalyticType
+    latitude: float
+    longitude: float
+    start_date: date
+    forecast: bool = True
+    threshold_celsius: float | None = None
+    direction: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.analytic_type, AnalyticType):
+            raise ValueError("unknown analytic type")
+        if not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
+            raise ValueError("coordinates must be within the supported US extent")
+        if self.forecast and not date.today() <= self.start_date <= date.today() + timedelta(days=1):
+            raise ValueError("forecast start date must be today or tomorrow")
+        if self.analytic_type in (AnalyticType.EXCEEDANCE, AnalyticType.PERSISTENCE):
+            if self.threshold_celsius is None:
+                raise ValueError("threshold is required for this analytic type")
+            if self.direction not in ("above", "below"):
+                raise ValueError("direction must be above or below")
+
+
+class ProviderErrorKind(str, Enum):
+    AUTHENTICATION = "authentication"
+    VALIDATION = "validation_or_plan"
+    RATE_LIMIT = "rate_limit"
+    SERVER = "server"
+    MALFORMED_RESPONSE = "malformed_response"
+    TASK_FAILURE = "task_failure"
+    TIMEOUT = "timeout"
+
+
+@dataclass(frozen=True)
+class ProviderError(Exception):
+    kind: ProviderErrorKind
+    status_code: int | None = None
+    detail: str = "provider request failed"
+
+    def __str__(self) -> str:
+        return f"{self.kind.value}: {self.detail}"
+
+
+def _sanitize_detail(detail: str) -> str:
+    detail = re.sub(r"(?i)(api[_ -]?key|authorization|token)\s*[:=]\s*[^\s,;]+", r"\1=[redacted]", detail)
+    return detail[:160]
+
+
+def classify_provider_error(status_code: int | None, detail: str = "") -> ProviderError:
+    if status_code in (401, 403):
+        kind = ProviderErrorKind.AUTHENTICATION
+    elif status_code in (400, 404, 422):
+        kind = ProviderErrorKind.VALIDATION
+    elif status_code == 429:
+        kind = ProviderErrorKind.RATE_LIMIT
+    elif status_code is not None and status_code >= 500:
+        kind = ProviderErrorKind.SERVER
+    else:
+        kind = ProviderErrorKind.MALFORMED_RESPONSE
+    return ProviderError(kind, status_code, _sanitize_detail(detail) or "provider request failed")
+
+
+class FortyGuardTransport(Protocol):
+    def post(self, endpoint: str, payload: Mapping[str, object], api_key: str) -> Mapping[str, object]: ...
+
+    def get(self, endpoint: str, api_key: str) -> Mapping[str, object]: ...
+
+
+@dataclass(frozen=True)
+class ActivityMetadata:
+    activity_id: str
+    submitted_at: datetime
+    endpoint: str
+    request_fields: tuple[str, ...]
+
+
+class FortyGuardClient:
+    """Authenticated submit/poll boundary; billable work is submitted exactly once."""
+
+    def __init__(self, transport: FortyGuardTransport, api_key: str, *, clock: Callable[[], datetime]) -> None:
+        if not api_key:
+            raise ValueError("an API key is required")
+        self._transport = transport
+        self._api_key = api_key
+        self._clock = clock
+
+    def submit_and_poll(
+        self,
+        endpoint: str,
+        payload: Mapping[str, object],
+        *,
+        sleep: Callable[[float], None] = default_sleep,
+        max_polls: int = 12,
+    ) -> tuple[Mapping[str, object], ActivityMetadata]:
+        response = self._transport.post(endpoint, payload, self._api_key)
+        status_code = response.get("status_code")
+        if isinstance(status_code, int) and status_code >= 400:
+            raise classify_provider_error(status_code, "activity submission failed")
+        activity_id = response.get("activity_id")
+        if not isinstance(activity_id, str) or not activity_id:
+            raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="missing activity id")
+        metadata = ActivityMetadata(activity_id, self._clock(), endpoint, tuple(sorted(payload)))
+
+        def get_status(_: str) -> Mapping[str, object]:
+            return self._transport.get(f"/v1/status/{activity_id}", self._api_key)
+
+        return poll_activity(activity_id, get_status=get_status, sleep=sleep, max_polls=max_polls), metadata
+
+
+def poll_activity(
+    activity_id: str,
+    *,
+    get_status: Callable[[str], Mapping[str, object]],
+    sleep: Callable[[float], None] = default_sleep,
+    max_polls: int = 12,
+    interval_seconds: float = 1.0,
+) -> Mapping[str, object]:
+    """Poll one already-submitted billable activity with bounded status checks."""
+    saw_submission_404 = False
+    for poll_number in range(1, max_polls + 1):
+        response = get_status(activity_id)
+        status_code = response.get("status_code")
+        if status_code == 404 and not saw_submission_404:
+            saw_submission_404 = True
+        elif status_code == 404:
+            raise classify_provider_error(404, "activity not found")
+        status = response.get("status")
+        if status == "Completed":
+            result = response.get("result")
+            if not isinstance(result, Mapping):
+                raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="missing task result")
+            return result
+        if status == "Failed":
+            raise ProviderError(ProviderErrorKind.TASK_FAILURE, detail="provider task failed")
+        if status_code not in (None, 200, 202, 404):
+            if not isinstance(status_code, int):
+                raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="invalid status code")
+            raise classify_provider_error(status_code, "status lookup failed")
+        if poll_number < max_polls:
+            sleep(interval_seconds)
+    raise ProviderError(ProviderErrorKind.TIMEOUT, detail="activity polling timed out")
+
+
+@dataclass(frozen=True)
+class Tile:
+    identity: str
+    geometry: Mapping[str, object]
+    metric: AnalyticType
+    value_celsius: float
+    unit: str
+    source: str
+    valid_time: datetime
+    forecast: bool
+    threshold_celsius: float | None = None
+    direction: str | None = None
+    activity_id: str | None = None
+
+
+@dataclass(frozen=True)
+class HeatmapResult:
+    tiles: tuple[Tile, ...]
+    provenance: Provenance
+
+
+def _parse_datetime(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("missing freshness metadata")
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _sanitize_payload(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {
+            str(key): "[redacted]" if re.search(r"(?i)(api[_ -]?key|authorization|token)", str(key)) else _sanitize_payload(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize_payload(item) for item in value]
+    return value
+
+
+def normalize_heatmap_response(
+    payload: Mapping[str, object],
+    *,
+    request: HeatmapRequest,
+    retrieved_at: datetime,
+    activity_id: str | None = None,
+    source: str = "provider",
+) -> HeatmapResult:
+    features = payload.get("features")
+    if not isinstance(features, Sequence) or isinstance(features, (str, bytes)) or not features:
+        raise ValueError("heatmap response contains no features")
+    tiles: list[Tile] = []
+    units: set[str] = set()
+    for index, feature in enumerate(features):
+        if not isinstance(feature, Mapping):
+            raise ValueError("malformed heatmap feature")
+        geometry = feature.get("geometry")
+        properties = feature.get("properties")
+        if (
+            not isinstance(geometry, Mapping)
+            or geometry.get("type") not in {"Point", "Polygon", "MultiPolygon"}
+            or not geometry.get("coordinates")
+        ):
+            raise ValueError("missing geometry")
+        if not isinstance(properties, Mapping):
+            raise ValueError("malformed heatmap properties")
+        metric = properties.get("metric", request.analytic_type.value)
+        if metric != request.analytic_type.value:
+            raise ValueError("unknown or mismatched metric")
+        value = properties.get("value")
+        unit = properties.get("unit")
+        if not isinstance(value, (int, float)) or unit != "C":
+            raise ValueError("mixed or unsupported units")
+        valid_time = _parse_datetime(properties.get("valid_time"))
+        units.add(unit)
+        tiles.append(Tile(str(properties.get("id", index)), geometry, request.analytic_type, float(value), unit, source, valid_time, request.forecast, request.threshold_celsius, request.direction, activity_id))
+    if len(units) != 1:
+        raise ValueError("mixed or unsupported units")
+    sanitized_payload = _sanitize_payload(payload)
+    if not isinstance(sanitized_payload, dict):
+        raise ValueError("malformed heatmap payload")
+    return HeatmapResult(
+        tuple(tiles),
+        Provenance(
+            source,
+            retrieved_at,
+            request.start_date.isoformat(),
+            source == "cache",
+            request.forecast,
+            activity_id,
+            sanitized_payload,
+        ),
+    )

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -37,6 +37,8 @@ class HeatmapRequest:
     def __post_init__(self) -> None:
         if not isinstance(self.analytic_type, AnalyticType):
             raise ValueError("unknown analytic type")
+        if not isinstance(self.forecast, bool):
+            raise ValueError("forecast must be a boolean")
         _validate_us_coordinates(self.latitude, self.longitude)
         if self.forecast and not date.today() <= self.start_date <= date.today() + timedelta(days=1):
             raise ValueError("forecast start date must be today or tomorrow")
@@ -512,6 +514,7 @@ def _valid_geometry_coordinates(geometry: Mapping[str, object]) -> bool:
         return (
             isinstance(ring, list)
             and len(ring) >= 4
+            and ring[0] == ring[-1]
             and all(
                 isinstance(position, list)
                 and len(position) >= 2

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from enum import Enum
 import re
@@ -93,17 +93,27 @@ class ActivityMetadata:
     submitted_at: datetime
     endpoint: str
     request_fields: tuple[str, ...]
+    status_transitions: tuple[str, ...] = ()
+    response_metadata: Mapping[str, object] = field(default_factory=dict)
 
 
 class FortyGuardClient:
     """Authenticated submit/poll boundary; billable work is submitted exactly once."""
 
-    def __init__(self, transport: FortyGuardTransport, api_key: str, *, clock: Callable[[], datetime]) -> None:
+    def __init__(
+        self,
+        transport: FortyGuardTransport,
+        api_key: str,
+        *,
+        clock: Callable[[], datetime],
+        event_sink: Callable[[Mapping[str, object]], None] | None = None,
+    ) -> None:
         if not api_key:
             raise ValueError("an API key is required")
         self._transport = transport
         self._api_key = api_key
         self._clock = clock
+        self._event_sink = event_sink
 
     def submit_and_poll(
         self,
@@ -120,12 +130,38 @@ class FortyGuardClient:
         activity_id = response.get("activity_id")
         if not isinstance(activity_id, str) or not activity_id:
             raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="missing activity id")
-        metadata = ActivityMetadata(activity_id, self._clock(), endpoint, tuple(sorted(payload)))
+        submitted_at = self._clock()
+        self._emit(
+            "fortyguard.submitted",
+            {"activity_id": activity_id, "endpoint": endpoint, "request": _sanitize_payload(payload)},
+        )
+        transitions: list[str] = []
 
         def get_status(_: str) -> Mapping[str, object]:
             return self._transport.get(f"/v1/status/{activity_id}", self._api_key)
 
-        return poll_activity(activity_id, get_status=get_status, sleep=sleep, max_polls=max_polls), metadata
+        result = poll_activity(
+            activity_id,
+            get_status=get_status,
+            sleep=sleep,
+            max_polls=max_polls,
+            on_transition=transitions.append,
+            on_event=self._emit,
+        )
+        metadata = ActivityMetadata(
+            activity_id,
+            submitted_at,
+            endpoint,
+            tuple(sorted(payload)),
+            tuple(transitions),
+            _response_metadata(result),
+        )
+        self._emit("fortyguard.completed", {"activity_id": activity_id, **_response_metadata(result)})
+        return result, metadata
+
+    def _emit(self, event: str, fields: Mapping[str, object]) -> None:
+        if self._event_sink is not None:
+            self._event_sink({"event": event, "at": self._clock().isoformat(), **fields})
 
 
 def poll_activity(
@@ -135,17 +171,39 @@ def poll_activity(
     sleep: Callable[[float], None] = default_sleep,
     max_polls: int = 12,
     interval_seconds: float = 1.0,
+    on_transition: Callable[[str], None] | None = None,
+    on_event: Callable[[str, Mapping[str, object]], None] | None = None,
 ) -> Mapping[str, object]:
     """Poll one already-submitted billable activity with bounded status checks."""
     saw_submission_404 = False
     for poll_number in range(1, max_polls + 1):
         response = get_status(activity_id)
         status_code = response.get("status_code")
+        if status_code == 429:
+            if on_transition is not None:
+                on_transition("rate_limited")
+            if on_event is not None:
+                on_event("fortyguard.status_transition", {"activity_id": activity_id, "status": "rate_limited"})
+            if poll_number < max_polls:
+                sleep(interval_seconds)
+                continue
+        if isinstance(status_code, int) and status_code >= 500:
+            if on_transition is not None:
+                on_transition("server_error")
+            if on_event is not None:
+                on_event("fortyguard.status_transition", {"activity_id": activity_id, "status": "server_error"})
+            if poll_number < max_polls:
+                sleep(interval_seconds)
+                continue
         if status_code == 404 and not saw_submission_404:
             saw_submission_404 = True
         elif status_code == 404:
             raise classify_provider_error(404, "activity not found")
         status = response.get("status")
+        if isinstance(status, str) and on_transition is not None:
+            on_transition(status)
+        if isinstance(status, str) and on_event is not None:
+            on_event("fortyguard.status_transition", {"activity_id": activity_id, "status": status})
         if status == "Completed":
             result = response.get("result")
             if not isinstance(result, Mapping):
@@ -160,6 +218,10 @@ def poll_activity(
         if poll_number < max_polls:
             sleep(interval_seconds)
     raise ProviderError(ProviderErrorKind.TIMEOUT, detail="activity polling timed out")
+
+
+def _response_metadata(result: Mapping[str, object]) -> dict[str, object]:
+    return {key: result[key] for key in ("credits_used", "request_id") if key in result}
 
 
 @dataclass(frozen=True)

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -183,7 +183,9 @@ def _sanitize_detail(detail: str) -> str:
 
 
 def classify_provider_error(status_code: int | None, detail: str = "") -> ProviderError:
-    if status_code in (401, 403):
+    if status_code == 408:
+        kind = ProviderErrorKind.TIMEOUT
+    elif status_code in (401, 403):
         kind = ProviderErrorKind.AUTHENTICATION
     elif status_code in (400, 404, 422):
         kind = ProviderErrorKind.VALIDATION
@@ -238,11 +240,11 @@ class HttpFortyGuardTransport:
                 parsed = json.loads(response.read())
         except self.HttpError as error:
             status = getattr(error.response, "status", None)
-            if payload is None and (status in (404, 429) or isinstance(status, int) and status >= 500):
+            if payload is None and (status in (404, 408, 429) or isinstance(status, int) and status >= 500):
                 return {"status_code": status}
             raise classify_provider_error(status, "provider HTTP request failed") from None
         except HTTPError as error:
-            if payload is None and (error.code in (404, 429) or error.code >= 500):
+            if payload is None and (error.code in (404, 408, 429) or error.code >= 500):
                 return {"status_code": error.code}
             raise classify_provider_error(error.code, "provider HTTP request failed") from None
         except (TimeoutError, URLError, OSError) as error:

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -6,8 +6,11 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from enum import Enum
 import re
+import json
 from time import sleep as default_sleep
 from typing import Callable, Mapping, Protocol, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 from app.domain import Provenance
 
@@ -40,6 +43,78 @@ class HeatmapRequest:
                 raise ValueError("threshold is required for this analytic type")
             if self.direction not in ("above", "below"):
                 raise ValueError("direction must be above or below")
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "analytic_type": self.analytic_type.value,
+            "latitude": self.latitude,
+            "longitude": self.longitude,
+            "start_date": self.start_date.isoformat(),
+            "forecast": self.forecast,
+        }
+        if self.threshold_celsius is not None:
+            payload["threshold_celsius"] = self.threshold_celsius
+        if self.direction is not None:
+            payload["direction"] = self.direction
+        return payload
+
+
+@dataclass(frozen=True)
+class EnvParamsRequest:
+    latitude: float
+    longitude: float
+    start_date: date
+    temperature_anchor_celsius: float | None
+    is_real_forecast: bool = False
+
+    def __post_init__(self) -> None:
+        if not 24 <= self.latitude <= 50 or not -125 <= self.longitude <= -66:
+            raise ValueError("coordinates must be within the supported US extent")
+        if self.temperature_anchor_celsius is None:
+            raise ValueError("caller-supplied temperature anchor is required")
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "latitude": self.latitude,
+            "longitude": self.longitude,
+            "start_date": self.start_date.isoformat(),
+            "temperature_anchor_celsius": self.temperature_anchor_celsius,
+            "forecast": False,
+            "warning": "fixed temperature anchor; not a real 24-hour forecast",
+        }
+
+
+@dataclass(frozen=True)
+class EnvParamsResult:
+    heat_index_celsius: float | None
+    humidity_percent: float | None
+    valid_time: datetime
+    forecast: bool
+    warning: str
+
+
+def normalize_env_params_response(
+    payload: Mapping[str, object], *, request: EnvParamsRequest
+) -> EnvParamsResult:
+    heat_index = payload.get("heat_index_celsius")
+    humidity = payload.get("humidity_percent")
+    valid_time = payload.get("valid_time")
+    if isinstance(heat_index, bool) or (heat_index is not None and not isinstance(heat_index, (int, float))):
+        raise ValueError("invalid heat index")
+    if isinstance(humidity, bool) or (humidity is not None and not isinstance(humidity, (int, float))):
+        raise ValueError("invalid humidity")
+    if not isinstance(valid_time, str):
+        raise ValueError("missing freshness metadata")
+    parsed_time = _parse_datetime(valid_time)
+    if payload.get("forecast") is True:
+        raise ValueError("fixed-anchor env_params response cannot be a real forecast")
+    return EnvParamsResult(
+        float(heat_index) if heat_index is not None else None,
+        float(humidity) if humidity is not None else None,
+        parsed_time,
+        False,
+        "caller-supplied temperature anchor; not a real 24-hour forecast",
+    )
 
 
 class ProviderErrorKind(str, Enum):
@@ -85,6 +160,54 @@ class FortyGuardTransport(Protocol):
     def post(self, endpoint: str, payload: Mapping[str, object], api_key: str) -> Mapping[str, object]: ...
 
     def get(self, endpoint: str, api_key: str) -> Mapping[str, object]: ...
+
+
+class HttpFortyGuardTransport:
+    class HttpError(Exception):
+        def __init__(self, response: object) -> None:
+            self.response = response
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout_seconds: float = 15,
+        opener: Callable[[Request, float], object] = urlopen,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self._opener = opener
+
+    def post(self, endpoint: str, payload: Mapping[str, object], api_key: str) -> Mapping[str, object]:
+        return self._request(endpoint, api_key, payload)
+
+    def get(self, endpoint: str, api_key: str) -> Mapping[str, object]:
+        return self._request(endpoint, api_key)
+
+    def _request(
+        self, endpoint: str, api_key: str, payload: Mapping[str, object] | None = None
+    ) -> Mapping[str, object]:
+        request = Request(
+            f"{self.base_url}/{endpoint.lstrip('/')}",
+            data=json.dumps(payload).encode() if payload is not None else None,
+            headers={"X-API-Key": api_key, "Content-Type": "application/json"},
+            method="POST" if payload is not None else "GET",
+        )
+        try:
+            with self._opener(request, self.timeout_seconds) as response:  # type: ignore[attr-defined]
+                parsed = json.loads(response.read())
+        except self.HttpError as error:
+            status = getattr(error.response, "status", None)
+            raise classify_provider_error(status, "provider HTTP request failed") from None
+        except HTTPError as error:
+            raise classify_provider_error(error.code, "provider HTTP request failed") from None
+        except (TimeoutError, URLError, OSError) as error:
+            raise ProviderError(ProviderErrorKind.SERVER, detail=type(error).__name__) from None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="invalid JSON response") from None
+        if not isinstance(parsed, Mapping):
+            raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="response must be an object")
+        return parsed
 
 
 @dataclass(frozen=True)

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -294,7 +294,7 @@ def normalize_heatmap_response(
             raise ValueError("unknown or mismatched metric")
         value = properties.get("value")
         unit = properties.get("unit")
-        if not isinstance(value, (int, float)) or unit != "C":
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or unit != "C":
             raise ValueError("mixed or unsupported units")
         valid_time = _parse_datetime(properties.get("valid_time"))
         units.add(unit)

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -13,6 +13,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from app.domain import Provenance
+from app.ledger import CreditLedger, UsageRecord
 
 
 class AnalyticType(str, Enum):
@@ -230,6 +231,7 @@ class FortyGuardClient:
         *,
         clock: Callable[[], datetime],
         event_sink: Callable[[Mapping[str, object]], None] | None = None,
+        ledger: CreditLedger | None = None,
     ) -> None:
         if not api_key:
             raise ValueError("an API key is required")
@@ -237,6 +239,7 @@ class FortyGuardClient:
         self._api_key = api_key
         self._clock = clock
         self._event_sink = event_sink
+        self._ledger = ledger
 
     def submit_and_poll(
         self,
@@ -279,6 +282,9 @@ class FortyGuardClient:
             tuple(transitions),
             _response_metadata(result),
         )
+        credits_used = result.get("credits_used")
+        if self._ledger is not None and isinstance(credits_used, int) and not isinstance(credits_used, bool):
+            self._ledger.record(UsageRecord(activity_id, endpoint, credits_used, self._clock(), "completed"))
         self._emit("fortyguard.completed", {"activity_id": activity_id, **_response_metadata(result)})
         return result, metadata
 
@@ -331,7 +337,11 @@ def poll_activity(
             result = response.get("result")
             if not isinstance(result, Mapping):
                 raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="missing task result")
-            return result
+            completed = dict(result)
+            for key in ("credits_used", "request_id"):
+                if key in response:
+                    completed[key] = response[key]
+            return completed
         if status == "Failed":
             raise ProviderError(ProviderErrorKind.TASK_FAILURE, detail="provider task failed")
         if status_code not in (None, 200, 202, 404):

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -106,6 +106,8 @@ class AreaHeatmapRequest:
             raise ValueError("area heatmap requires polygon geometry")
         if not self.analytic_types:
             raise ValueError("at least one analytic type is required")
+        if any(not isinstance(analytic_type, AnalyticType) for analytic_type in self.analytic_types):
+            raise ValueError("area analytic types must be known")
         if self.context not in {"district", "corridor"}:
             raise ValueError("area context must be district or corridor")
         if self.unit != "C" or self.unit_source not in {"explicit", "inferred"}:
@@ -324,8 +326,11 @@ class FortyGuardClient:
             _response_metadata(result),
         )
         credits_used = result.get("credits_used")
-        if self._ledger is not None and isinstance(credits_used, int) and not isinstance(credits_used, bool):
-            self._ledger.record(UsageRecord(activity_id, endpoint, credits_used, self._clock(), "completed"))
+        if credits_used is not None:
+            if isinstance(credits_used, bool) or not isinstance(credits_used, int) or credits_used < 0:
+                raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="invalid credit usage metadata")
+            if self._ledger is not None:
+                self._ledger.record(UsageRecord(activity_id, endpoint, credits_used, self._clock(), "completed"))
         self._emit("fortyguard.completed", {"activity_id": activity_id, **_response_metadata(result)})
         return result, metadata
 
@@ -454,6 +459,7 @@ def normalize_heatmap_response(
             not isinstance(geometry, Mapping)
             or geometry.get("type") not in {"Point", "Polygon", "MultiPolygon"}
             or not geometry.get("coordinates")
+            or not _valid_geometry_coordinates(geometry)
         ):
             raise ValueError("missing geometry")
         if not isinstance(properties, Mapping):
@@ -492,3 +498,15 @@ def normalize_heatmap_response(
             sanitized_payload,
         ),
     )
+
+
+def _valid_geometry_coordinates(geometry: Mapping[str, object]) -> bool:
+    coordinates = geometry.get("coordinates")
+    if geometry.get("type") == "Point":
+        return isinstance(coordinates, list) and len(coordinates) == 2 and all(
+            isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+            for value in coordinates
+        )
+    if not isinstance(coordinates, list) or not coordinates:
+        return False
+    return all(isinstance(ring, list) and len(ring) >= 4 for ring in coordinates)

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -207,7 +207,7 @@ class HttpFortyGuardTransport:
         base_url: str,
         *,
         timeout_seconds: float = 15,
-        opener: Callable[[Request, float], object] = urlopen,
+        opener: Callable[..., object] = urlopen,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.timeout_seconds = timeout_seconds
@@ -436,6 +436,11 @@ def normalize_heatmap_response(
     features = payload.get("features")
     if not isinstance(features, Sequence) or isinstance(features, (str, bytes)) or not features:
         raise ValueError("heatmap response contains no features")
+    payload_mode = payload.get("mode")
+    if payload_mode is not None:
+        expected_mode = "forecast" if request.forecast else "historical"
+        if payload_mode != expected_mode:
+            raise ValueError("provider forecast/historical mode does not match request")
     tiles: list[Tile] = []
     units: set[str] = set()
     for index, feature in enumerate(features):

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -227,8 +227,12 @@ class HttpFortyGuardTransport:
                 parsed = json.loads(response.read())
         except self.HttpError as error:
             status = getattr(error.response, "status", None)
+            if payload is None and (status in (404, 429) or isinstance(status, int) and status >= 500):
+                return {"status_code": status}
             raise classify_provider_error(status, "provider HTTP request failed") from None
         except HTTPError as error:
+            if payload is None and (error.code in (404, 429) or error.code >= 500):
+                return {"status_code": error.code}
             raise classify_provider_error(error.code, "provider HTTP request failed") from None
         except (TimeoutError, URLError, OSError) as error:
             raise ProviderError(ProviderErrorKind.SERVER, detail=type(error).__name__) from None
@@ -390,7 +394,8 @@ class Tile:
     identity: str
     geometry: Mapping[str, object]
     metric: AnalyticType
-    value_celsius: float
+    value_celsius: float | None
+    metric_value: float
     unit: str
     source: str
     valid_time: datetime
@@ -455,11 +460,13 @@ def normalize_heatmap_response(
             raise ValueError("unknown or mismatched metric")
         value = properties.get("value")
         unit = properties.get("unit")
-        if isinstance(value, bool) or not isinstance(value, (int, float)) or unit != "C":
+        expected_unit = "C" if request.analytic_type is AnalyticType.TCM else "hours"
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or unit != expected_unit:
             raise ValueError("mixed or unsupported units")
         valid_time = _parse_datetime(properties.get("valid_time"))
         units.add(unit)
-        tiles.append(Tile(str(properties.get("id", index)), geometry, request.analytic_type, float(value), unit, source, valid_time, request.forecast, request.threshold_celsius, request.direction, activity_id))
+        numeric_value = float(value)
+        tiles.append(Tile(str(properties.get("id", index)), geometry, request.analytic_type, numeric_value if request.analytic_type is AnalyticType.TCM else None, numeric_value, unit, source, valid_time, request.forecast, request.threshold_celsius, request.direction, activity_id))
     if len(units) != 1:
         raise ValueError("mixed or unsupported units")
     sanitized_payload = _sanitize_payload(payload)

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -12,6 +12,7 @@ from time import sleep as default_sleep
 from typing import Callable, Mapping, Protocol, Sequence
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from shapely.geometry import shape
 
 from app.domain import Provenance
 from app.ledger import CreditLedger, UsageRecord
@@ -528,9 +529,17 @@ def _valid_geometry_coordinates(geometry: Mapping[str, object]) -> bool:
             )
         )
 
-    if geometry.get("type") == "Polygon":
-        return all(valid_ring(ring) for ring in coordinates)
-    return all(isinstance(polygon, list) and polygon and all(valid_ring(ring) for ring in polygon) for polygon in coordinates)
+    structurally_valid = (
+        all(valid_ring(ring) for ring in coordinates)
+        if geometry.get("type") == "Polygon"
+        else all(isinstance(polygon, list) and polygon and all(valid_ring(ring) for ring in polygon) for polygon in coordinates)
+    )
+    if not structurally_valid:
+        return False
+    try:
+        return bool(shape(dict(geometry)).is_valid)
+    except (TypeError, ValueError):
+        return False
 
 
 def _validate_us_coordinates(latitude: float, longitude: float) -> None:

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -269,6 +269,7 @@ def normalize_heatmap_response(
     retrieved_at: datetime,
     activity_id: str | None = None,
     source: str = "provider",
+    data_date: str | None = None,
 ) -> HeatmapResult:
     features = payload.get("features")
     if not isinstance(features, Sequence) or isinstance(features, (str, bytes)) or not features:
@@ -308,7 +309,7 @@ def normalize_heatmap_response(
         Provenance(
             source,
             retrieved_at,
-            request.start_date.isoformat(),
+            data_date or request.start_date.isoformat(),
             source == "cache",
             request.forecast,
             activity_id,

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -86,6 +86,34 @@ class EnvParamsRequest:
 
 
 @dataclass(frozen=True)
+class AreaHeatmapRequest:
+    geometry: Mapping[str, object]
+    analytic_types: tuple[AnalyticType, ...]
+    context: str
+    unit: str
+    unit_source: str
+
+    def __post_init__(self) -> None:
+        if self.geometry.get("type") not in {"Polygon", "MultiPolygon"} or not self.geometry.get("coordinates"):
+            raise ValueError("area heatmap requires polygon geometry")
+        if not self.analytic_types:
+            raise ValueError("at least one analytic type is required")
+        if self.context not in {"district", "corridor"}:
+            raise ValueError("area context must be district or corridor")
+        if self.unit != "C" or self.unit_source not in {"explicit", "inferred"}:
+            raise ValueError("area request requires Celsius with explicit or inferred unit source")
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "geometry": self.geometry,
+            "analytic_types": [analytic_type.value for analytic_type in self.analytic_types],
+            "context": self.context,
+            "unit": self.unit,
+            "unit_source": self.unit_source,
+        }
+
+
+@dataclass(frozen=True)
 class EnvParamsResult:
     heat_index_celsius: float | None
     humidity_percent: float | None

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -11,6 +11,7 @@ import json
 from time import sleep as default_sleep
 from typing import Callable, Mapping, Protocol, Sequence
 from urllib.error import HTTPError, URLError
+import socket
 from urllib.request import Request, urlopen
 from shapely.geometry import shape
 
@@ -248,7 +249,8 @@ class HttpFortyGuardTransport:
                 return {"status_code": error.code}
             raise classify_provider_error(error.code, "provider HTTP request failed") from None
         except (TimeoutError, URLError, OSError) as error:
-            kind = ProviderErrorKind.TIMEOUT if isinstance(error, TimeoutError) else ProviderErrorKind.SERVER
+            wrapped_timeout = isinstance(error, URLError) and isinstance(error.reason, socket.timeout)
+            kind = ProviderErrorKind.TIMEOUT if isinstance(error, (TimeoutError, socket.timeout)) or wrapped_timeout else ProviderErrorKind.SERVER
             raise ProviderError(kind, detail=type(error).__name__) from None
         except (json.JSONDecodeError, UnicodeDecodeError):
             raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="invalid JSON response") from None
@@ -357,11 +359,11 @@ def poll_activity(
     for poll_number in range(1, max_polls + 1):
         response = get_status(activity_id)
         status_code = response.get("status_code")
-        if status_code == 429:
+        if status_code in (408, 429):
             if on_transition is not None:
-                on_transition("rate_limited")
+                on_transition("timed_out" if status_code == 408 else "rate_limited")
             if on_event is not None:
-                on_event("fortyguard.status_transition", {"activity_id": activity_id, "status": "rate_limited"})
+                on_event("fortyguard.status_transition", {"activity_id": activity_id, "status": "timed_out" if status_code == 408 else "rate_limited"})
             if poll_number < max_polls:
                 sleep(interval_seconds)
                 continue

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -457,7 +457,12 @@ def normalize_heatmap_response(
         value = properties.get("value")
         unit = properties.get("unit")
         expected_unit = "C" if request.analytic_type is AnalyticType.TCM else "hours"
-        if isinstance(value, bool) or not isinstance(value, (int, float)) or unit != expected_unit:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or unit != expected_unit
+        ):
             raise ValueError("mixed or unsupported units")
         valid_time = _parse_datetime(properties.get("valid_time"))
         units.add(unit)

--- a/app/fortyguard.py
+++ b/app/fortyguard.py
@@ -79,6 +79,8 @@ class EnvParamsRequest:
             raise ValueError("coordinates must be within the supported US extent")
         if self.temperature_anchor_celsius is None:
             raise ValueError("caller-supplied temperature anchor is required")
+        if self.is_real_forecast:
+            raise ValueError("fixed-anchor env_params cannot be a real forecast")
 
     def to_payload(self) -> dict[str, object]:
         return {

--- a/app/ledger.py
+++ b/app/ledger.py
@@ -1,0 +1,44 @@
+"""Operational credit accounting without credentials or raw provider payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class UsageRecord:
+    activity_id: str
+    endpoint: str
+    credits_used: int
+    completed_at: datetime
+    status: str
+
+
+class CreditLedger:
+    def __init__(self, budget: int) -> None:
+        if budget < 0:
+            raise ValueError("budget must be non-negative")
+        self.budget = budget
+        self.records: list[UsageRecord] = []
+        self.planned_optional: dict[str, int] = {}
+
+    @property
+    def total_used(self) -> int:
+        return sum(record.credits_used for record in self.records)
+
+    @property
+    def remaining(self) -> int:
+        return self.budget - self.total_used
+
+    def plan_optional(self, subject: str, credits: int) -> None:
+        if credits < 0:
+            raise ValueError("planned credits must be non-negative")
+        self.planned_optional[subject] = credits
+
+    def record(self, usage: UsageRecord) -> None:
+        if usage.credits_used < 0:
+            raise ValueError("actual credits must be non-negative")
+        if usage.credits_used > self.remaining:
+            raise ValueError("credit budget exceeded")
+        self.records.append(usage)

--- a/app/ledger.py
+++ b/app/ledger.py
@@ -37,6 +37,8 @@ class CreditLedger:
         self.planned_optional[subject] = credits
 
     def record(self, usage: UsageRecord) -> None:
+        if any(record.activity_id == usage.activity_id for record in self.records):
+            return
         if usage.credits_used < 0:
             raise ValueError("actual credits must be non-negative")
         if usage.credits_used > self.remaining:

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,19 @@
+"""Shared sanitization policy for provider payloads and operational events."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+def sanitize_payload(value: object) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): "[redacted]"
+            if re.search(r"(?i)(api[_ -]?key|authorization|token)", str(key))
+            else sanitize_payload(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [sanitize_payload(item) for item in value]
+    return value

--- a/app/trip.py
+++ b/app/trip.py
@@ -1,0 +1,89 @@
+"""Pure tourism ranking and route-decision contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class HotelCandidate:
+    identity: str
+    components: Mapping[str, float]
+
+
+@dataclass(frozen=True)
+class RankedHotel:
+    identity: str
+    components: Mapping[str, float]
+    score: float
+    percentile: float
+    tie_group: int
+
+
+class HotelRanker:
+    default_weights = {"night": 0.35, "hot_hours": 0.25, "persistence": 0.20, "day": 0.20}
+
+    def rank(
+        self, candidates: Sequence[HotelCandidate], weights: Mapping[str, float] | None = None
+    ) -> tuple[RankedHotel, ...]:
+        selected_weights = dict(weights or self.default_weights)
+        if abs(sum(selected_weights.values()) - 1) > 0.001:
+            raise ValueError("hotel weights must sum to one")
+        scores = [
+            sum(candidate.components[name] * weight for name, weight in selected_weights.items())
+            for candidate in candidates
+        ]
+        ordered = sorted(zip(candidates, scores), key=lambda item: (item[1], item[0].identity))
+        distinct = sorted(set(scores))
+        result: list[RankedHotel] = []
+        for position, (candidate, score) in enumerate(ordered):
+            tie_group = distinct.index(score)
+            percentile = 100 * (1 - (distinct.index(score) / max(1, len(distinct) - 1)))
+            result.append(RankedHotel(candidate.identity, candidate.components, score, percentile, tie_group))
+        return tuple(result)
+
+
+@dataclass(frozen=True)
+class RouteCandidate:
+    identity: str
+    distance_m: float
+    duration_s: float
+
+
+@dataclass(frozen=True)
+class RouteComparison:
+    recommended_id: str
+    reason: str
+    corridor_heat_value: float
+    shade_was_computed: bool
+
+
+class RouteComparator:
+    def __init__(self, representative_threshold_m: float = 1500) -> None:
+        self.representative_threshold_m = representative_threshold_m
+
+    def compare(
+        self,
+        route_loader: Callable[[], Sequence[RouteCandidate]],
+        *,
+        heat_value: float | None = None,
+        heat_values: Sequence[float] | None = None,
+        heat_threshold: float,
+        shade: Callable[[RouteCandidate], float],
+        building_coverage: float = 1.0,
+    ) -> RouteComparison:
+        routes = tuple(route_loader())
+        if not routes:
+            raise ValueError("at least one route is required")
+        shortest = min(routes, key=lambda route: route.distance_m)
+        corridor_heat = max(heat_values) if heat_values else heat_value
+        if corridor_heat is None:
+            raise ValueError("heat value is required")
+        if corridor_heat <= heat_threshold:
+            return RouteComparison(shortest.identity, "heat below threshold", corridor_heat, False)
+        shade_values = {route.identity: shade(route) for route in routes}
+        if building_coverage < 0.7:
+            return RouteComparison(shortest.identity, "insufficient shade coverage", corridor_heat, True)
+        best = max(routes, key=lambda route: (shade_values[route.identity], -route.distance_m))
+        return RouteComparison(best.identity, "highest modeled shade among returned routes", corridor_heat, True)

--- a/app/trip.py
+++ b/app/trip.py
@@ -77,7 +77,10 @@ class RouteComparator:
         if not routes:
             raise ValueError("at least one route is required")
         shortest = min(routes, key=lambda route: route.distance_m)
-        corridor_heat = max(heat_values) if heat_values else heat_value
+        if shortest.distance_m > self.representative_threshold_m:
+            corridor_heat = max(heat_values) if heat_values else None
+        else:
+            corridor_heat = heat_value
         if corridor_heat is None:
             raise ValueError("heat value is required")
         if corridor_heat <= heat_threshold:

--- a/app/trip.py
+++ b/app/trip.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import Callable, Mapping, Sequence
 
 
@@ -30,6 +31,23 @@ class HotelRanker:
         selected_weights = dict(weights or self.default_weights)
         if abs(sum(selected_weights.values()) - 1) > 0.001:
             raise ValueError("hotel weights must sum to one")
+        required = set(self.default_weights)
+        if set(selected_weights) != required or any(
+            isinstance(weight, bool) or not isinstance(weight, (int, float)) or not math.isfinite(weight) or weight < 0
+            for weight in selected_weights.values()
+        ):
+            raise ValueError("hotel weights must be finite, non-negative, and complete")
+        if any(
+            set(candidate.components) != required
+            or any(
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                for value in candidate.components.values()
+            )
+            for candidate in candidates
+        ):
+            raise ValueError("hotel components must be finite and complete")
         scores = [
             sum(candidate.components[name] * weight for name, weight in selected_weights.items())
             for candidate in candidates

--- a/docs/design/fortyguard-extraction.md
+++ b/docs/design/fortyguard-extraction.md
@@ -1,0 +1,32 @@
+# FortyGuard Extraction Contracts
+
+The application integration is server-side and supports fixture execution without
+provider credentials. `app.fortyguard` owns request validation, authenticated
+submit/poll behavior, provider error classification, and normalization into the
+internal tile shape. A submitted activity is polled at most `max_polls` times;
+the first status `404` is tolerated because the provider may not expose a newly
+submitted activity immediately. The client never resubmits a billable activity.
+
+All heat values are stored in Celsius. `tcm` is a provider temperature metric and
+is not silently labeled as NOAA Heat Index. Forecast and historical results retain
+separate status in the request and normalized provenance. Normalized tiles require
+geometry, Celsius units, and a `valid_time` freshness field. The raw sanitized
+provider payload is retained on the result for fixture/debugging use and is not
+ordinary log output.
+
+`app.cache.CacheService` hashes the complete canonical request payload together
+with endpoint and schema version. Cache hits are explicitly marked `source=cache`
+and `stale=true`; a replay is never presented as a current forecast. Activity IDs,
+retrieval timestamps, and data dates remain available in provenance.
+
+Spatial joins are behind an adapter boundary. Polygon joins must be area-weighted
+in a projected CRS and report coverage. Point joins distinguish containing-tile,
+boundary, outside-AOI, and nearest-distance fallback results. The base product
+flow does not depend on optional enrichment: `EnrichmentPlanner` bounds selection
+by top-N and available credits, and readiness reason codes are deterministic local
+logic.
+
+The current repository intentionally does not include live acquisition scripts or
+geospatial dependencies. Live calls are metered manual operations; projected
+geometry implementation belongs in the application adapter once the dependency
+and fixture contract is selected.

--- a/docs/design/fortyguard-extraction.md
+++ b/docs/design/fortyguard-extraction.md
@@ -26,7 +26,13 @@ flow does not depend on optional enrichment: `EnrichmentPlanner` bounds selectio
 by top-N and available credits, and readiness reason codes are deterministic local
 logic.
 
-The current repository intentionally does not include live acquisition scripts or
-geospatial dependencies. Live calls are metered manual operations; projected
-geometry implementation belongs in the application adapter once the dependency
-and fixture contract is selected.
+The repository intentionally does not include live acquisition scripts. Live calls
+are metered manual operations. Polygon joins and AOI construction use pinned
+Shapely and pyproj dependencies, select a local UTM projected CRS, reject invalid
+geometry, and expose coverage or point-match quality.
+
+The fixture-backed HTTP boundary is `POST /api/heatmap`. It accepts an analytic
+type, US coordinates, start date, forecast flag, and optional threshold/direction,
+then returns the same normalized tile and provenance shape used by the execution
+layer. Invalid requests and unavailable fixtures return an explicit `unavailable`
+error; provider credentials never cross this boundary.

--- a/docs/design/fortyguard-extraction.md
+++ b/docs/design/fortyguard-extraction.md
@@ -36,3 +36,47 @@ type, US coordinates, start date, forecast flag, and optional threshold/directio
 then returns the same normalized tile and provenance shape used by the execution
 layer. Invalid requests and unavailable fixtures return an explicit `unavailable`
 error; provider credentials never cross this boundary.
+
+## Live transport
+
+`HttpFortyGuardTransport` is the concrete server-side HTTP adapter. It sends
+JSON to the configured base URL using the `X-API-Key` header and a bounded
+socket timeout. HTTP and network failures are classified without retaining a
+response body. A heatmap activity is submitted once; transient status lookup
+failures consume the bounded polling budget and never trigger submission again.
+
+`HeatmapRequest.to_payload()` preserves the analytic type, US coordinates,
+start date, forecast/historical status, threshold, and direction. Area requests
+accept caller-supplied Polygon or MultiPolygon geometry for district or corridor
+contexts and identify whether Celsius units were explicit or inferred.
+
+## Environmental parameters
+
+The optional `env_params` adapter is guarded by the committed
+`fixtures/env-params.json` contract. Its caller must supply a Celsius temperature
+anchor. The normalized result always carries the warning that a fixed-anchor
+series is not a real 24-hour forecast. `heat_index_celsius`, when present, is a
+separate metric and does not rename or reclassify `tcm`.
+
+## Budget and decisions
+
+The operational ledger records actual provider-reported credits by activity ID,
+endpoint, completion time, and status. Planned optional enrichment is recorded
+separately and does not count as actual spend. Budget enforcement occurs before
+an actual usage record is accepted.
+
+`POST /api/trip/analyze` is the product-level decision boundary. Hotel ranking
+uses the documented provisional component weights, retains components, and
+reports ties and candidate-set percentiles rather than an absolute grade. Route
+comparison consumes one supplied route set, uses maximum corridor heat, avoids
+shade work below the heat threshold, and recommends the shortest route when
+building-height coverage is insufficient.
+
+## Known limitations
+
+Live acquisition remains a deliberate, metered maintainer operation outside CI.
+The HTTP transport has no implicit submission retry because a failed response
+does not prove that a billable activity was not created. The current trip endpoint
+accepts already-acquired hotel, route, heat, and shade inputs; OSRM, Overpass,
+building-height parsing, and shade modeling are separate application integrations.
+P2 Fahrenheit presentation helpers and operational exports remain deferred.

--- a/fixtures/env-params.json
+++ b/fixtures/env-params.json
@@ -1,0 +1,7 @@
+{
+  "temperature_anchor_celsius": 35.0,
+  "heat_index_celsius": 38.1,
+  "humidity_percent": 55,
+  "valid_time": "2026-08-23T15:00:00+00:00",
+  "forecast": false
+}

--- a/fixtures/heatmap-empty.json
+++ b/fixtures/heatmap-empty.json
@@ -1,0 +1,1 @@
+{ "mode": "forecast", "features": [] }

--- a/fixtures/heatmap-exceedance.json
+++ b/fixtures/heatmap-exceedance.json
@@ -1,0 +1,16 @@
+{
+  "mode": "historical",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [-98.4936, 29.4241] },
+      "properties": {
+        "id": "exceedance-1",
+        "metric": "exceedance",
+        "value": 6,
+        "unit": "C",
+        "valid_time": "2026-08-20T00:00:00+00:00"
+      }
+    }
+  ]
+}

--- a/fixtures/heatmap-exceedance.json
+++ b/fixtures/heatmap-exceedance.json
@@ -8,7 +8,7 @@
         "id": "exceedance-1",
         "metric": "exceedance",
         "value": 6,
-        "unit": "C",
+        "unit": "hours",
         "valid_time": "2026-08-20T00:00:00+00:00"
       }
     }

--- a/fixtures/heatmap-exceedance.json
+++ b/fixtures/heatmap-exceedance.json
@@ -1,5 +1,14 @@
 {
   "mode": "historical",
+  "request": {
+    "analytic_type": "exceedance",
+    "latitude": 29.4241,
+    "longitude": -98.4936,
+    "start_date": "2026-08-23",
+    "forecast": false,
+    "threshold_celsius": 35,
+    "direction": "above"
+  },
   "features": [
     {
       "type": "Feature",

--- a/fixtures/heatmap-failed.json
+++ b/fixtures/heatmap-failed.json
@@ -1,0 +1,1 @@
+{ "status": "Failed", "error_code": "provider_task_failed" }

--- a/fixtures/heatmap-forecast.json
+++ b/fixtures/heatmap-forecast.json
@@ -1,0 +1,16 @@
+{
+  "mode": "forecast",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [-98.4936, 29.4241] },
+      "properties": {
+        "id": "forecast-1",
+        "metric": "tcm",
+        "value": 35.5,
+        "unit": "C",
+        "valid_time": "2026-08-23T15:00:00+00:00"
+      }
+    }
+  ]
+}

--- a/fixtures/heatmap-forecast.json
+++ b/fixtures/heatmap-forecast.json
@@ -1,5 +1,14 @@
 {
   "mode": "forecast",
+  "request": {
+    "analytic_type": "tcm",
+    "latitude": 29.4241,
+    "longitude": -98.4936,
+    "start_date": "2026-08-24",
+    "forecast": true,
+    "threshold_celsius": null,
+    "direction": null
+  },
   "features": [
     {
       "type": "Feature",

--- a/fixtures/heatmap-historical.json
+++ b/fixtures/heatmap-historical.json
@@ -1,5 +1,14 @@
 {
   "mode": "historical",
+  "request": {
+    "analytic_type": "tcm",
+    "latitude": 29.4241,
+    "longitude": -98.4936,
+    "start_date": "2026-08-23",
+    "forecast": false,
+    "threshold_celsius": null,
+    "direction": null
+  },
   "features": [
     {
       "type": "Feature",

--- a/fixtures/heatmap-historical.json
+++ b/fixtures/heatmap-historical.json
@@ -1,0 +1,16 @@
+{
+  "mode": "historical",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [-98.4936, 29.4241] },
+      "properties": {
+        "id": "historical-1",
+        "metric": "tcm",
+        "value": 33.2,
+        "unit": "C",
+        "valid_time": "2026-08-20T15:00:00+00:00"
+      }
+    }
+  ]
+}

--- a/fixtures/heatmap-malformed.json
+++ b/fixtures/heatmap-malformed.json
@@ -1,0 +1,10 @@
+{
+  "mode": "forecast",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point" },
+      "properties": { "metric": "unknown", "value": 35.5, "unit": "F" }
+    }
+  ]
+}

--- a/fixtures/heatmap-persistence.json
+++ b/fixtures/heatmap-persistence.json
@@ -8,7 +8,7 @@
         "id": "persistence-1",
         "metric": "persistence",
         "value": 4,
-        "unit": "C",
+        "unit": "hours",
         "valid_time": "2026-08-20T00:00:00+00:00"
       }
     }

--- a/fixtures/heatmap-persistence.json
+++ b/fixtures/heatmap-persistence.json
@@ -1,5 +1,14 @@
 {
   "mode": "historical",
+  "request": {
+    "analytic_type": "persistence",
+    "latitude": 29.4241,
+    "longitude": -98.4936,
+    "start_date": "2026-08-23",
+    "forecast": false,
+    "threshold_celsius": 35,
+    "direction": "above"
+  },
   "features": [
     {
       "type": "Feature",

--- a/fixtures/heatmap-persistence.json
+++ b/fixtures/heatmap-persistence.json
@@ -1,0 +1,16 @@
+{
+  "mode": "historical",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [-98.4936, 29.4241] },
+      "properties": {
+        "id": "persistence-1",
+        "metric": "persistence",
+        "value": 4,
+        "unit": "C",
+        "valid_time": "2026-08-20T00:00:00+00:00"
+      }
+    }
+  ]
+}

--- a/fixtures/heatmap-tcm.json
+++ b/fixtures/heatmap-tcm.json
@@ -1,0 +1,15 @@
+{
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [-98.4936, 29.4241] },
+      "properties": {
+        "id": "san-antonio-downtown-1",
+        "metric": "tcm",
+        "value": 35.5,
+        "unit": "C",
+        "valid_time": "2026-08-23T15:00:00+00:00"
+      }
+    }
+  ]
+}

--- a/fixtures/heatmap-tcm.json
+++ b/fixtures/heatmap-tcm.json
@@ -1,4 +1,5 @@
 {
+  "mode": "forecast",
   "features": [
     {
       "type": "Feature",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "python:lint": "python -m ruff check app tests",
+    "python:test": "python -m pytest -q",
+    "python:typecheck": "python -m mypy app tests",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = ["fastapi==0.141.1", "pyproj==3.7.2", "shapely==2.1.2"]
 
+[project.optional-dependencies]
+test = ["httpx2==2.12.0"]
+
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = ["fastapi==0.141.1", "pyproj==3.7.2", "shapely==2.1.2"]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ["app"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ line-length = 100
 python_version = "3.11"
 strict = true
 ignore_missing_imports = true
+follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disable_error_code = ["untyped-decorator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "heat-aware-tourism-guide"
 version = "0.1.0"
 requires-python = ">=3.11"
+dependencies = ["pyproj==3.7.2", "shapely==2.1.2"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "heat-aware-tourism-guide"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = ["pyproj==3.7.2", "shapely==2.1.2"]
+dependencies = ["fastapi==0.141.1", "pyproj==3.7.2", "shapely==2.1.2"]
 
 [build-system]
 requires = ["setuptools>=68"]
@@ -22,4 +22,8 @@ follow_imports = "skip"
 
 [[tool.mypy.overrides]]
 module = "tests.*"
+disable_error_code = ["untyped-decorator"]
+
+[[tool.mypy.overrides]]
+module = "app.api"
 disable_error_code = ["untyped-decorator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "heat-aware-tourism-guide"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+python_version = "3.11"
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = ["pyproj==3.7.2", "shapely==2.1.2"]
 
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
@@ -13,3 +17,4 @@ line-length = 100
 [tool.mypy]
 python_version = "3.11"
 strict = true
+ignore_missing_imports = true

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 from threading import Thread
 from urllib.request import Request, urlopen
+from urllib.error import HTTPError
 
 from app.api import create_fixture_server
 
@@ -33,6 +34,31 @@ def test_fixture_backed_http_flow_returns_normalized_domain_result() -> None:
         assert result["tiles"][0]["value_celsius"] == 33.2
         assert result["provenance"]["source"] == "fixture"
         assert result["provenance"]["forecast"] is False
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_invalid_boolean_and_missing_fixture_return_unavailable() -> None:
+    server = create_fixture_server(Path("fixtures/missing.json"))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = json.dumps(
+            {
+                "analytic_type": "tcm",
+                "latitude": 29.4241,
+                "longitude": -98.4936,
+                "start_date": "2026-08-23",
+                "forecast": "false",
+            }
+        ).encode()
+        try:
+            urlopen(Request(f"http://127.0.0.1:{server.server_port}/api/heatmap", data=body, method="POST"))
+        except HTTPError as error:
+            assert error.code == 400
+            assert json.load(error)["status"] == "unavailable"
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -74,6 +74,7 @@ def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> No
             {
                 "heat_value": 38,
                 "heat_threshold": 35,
+                "corridor_heat_values": [34, 38],
                 "building_coverage": 0.9,
                 "hotels": [
                     {"identity": "cooler", "components": {"night": 30, "hot_hours": 5, "persistence": 2, "day": 32}},

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,39 @@
+from datetime import date
+import json
+from pathlib import Path
+from threading import Thread
+from urllib.request import Request, urlopen
+
+from app.api import create_fixture_server
+
+
+def test_fixture_backed_http_flow_returns_normalized_domain_result() -> None:
+    server = create_fixture_server(Path("fixtures/heatmap-historical.json"))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = json.dumps(
+            {
+                "analytic_type": "tcm",
+                "latitude": 29.4241,
+                "longitude": -98.4936,
+                "start_date": date(2026, 8, 23).isoformat(),
+                "forecast": False,
+            }
+        ).encode()
+        response = urlopen(
+            Request(
+                f"http://127.0.0.1:{server.server_port}/api/heatmap",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+        )
+        result = json.load(response)
+        assert result["tiles"][0]["value_celsius"] == 33.2
+        assert result["provenance"]["source"] == "fixture"
+        assert result["provenance"]["forecast"] is False
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -63,3 +63,41 @@ def test_invalid_boolean_and_missing_fixture_return_unavailable() -> None:
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> None:
+    server = create_fixture_server(Path("fixtures/heatmap-historical.json"))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = json.dumps(
+            {
+                "heat_value": 38,
+                "heat_threshold": 35,
+                "building_coverage": 0.9,
+                "hotels": [
+                    {"identity": "cooler", "components": {"night": 30, "hot_hours": 5, "persistence": 2, "day": 32}},
+                    {"identity": "hotter", "components": {"night": 36, "hot_hours": 9, "persistence": 5, "day": 38}},
+                ],
+                "routes": [
+                    {"identity": "short", "distance_m": 1000, "duration_s": 600},
+                    {"identity": "shady", "distance_m": 1200, "duration_s": 700},
+                ],
+                "shade": {"short": 20, "shady": 80},
+            }
+        ).encode()
+        response = urlopen(
+            Request(
+                f"http://127.0.0.1:{server.server_port}/api/trip/analyze",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+        )
+        result = json.load(response)
+        assert result["hotels"][0]["identity"] == "cooler"
+        assert result["route"]["recommended_id"] == "shady"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -102,3 +102,20 @@ def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> No
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def test_trip_analysis_rejects_untrusted_metric_and_provenance_fields() -> None:
+    server = create_fixture_server(Path("fixtures/heatmap-historical.json"))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = json.dumps({"heat_metric": "heat_index_celsius"}).encode()
+        try:
+            urlopen(Request(f"http://127.0.0.1:{server.server_port}/api/trip/analyze", data=body, method="POST"))
+        except HTTPError as error:
+            assert error.code == 400
+            assert json.load(error)["status"] == "unavailable"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -65,6 +65,22 @@ def test_invalid_boolean_and_missing_fixture_return_unavailable() -> None:
         thread.join(timeout=2)
 
 
+def test_non_object_json_body_returns_unavailable() -> None:
+    server = create_fixture_server(Path("fixtures/heatmap-historical.json"))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        try:
+            urlopen(Request(f"http://127.0.0.1:{server.server_port}/api/heatmap", data=b"[]", method="POST"))
+        except HTTPError as error:
+            assert error.code == 400
+            assert json.load(error)["status"] == "unavailable"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> None:
     server = create_fixture_server(Path("fixtures/heatmap-historical.json"))
     thread = Thread(target=server.serve_forever, daemon=True)

--- a/tests/test_application_domain.py
+++ b/tests/test_application_domain.py
@@ -40,6 +40,23 @@ def test_cache_hit_is_marked_as_replayed_and_cache_miss_is_none() -> None:
     assert service.get(CacheKey.create("heatmap", "v1", {"metric": "other"})) is None
 
 
+def test_cache_preserves_forecast_and_data_date_metadata() -> None:
+    service = CacheService()
+    key = service.put(
+        "heatmap",
+        "v1",
+        {"metric": "tcm"},
+        {"value": 35},
+        retrieved_at=datetime(2026, 8, 23, tzinfo=timezone.utc),
+        data_date="2026-08-23",
+        forecast=True,
+    )
+    entry = service.get(key)
+    assert entry is not None
+    assert entry.provenance.forecast is True
+    assert entry.provenance.data_date == "2026-08-23"
+
+
 def test_enrichment_is_top_n_and_budgeted_without_blocking_core_flow() -> None:
     plan = EnrichmentPlanner(credits=3).plan(
         ["hotel-a", "hotel-b", "hotel-c", "hotel-d"],

--- a/tests/test_application_domain.py
+++ b/tests/test_application_domain.py
@@ -92,7 +92,7 @@ def test_historical_exposure_is_explicit_supporting_context() -> None:
     summary = extract_exposure(
         {
             "value": 6,
-            "unit": "C",
+            "unit": "hours",
             "valid_from": "2026-08-20T00:00:00+00:00",
             "valid_to": "2026-08-20T23:00:00+00:00",
             "fresh_at": "2026-08-21T00:00:00+00:00",

--- a/tests/test_application_domain.py
+++ b/tests/test_application_domain.py
@@ -8,6 +8,7 @@ from app.domain import (
     Provenance,
     ReadinessInput,
     readiness,
+    EnrichmentOutcome,
 )
 from app.cache import CacheService
 from app.analysis import extract_exposure, point_join_contract, polygon_join_contract
@@ -86,6 +87,21 @@ def test_enrichment_execution_preserves_ranked_output_after_partial_failure() ->
     assert result.failures == {"hotel-b": "optional provider failed"}
     assert result.remaining_credits == 0
     assert planner.credits == 0
+
+
+def test_enrichment_execution_records_actual_provider_usage() -> None:
+    from app.ledger import CreditLedger
+
+    ledger = CreditLedger(5)
+    result = EnrichmentPlanner(5).execute(
+        ["hotel-a"],
+        EnrichmentRequest(top_n=1, credits_per_item=2),
+        lambda _: EnrichmentOutcome({"canopy": 42}, "activity-1", 2, "/v1/satellite"),
+        ledger=ledger,
+    )
+    assert result.enriched["hotel-a"] == {"canopy": 42}
+    assert ledger.total_used == 2
+    assert ledger.records[0].activity_id == "activity-1"
 
 
 def test_historical_exposure_is_explicit_supporting_context() -> None:

--- a/tests/test_application_domain.py
+++ b/tests/test_application_domain.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import pytest
 
 from app.domain import (
     CacheKey,
@@ -9,7 +10,7 @@ from app.domain import (
     readiness,
 )
 from app.cache import CacheService
-from app.analysis import point_join_contract, polygon_join_contract
+from app.analysis import extract_exposure, point_join_contract, polygon_join_contract
 
 
 def test_cache_key_separates_endpoint_and_schema_for_same_payload() -> None:
@@ -65,6 +66,55 @@ def test_enrichment_is_top_n_and_budgeted_without_blocking_core_flow() -> None:
     assert plan.selected == ("hotel-a",)
     assert plan.remaining_credits == 1
     assert plan.base_result_preserved is True
+
+
+def test_enrichment_execution_preserves_ranked_output_after_partial_failure() -> None:
+    planner = EnrichmentPlanner(credits=4)
+
+    def enrich(candidate: str) -> dict[str, str]:
+        if candidate == "hotel-b":
+            raise RuntimeError("optional provider failed")
+        return {"candidate": candidate}
+
+    result = planner.execute(
+        ["hotel-a", "hotel-b", "hotel-c"],
+        EnrichmentRequest(top_n=2, credits_per_item=2),
+        enrich,
+    )
+    assert result.base_ranking == ("hotel-a", "hotel-b", "hotel-c")
+    assert result.enriched == {"hotel-a": {"candidate": "hotel-a"}}
+    assert result.failures == {"hotel-b": "optional provider failed"}
+    assert result.remaining_credits == 0
+    assert planner.credits == 0
+
+
+def test_historical_exposure_is_explicit_supporting_context() -> None:
+    summary = extract_exposure(
+        {
+            "value": 6,
+            "unit": "C",
+            "valid_from": "2026-08-20T00:00:00+00:00",
+            "valid_to": "2026-08-20T23:00:00+00:00",
+            "fresh_at": "2026-08-21T00:00:00+00:00",
+        },
+        metric="exceedance",
+        threshold_celsius=35,
+        direction="above",
+        source="fortyguard",
+        forecast=False,
+    )
+    assert summary.role == "supporting_context"
+    assert summary.forecast is False
+    assert summary.threshold_celsius == 35
+    assert summary.fresh_at == "2026-08-21T00:00:00+00:00"
+
+
+def test_exposure_rejects_forecast_and_missing_freshness() -> None:
+    payload = {"value": 6, "unit": "C", "valid_from": "start", "valid_to": "end"}
+    with pytest.raises(ValueError, match="freshness"):
+        extract_exposure(payload, metric="exceedance", threshold_celsius=35, direction="above", source="fortyguard", forecast=False)
+    with pytest.raises(ValueError, match="historical"):
+        extract_exposure({**payload, "fresh_at": "fresh"}, metric="persistence", threshold_celsius=35, direction="above", source="fortyguard", forecast=True)
 
 
 def test_readiness_returns_deterministic_reason_codes() -> None:

--- a/tests/test_application_domain.py
+++ b/tests/test_application_domain.py
@@ -133,6 +133,14 @@ def test_exposure_rejects_forecast_and_missing_freshness() -> None:
         extract_exposure({**payload, "fresh_at": "fresh"}, metric="persistence", threshold_celsius=35, direction="above", source="fortyguard", forecast=True)
 
 
+def test_exposure_rejects_boolean_and_non_finite_values() -> None:
+    base = {"unit": "hours", "valid_from": "start", "valid_to": "end", "fresh_at": "fresh"}
+    with pytest.raises(ValueError, match="value"):
+        extract_exposure({**base, "value": True}, metric="exceedance", threshold_celsius=35, direction="above", source="fortyguard", forecast=False)
+    with pytest.raises(ValueError, match="value"):
+        extract_exposure({**base, "value": float("nan")}, metric="persistence", threshold_celsius=35, direction="above", source="fortyguard", forecast=False)
+
+
 def test_readiness_returns_deterministic_reason_codes() -> None:
     result = readiness(
         ReadinessInput(heat_celsius=38, threshold_celsius=35, coverage=0.9, forecast=True)

--- a/tests/test_application_domain.py
+++ b/tests/test_application_domain.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timezone
+
+from app.domain import (
+    CacheKey,
+    EnrichmentPlanner,
+    EnrichmentRequest,
+    Provenance,
+    ReadinessInput,
+    readiness,
+)
+from app.cache import CacheService
+from app.analysis import point_join_contract, polygon_join_contract
+
+
+def test_cache_key_separates_endpoint_and_schema_for_same_payload() -> None:
+    payload = {"latitude": 29.4241, "longitude": -98.4936}
+    assert CacheKey.create("heatmap", "v1", payload) != CacheKey.create("status", "v1", payload)
+    assert CacheKey.create("heatmap", "v1", payload) == CacheKey.create("heatmap", "v1", dict(reversed(list(payload.items()))))
+
+
+def test_stale_cache_provenance_is_explicit() -> None:
+    provenance = Provenance.cached(
+        retrieved_at=datetime(2026, 8, 20, tzinfo=timezone.utc),
+        data_date="2026-08-20",
+        activity_id="activity-1",
+    )
+    assert provenance.source == "cache"
+    assert provenance.stale is True
+    assert provenance.activity_id == "activity-1"
+
+
+def test_cache_hit_is_marked_as_replayed_and_cache_miss_is_none() -> None:
+    service = CacheService()
+    key = service.put("heatmap", "v1", {"metric": "tcm"}, {"value": 35}, retrieved_at=datetime(2026, 8, 23, tzinfo=timezone.utc), data_date="2026-08-23", activity_id="a1")
+    hit = service.get(key)
+    assert hit is not None
+    assert hit.provenance.source == "cache"
+    assert hit.provenance.stale is True
+    assert hit.provenance.raw_payload == {"value": 35}
+    assert service.get(CacheKey.create("heatmap", "v1", {"metric": "other"})) is None
+
+
+def test_enrichment_is_top_n_and_budgeted_without_blocking_core_flow() -> None:
+    plan = EnrichmentPlanner(credits=3).plan(
+        ["hotel-a", "hotel-b", "hotel-c", "hotel-d"],
+        EnrichmentRequest(top_n=2, credits_per_item=2),
+    )
+    assert plan.selected == ("hotel-a",)
+    assert plan.remaining_credits == 1
+    assert plan.base_result_preserved is True
+
+
+def test_readiness_returns_deterministic_reason_codes() -> None:
+    result = readiness(
+        ReadinessInput(heat_celsius=38, threshold_celsius=35, coverage=0.9, forecast=True)
+    )
+    assert result.priority == "high"
+    assert result.reason_codes == ("HEAT_THRESHOLD_EXCEEDED",)
+
+
+def test_spatial_contract_reports_partial_polygon_coverage_and_point_fallback() -> None:
+    polygon = polygon_join_contract([(30, 2), (40, 1)], coverage=0.75, projected_crs="EPSG:32614")
+    assert polygon.value == 100 / 3
+    assert polygon.quality == "partial"
+    point = point_join_contract(containing_value=None, boundary=False, outside_aoi=True, nearest_value=35, nearest_distance_m=12)
+    assert point.quality == "nearest_fallback"
+    assert point.distance_m == 12

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1,0 +1,39 @@
+from datetime import date
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.api import create_app
+
+
+def test_fastapi_app_exposes_fixture_heatmap_contract() -> None:
+    client = TestClient(create_app(Path("fixtures/heatmap-historical.json")))
+    response = client.post(
+        "/api/heatmap",
+        json={
+            "analytic_type": "tcm",
+            "latitude": 29.4241,
+            "longitude": -98.4936,
+            "start_date": date(2026, 8, 23).isoformat(),
+            "forecast": False,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["provenance"]["source"] == "fixture"
+
+
+def test_fastapi_app_does_not_allow_public_live_mode() -> None:
+    client = TestClient(create_app(Path("fixtures/heatmap-historical.json")))
+    response = client.post(
+        "/api/heatmap",
+        json={
+            "analytic_type": "tcm",
+            "latitude": 29.4241,
+            "longitude": -98.4936,
+            "start_date": date(2026, 8, 23).isoformat(),
+            "forecast": False,
+            "execution_mode": "live",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"]["status"] == "unavailable"

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -23,6 +23,7 @@ def test_heatmap_request_requires_threshold_and_direction_for_exceedance() -> No
             latitude=29.4241,
             longitude=-98.4936,
             start_date=date(2026, 8, 23),
+            forecast=False,
         )
 
 
@@ -41,7 +42,7 @@ def test_normalizer_preserves_forecast_provenance_and_units() -> None:
         analytic_type=AnalyticType.TCM,
         latitude=29.4241,
         longitude=-98.4936,
-        start_date=date(2026, 8, 23),
+        start_date=date.today(),
     )
     result = normalize_heatmap_response(
         {"features": [{"geometry": {"type": "Point", "coordinates": [-98.49, 29.42]}, "properties": {"value": 35.5, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]},
@@ -55,7 +56,7 @@ def test_normalizer_preserves_forecast_provenance_and_units() -> None:
 
 
 def test_normalizer_rejects_boolean_metric_values() -> None:
-    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23))
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
     with pytest.raises(ValueError, match="units"):
         normalize_heatmap_response(
             {"features": [{"geometry": {"type": "Point", "coordinates": [-98.49, 29.42]}, "properties": {"value": True, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]},
@@ -82,7 +83,7 @@ def test_committed_fixtures_normalize_to_the_same_tile_schema(
         analytic_type,
         29.4241,
         -98.4936,
-        date(2026, 8, 23),
+        date.today() if forecast else date(2026, 8, 23),
         forecast=forecast,
         threshold_celsius=35 if analytic_type is not AnalyticType.TCM else None,
         direction="above" if analytic_type is not AnalyticType.TCM else None,
@@ -106,7 +107,7 @@ def test_empty_failed_and_malformed_fixtures_are_rejected() -> None:
 def test_fixture_mode_must_match_forecast_or_historical_request() -> None:
     from app.execution import HeatmapExecution
 
-    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=True)
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today(), forecast=True)
     with pytest.raises(ValueError, match="mode"):
         HeatmapExecution(fixture_path=Path("fixtures") / "heatmap-historical.json").run(request)
 

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -380,6 +380,13 @@ def test_polling_retries_transient_status_transport_without_resubmission() -> No
     assert transitions == ["rate_limited", "server_error", "Completed"]
 
 
+def test_polling_retries_status_timeout_within_bound() -> None:
+    responses: Iterator[dict[str, object]] = iter(
+        [{"status_code": 408}, {"status_code": 200, "status": "Completed", "result": {"ok": True}}]
+    )
+    assert poll_activity("activity-1", get_status=lambda _: next(responses), sleep=lambda _: None, max_polls=2) == {"ok": True}
+
+
 def test_client_emits_sanitized_structured_activity_events() -> None:
     class Transport:
         def post(self, endpoint: str, payload: object, api_key: str) -> dict[str, object]:

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -45,6 +45,16 @@ def test_heatmap_request_rejects_non_finite_coordinates() -> None:
         HeatmapRequest(AnalyticType.TCM, float("nan"), -98.4936, date.today())
 
 
+def test_normalizer_rejects_malformed_point_coordinates() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    with pytest.raises(ValueError, match="geometry"):
+        normalize_heatmap_response(
+            {"features": [{"geometry": {"type": "Point", "coordinates": [1]}, "properties": {"value": 35, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]},
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
 def test_heatmap_request_rejects_unknown_analytic_type() -> None:
     with pytest.raises(ValueError, match="analytic type"):
         HeatmapRequest(
@@ -391,3 +401,17 @@ def test_client_records_provider_reported_credits_in_ledger() -> None:
     ).submit_and_poll("/v1/heatmap", {}, sleep=lambda _: None)
     assert ledger.total_used == 4
     assert ledger.records[0].endpoint == "/v1/heatmap"
+
+
+def test_client_rejects_invalid_provider_credit_metadata() -> None:
+    class Transport:
+        def post(self, endpoint: str, payload: object, api_key: str) -> dict[str, object]:
+            return {"activity_id": "activity-1"}
+
+        def get(self, endpoint: str, api_key: str) -> dict[str, object]:
+            return {"status": "Completed", "credits_used": 1.5, "result": {"ok": True}}
+
+    with pytest.raises(Exception, match="invalid credit"):
+        FortyGuardClient(Transport(), "secret", clock=lambda: datetime.now(timezone.utc)).submit_and_poll(
+            "/v1/heatmap", {}, sleep=lambda _: None
+        )

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -290,3 +290,21 @@ def test_client_emits_sanitized_structured_activity_events() -> None:
     assert events[0]["request"] == {"analytic_type": "tcm", "api_key": "[redacted]"}
     assert "must-not-appear" not in repr(events)
     assert metadata.status_transitions == ("Completed",)
+
+
+def test_client_records_provider_reported_credits_in_ledger() -> None:
+    from app.ledger import CreditLedger
+
+    class Transport:
+        def post(self, endpoint: str, payload: object, api_key: str) -> dict[str, object]:
+            return {"activity_id": "activity-1"}
+
+        def get(self, endpoint: str, api_key: str) -> dict[str, object]:
+            return {"status": "Completed", "credits_used": 4, "result": {"ok": True}}
+
+    ledger = CreditLedger(5)
+    FortyGuardClient(
+        Transport(), "secret", clock=lambda: datetime(2026, 8, 23, tzinfo=timezone.utc), ledger=ledger
+    ).submit_and_poll("/v1/heatmap", {}, sleep=lambda _: None)
+    assert ledger.total_used == 4
+    assert ledger.records[0].endpoint == "/v1/heatmap"

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -1,0 +1,130 @@
+from datetime import date, datetime, timezone
+import json
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from app.fortyguard import (
+    AnalyticType,
+    HeatmapRequest,
+    ProviderErrorKind,
+    FortyGuardClient,
+    classify_provider_error,
+    normalize_heatmap_response,
+    poll_activity,
+)
+
+
+def test_heatmap_request_requires_threshold_and_direction_for_exceedance() -> None:
+    with pytest.raises(ValueError, match="threshold"):
+        HeatmapRequest(
+            analytic_type=AnalyticType.EXCEEDANCE,
+            latitude=29.4241,
+            longitude=-98.4936,
+            start_date=date(2026, 8, 23),
+        )
+
+
+def test_heatmap_request_rejects_unknown_analytic_type() -> None:
+    with pytest.raises(ValueError, match="analytic type"):
+        HeatmapRequest(
+            analytic_type="unknown",  # type: ignore[arg-type]
+            latitude=29.4241,
+            longitude=-98.4936,
+            start_date=date(2026, 8, 23),
+        )
+
+
+def test_normalizer_preserves_forecast_provenance_and_units() -> None:
+    request = HeatmapRequest(
+        analytic_type=AnalyticType.TCM,
+        latitude=29.4241,
+        longitude=-98.4936,
+        start_date=date(2026, 8, 23),
+    )
+    result = normalize_heatmap_response(
+        {"features": [{"geometry": {"type": "Point", "coordinates": [-98.49, 29.42]}, "properties": {"value": 35.5, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]},
+        request=request,
+        retrieved_at=datetime(2026, 8, 23, 12, tzinfo=timezone.utc),
+        activity_id="activity-1",
+    )
+    assert result.tiles[0].value_celsius == 35.5
+    assert result.provenance.forecast is True
+    assert result.provenance.activity_id == "activity-1"
+
+
+def test_fixture_and_live_execution_share_normalized_schema(tmp_path: Path) -> None:
+    from app.execution import HeatmapExecution
+
+    fixture = tmp_path / "heatmap.json"
+    fixture.write_text('{"features": [{"geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"value": 35.5, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]}')
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    execution = HeatmapExecution(fixture_path=fixture, live_loader=lambda _: json.loads(fixture.read_text()))
+    fixture_result = execution.run(request)
+    live_result = execution.run(request, live=True)
+    assert fixture_result.tiles[0].geometry == live_result.tiles[0].geometry
+    assert fixture_result.tiles[0].value_celsius == live_result.tiles[0].value_celsius
+    assert fixture_result.tiles[0].metric == live_result.tiles[0].metric
+    assert fixture_result.provenance.source == "fixture"
+    assert live_result.provenance.source == "provider"
+    assert fixture_result.provenance.forecast is False
+
+
+def test_polling_tolerates_one_post_submit_404_but_does_not_resubmit() -> None:
+    responses: Iterator[dict[str, object]] = iter([{"status_code": 404}, {"status_code": 200, "status": "Completed", "result": {"ok": True}}])
+    submitted = 0
+
+    def get_status(_: str) -> dict[str, object]:
+        return next(responses)
+
+    result = poll_activity("activity-1", get_status=get_status, sleep=lambda _: None, max_polls=2)
+    assert result == {"ok": True}
+    assert submitted == 0
+
+
+def test_polling_reports_failed_tasks_and_timeouts() -> None:
+    with pytest.raises(Exception, match="task_failure"):
+        poll_activity("activity-1", get_status=lambda _: {"status": "Failed"}, sleep=lambda _: None)
+    with pytest.raises(Exception, match="timed out"):
+        poll_activity("activity-1", get_status=lambda _: {"status": "Processing"}, sleep=lambda _: None, max_polls=1)
+
+
+def test_provider_errors_are_classified_without_exposing_response_body() -> None:
+    error = classify_provider_error(401, "api key=secret")
+    assert error.kind is ProviderErrorKind.AUTHENTICATION
+    assert "secret" not in str(error)
+
+
+def test_client_submits_once_and_captures_sanitized_activity_metadata() -> None:
+    class Transport:
+        def __init__(self) -> None:
+            self.posts = 0
+
+        def post(self, endpoint: str, payload: object, api_key: str) -> dict[str, object]:
+            self.posts += 1
+            assert api_key == "secret"
+            return {"activity_id": "activity-1"}
+
+        def get(self, endpoint: str, api_key: str) -> dict[str, object]:
+            return {"status": "Completed", "result": {"features": []}}
+
+    transport = Transport()
+    result, metadata = FortyGuardClient(
+        transport, "secret", clock=lambda: datetime(2026, 8, 23, tzinfo=timezone.utc)
+    ).submit_and_poll("/v1/heatmap", {"analytic_type": "tcm"}, sleep=lambda _: None)
+    assert result["features"] == []
+    assert transport.posts == 1
+    assert metadata.request_fields == ("analytic_type",)
+
+
+def test_client_classifies_submit_errors_before_activity_lookup() -> None:
+    class Transport:
+        def post(self, endpoint: str, payload: object, api_key: str) -> dict[str, object]:
+            return {"status_code": 429, "detail": "slow down"}
+
+        def get(self, endpoint: str, api_key: str) -> dict[str, object]:
+            raise AssertionError("status lookup must not run")
+
+    with pytest.raises(Exception, match="rate_limit"):
+        FortyGuardClient(Transport(), "secret", clock=lambda: datetime.now(timezone.utc)).submit_and_poll("/v1/heatmap", {})

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -89,7 +89,11 @@ def test_committed_fixtures_normalize_to_the_same_tile_schema(
         direction="above" if analytic_type is not AnalyticType.TCM else None,
     )
     result = HeatmapExecution(fixture_path=Path("fixtures") / fixture_name).run(request)
-    assert result.tiles[0].value_celsius == value
+    if analytic_type is AnalyticType.TCM:
+        assert result.tiles[0].value_celsius == value
+    else:
+        assert result.tiles[0].value_celsius is None
+    assert result.tiles[0].metric_value == value
     assert result.tiles[0].metric is analytic_type
     assert result.tiles[0].source == "fixture"
     assert result.provenance.forecast is forecast
@@ -109,6 +113,14 @@ def test_fixture_mode_must_match_forecast_or_historical_request() -> None:
 
     request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today(), forecast=True)
     with pytest.raises(ValueError, match="mode"):
+        HeatmapExecution(fixture_path=Path("fixtures") / "heatmap-historical.json").run(request)
+
+
+def test_fixture_request_identity_must_match_scenario() -> None:
+    from app.execution import HeatmapExecution
+
+    request = HeatmapRequest(AnalyticType.TCM, 30.2672, -97.7431, date(2026, 8, 23), forecast=False)
+    with pytest.raises(ValueError, match="scenario"):
         HeatmapExecution(fixture_path=Path("fixtures") / "heatmap-historical.json").run(request)
 
 

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -286,7 +286,7 @@ def test_fixture_and_live_execution_share_normalized_schema(tmp_path: Path) -> N
     from app.execution import HeatmapExecution
 
     fixture = tmp_path / "heatmap.json"
-    fixture.write_text('{"mode": "historical", "features": [{"geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"value": 35.5, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]}')
+    fixture.write_text('{"mode": "historical", "request": {"analytic_type": "tcm", "latitude": 29.4241, "longitude": -98.4936, "start_date": "2026-08-23", "forecast": false, "threshold_celsius": null, "direction": null}, "features": [{"geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"value": 35.5, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]}')
     request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
     execution = HeatmapExecution(fixture_path=fixture, live_loader=lambda _: json.loads(fixture.read_text()))
     fixture_result = execution.run(request)

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -214,6 +214,17 @@ def test_live_result_preserves_activity_id_and_malformed_payload_uses_cache() ->
     assert replayed.provenance.source == "cache"
 
 
+def test_live_provenance_uses_provider_freshness_date() -> None:
+    from app.execution import HeatmapExecution, LiveHeatmapPayload
+
+    payload = json.loads((Path("fixtures") / "heatmap-historical.json").read_text())
+    result = HeatmapExecution(
+        fixture_path=Path("fixtures") / "heatmap-historical.json",
+        live_loader=lambda _: LiveHeatmapPayload(payload, "live-1"),
+    ).run(HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False), live=True)
+    assert result.provenance.data_date == "2026-08-20"
+
+
 def test_live_failure_without_matching_cache_is_not_silently_successful() -> None:
     from app.cache import CacheService
     from app.execution import HeatmapExecution

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -54,6 +54,16 @@ def test_normalizer_preserves_forecast_provenance_and_units() -> None:
     assert result.provenance.activity_id == "activity-1"
 
 
+def test_normalizer_rejects_boolean_metric_values() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23))
+    with pytest.raises(ValueError, match="units"):
+        normalize_heatmap_response(
+            {"features": [{"geometry": {"type": "Point", "coordinates": [-98.49, 29.42]}, "properties": {"value": True, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]},
+            request=request,
+            retrieved_at=datetime(2026, 8, 23, 12, tzinfo=timezone.utc),
+        )
+
+
 @pytest.mark.parametrize(
     ("fixture_name", "analytic_type", "forecast", "value"),
     [
@@ -126,7 +136,7 @@ def test_live_failure_replays_matching_cache_as_stale_data() -> None:
     )
 
     def failed(_: HeatmapRequest) -> dict[str, object]:
-        raise RuntimeError("provider unavailable")
+        raise ConnectionError("provider unavailable")
 
     result = HeatmapExecution(fixture_path=Path("fixtures") / "heatmap-historical.json", live_loader=failed, cache=cache).run(request, live=True)
     assert result.provenance.source == "cache"
@@ -139,10 +149,10 @@ def test_live_failure_without_matching_cache_is_not_silently_successful() -> Non
     from app.execution import HeatmapExecution
 
     request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
-    with pytest.raises(RuntimeError, match="provider unavailable"):
+    with pytest.raises(ConnectionError, match="provider unavailable"):
         HeatmapExecution(
             fixture_path=Path("fixtures") / "heatmap-historical.json",
-            live_loader=lambda _: (_ for _ in ()).throw(RuntimeError("provider unavailable")),
+            live_loader=lambda _: (_ for _ in ()).throw(ConnectionError("provider unavailable")),
             cache=CacheService(),
         ).run(request, live=True)
 

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -101,6 +101,52 @@ def test_fixture_mode_must_match_forecast_or_historical_request() -> None:
         HeatmapExecution(fixture_path=Path("fixtures") / "heatmap-historical.json").run(request)
 
 
+def test_live_failure_replays_matching_cache_as_stale_data() -> None:
+    from app.cache import CacheService
+    from app.execution import HeatmapExecution
+
+    cache = CacheService()
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    payload = json.loads((Path("fixtures") / "heatmap-historical.json").read_text())
+    cache.put(
+        "/v1/heatmap",
+        "v1",
+        {
+            "analytic_type": "tcm",
+            "latitude": 29.4241,
+            "longitude": -98.4936,
+            "start_date": "2026-08-23",
+            "forecast": False,
+            "threshold_celsius": None,
+            "direction": None,
+        },
+        payload,
+        retrieved_at=datetime(2026, 8, 23, tzinfo=timezone.utc),
+        data_date="2026-08-20",
+    )
+
+    def failed(_: HeatmapRequest) -> dict[str, object]:
+        raise RuntimeError("provider unavailable")
+
+    result = HeatmapExecution(fixture_path=Path("fixtures") / "heatmap-historical.json", live_loader=failed, cache=cache).run(request, live=True)
+    assert result.provenance.source == "cache"
+    assert result.provenance.stale is True
+    assert result.provenance.data_date == "2026-08-20"
+
+
+def test_live_failure_without_matching_cache_is_not_silently_successful() -> None:
+    from app.cache import CacheService
+    from app.execution import HeatmapExecution
+
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        HeatmapExecution(
+            fixture_path=Path("fixtures") / "heatmap-historical.json",
+            live_loader=lambda _: (_ for _ in ()).throw(RuntimeError("provider unavailable")),
+            cache=CacheService(),
+        ).run(request, live=True)
+
+
 def test_fixture_and_live_execution_share_normalized_schema(tmp_path: Path) -> None:
     from app.execution import HeatmapExecution
 

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -89,6 +89,11 @@ def test_heatmap_request_rejects_unknown_analytic_type() -> None:
         )
 
 
+def test_heatmap_request_rejects_non_boolean_forecast() -> None:
+    with pytest.raises(ValueError, match="forecast"):
+        HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today(), forecast="false")  # type: ignore[arg-type]
+
+
 def test_normalizer_preserves_forecast_provenance_and_units() -> None:
     request = HeatmapRequest(
         analytic_type=AnalyticType.TCM,

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -54,11 +54,58 @@ def test_normalizer_preserves_forecast_provenance_and_units() -> None:
     assert result.provenance.activity_id == "activity-1"
 
 
+@pytest.mark.parametrize(
+    ("fixture_name", "analytic_type", "forecast", "value"),
+    [
+        ("heatmap-forecast.json", AnalyticType.TCM, True, 35.5),
+        ("heatmap-historical.json", AnalyticType.TCM, False, 33.2),
+        ("heatmap-exceedance.json", AnalyticType.EXCEEDANCE, False, 6.0),
+        ("heatmap-persistence.json", AnalyticType.PERSISTENCE, False, 4.0),
+    ],
+)
+def test_committed_fixtures_normalize_to_the_same_tile_schema(
+    fixture_name: str, analytic_type: AnalyticType, forecast: bool, value: float
+) -> None:
+    from app.execution import HeatmapExecution
+
+    request = HeatmapRequest(
+        analytic_type,
+        29.4241,
+        -98.4936,
+        date(2026, 8, 23),
+        forecast=forecast,
+        threshold_celsius=35 if analytic_type is not AnalyticType.TCM else None,
+        direction="above" if analytic_type is not AnalyticType.TCM else None,
+    )
+    result = HeatmapExecution(fixture_path=Path("fixtures") / fixture_name).run(request)
+    assert result.tiles[0].value_celsius == value
+    assert result.tiles[0].metric is analytic_type
+    assert result.tiles[0].source == "fixture"
+    assert result.provenance.forecast is forecast
+
+
+def test_empty_failed_and_malformed_fixtures_are_rejected() -> None:
+    from app.execution import HeatmapExecution
+
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    for name in ("heatmap-empty.json", "heatmap-failed.json", "heatmap-malformed.json"):
+        with pytest.raises(ValueError):
+            HeatmapExecution(fixture_path=Path("fixtures") / name).run(request)
+
+
+def test_fixture_mode_must_match_forecast_or_historical_request() -> None:
+    from app.execution import HeatmapExecution
+
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=True)
+    with pytest.raises(ValueError, match="mode"):
+        HeatmapExecution(fixture_path=Path("fixtures") / "heatmap-historical.json").run(request)
+
+
 def test_fixture_and_live_execution_share_normalized_schema(tmp_path: Path) -> None:
     from app.execution import HeatmapExecution
 
     fixture = tmp_path / "heatmap.json"
-    fixture.write_text('{"features": [{"geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"value": 35.5, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]}')
+    fixture.write_text('{"mode": "historical", "features": [{"geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {"value": 35.5, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]}')
     request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
     execution = HeatmapExecution(fixture_path=fixture, live_loader=lambda _: json.loads(fixture.read_text()))
     fixture_result = execution.run(request)

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -78,6 +78,16 @@ def test_normalizer_rejects_boolean_metric_values() -> None:
         )
 
 
+def test_normalizer_rejects_non_finite_metric_values() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    with pytest.raises(ValueError, match="units"):
+        normalize_heatmap_response(
+            {"features": [{"geometry": {"type": "Point", "coordinates": [-98.49, 29.42]}, "properties": {"value": float("nan"), "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]},
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
 @pytest.mark.parametrize(
     ("fixture_name", "analytic_type", "forecast", "value"),
     [

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -55,6 +55,30 @@ def test_normalizer_rejects_malformed_point_coordinates() -> None:
         )
 
 
+def test_normalizer_accepts_valid_multipolygon_geometry() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "MultiPolygon",
+                        "coordinates": [[[[1, 1], [2, 1], [2, 2], [1, 1]]]],
+                    },
+                    "properties": {
+                        "value": 35,
+                        "unit": "C",
+                        "valid_time": "2026-08-23T15:00:00+00:00",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+    )
+    assert result.tiles[0].geometry["type"] == "MultiPolygon"
+
+
 def test_heatmap_request_rejects_unknown_analytic_type() -> None:
     with pytest.raises(ValueError, match="analytic type"):
         HeatmapRequest(

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -128,3 +128,61 @@ def test_client_classifies_submit_errors_before_activity_lookup() -> None:
 
     with pytest.raises(Exception, match="rate_limit"):
         FortyGuardClient(Transport(), "secret", clock=lambda: datetime.now(timezone.utc)).submit_and_poll("/v1/heatmap", {})
+
+
+def test_polling_retries_transient_status_transport_without_resubmission() -> None:
+    responses: Iterator[dict[str, object]] = iter(
+        [
+            {"status_code": 429},
+            {"status_code": 503},
+            {"status_code": 200, "status": "Completed", "result": {"ok": True}},
+        ]
+    )
+    transitions: list[str] = []
+
+    result = poll_activity(
+        "activity-1",
+        get_status=lambda _: next(responses),
+        sleep=lambda _: None,
+        max_polls=3,
+        on_transition=transitions.append,
+    )
+
+    assert result == {"ok": True}
+    assert transitions == (  # type: ignore[comparison-overlap]
+        ["rate_limited", "server_error", "Completed"]
+    )
+
+
+def test_client_emits_sanitized_structured_activity_events() -> None:
+    class Transport:
+        def post(self, endpoint: str, payload: object, api_key: str) -> dict[str, object]:
+            return {"activity_id": "activity-1"}
+
+        def get(self, endpoint: str, api_key: str) -> dict[str, object]:
+            return {
+                "status": "Completed",
+                "result": {"features": []},
+                "credits_used": 4,
+            }
+
+    events: list[dict[str, object]] = []
+    _, metadata = FortyGuardClient(
+        Transport(),
+        "secret",
+        clock=lambda: datetime(2026, 8, 23, tzinfo=timezone.utc),
+        event_sink=events.append,
+    ).submit_and_poll(
+        "/v1/heatmap",
+        {"analytic_type": "tcm", "api_key": "must-not-appear"},
+        sleep=lambda _: None,
+    )
+
+    assert [event["event"] for event in events] == [
+        "fortyguard.submitted",
+        "fortyguard.status_transition",
+        "fortyguard.completed",
+    ]
+    assert events[0]["request"] == {"analytic_type": "tcm", "api_key": "[redacted]"}
+    assert "must-not-appear" not in repr(events)
+    assert metadata.status_transitions == ("Completed",)

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -27,6 +27,19 @@ def test_heatmap_request_requires_threshold_and_direction_for_exceedance() -> No
         )
 
 
+def test_heatmap_request_rejects_non_finite_thresholds() -> None:
+    with pytest.raises(ValueError, match="threshold"):
+        HeatmapRequest(
+            AnalyticType.EXCEEDANCE,
+            29.4241,
+            -98.4936,
+            date(2026, 8, 23),
+            forecast=False,
+            threshold_celsius=float("inf"),
+            direction="above",
+        )
+
+
 def test_heatmap_request_rejects_unknown_analytic_type() -> None:
     with pytest.raises(ValueError, match="analytic type"):
         HeatmapRequest(
@@ -155,6 +168,30 @@ def test_live_failure_replays_matching_cache_as_stale_data() -> None:
     assert result.provenance.source == "cache"
     assert result.provenance.stale is True
     assert result.provenance.data_date == "2026-08-20"
+
+
+def test_live_result_preserves_activity_id_and_malformed_payload_uses_cache() -> None:
+    from app.cache import CacheService
+    from app.execution import HeatmapExecution, LiveHeatmapPayload
+
+    cache = CacheService()
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    payload = json.loads((Path("fixtures") / "heatmap-historical.json").read_text())
+    cache.put(
+        "/v1/heatmap", "v1", {"analytic_type": "tcm", "latitude": 29.4241, "longitude": -98.4936, "start_date": "2026-08-23", "forecast": False, "threshold_celsius": None, "direction": None}, payload,
+        retrieved_at=datetime(2026, 8, 20, tzinfo=timezone.utc), data_date="2026-08-20", activity_id="cached",
+    )
+    live = HeatmapExecution(
+        fixture_path=Path("fixtures") / "heatmap-historical.json",
+        live_loader=lambda _: LiveHeatmapPayload(payload, "live-1"),
+    ).run(request, live=True)
+    assert live.provenance.activity_id == "live-1"
+    replayed = HeatmapExecution(
+        fixture_path=Path("fixtures") / "heatmap-historical.json",
+        live_loader=lambda _: {"features": [{"geometry": {}, "properties": {}}]},
+        cache=cache,
+    ).run(request, live=True)
+    assert replayed.provenance.source == "cache"
 
 
 def test_live_failure_without_matching_cache_is_not_silently_successful() -> None:

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -40,6 +40,11 @@ def test_heatmap_request_rejects_non_finite_thresholds() -> None:
         )
 
 
+def test_heatmap_request_rejects_non_finite_coordinates() -> None:
+    with pytest.raises(ValueError, match="coordinates"):
+        HeatmapRequest(AnalyticType.TCM, float("nan"), -98.4936, date.today())
+
+
 def test_heatmap_request_rejects_unknown_analytic_type() -> None:
     with pytest.raises(ValueError, match="analytic type"):
         HeatmapRequest(

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -88,7 +88,17 @@ def test_normalizer_rejects_non_finite_metric_values() -> None:
         )
 
 
-@pytest.mark.parametrize(
+def test_normalizer_rejects_provider_mode_mismatch() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    with pytest.raises(ValueError, match="mode"):
+        normalize_heatmap_response(
+            {"mode": "historical", "features": [{"geometry": {"type": "Point", "coordinates": [-98.49, 29.42]}, "properties": {"value": 35, "unit": "C", "valid_time": "2026-08-23T15:00:00+00:00"}}]},
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("fixture_name", "analytic_type", "forecast", "value"),
     [
         ("heatmap-forecast.json", AnalyticType.TCM, True, 35.5),
@@ -312,9 +322,7 @@ def test_polling_retries_transient_status_transport_without_resubmission() -> No
     )
 
     assert result == {"ok": True}
-    assert transitions == (  # type: ignore[comparison-overlap]
-        ["rate_limited", "server_error", "Completed"]
-    )
+    assert transitions == ["rate_limited", "server_error", "Completed"]
 
 
 def test_client_emits_sanitized_structured_activity_events() -> None:
@@ -334,7 +342,7 @@ def test_client_emits_sanitized_structured_activity_events() -> None:
         Transport(),
         "secret",
         clock=lambda: datetime(2026, 8, 23, tzinfo=timezone.utc),
-        event_sink=events.append,
+        event_sink=lambda event: events.append(dict(event)),
     ).submit_and_poll(
         "/v1/heatmap",
         {"analytic_type": "tcm", "api_key": "must-not-appear"},

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.ledger import CreditLedger, UsageRecord
+
+
+def test_ledger_records_actual_provider_usage_and_rejects_overspend() -> None:
+    ledger = CreditLedger(budget=10)
+    ledger.record(UsageRecord("activity-1", "/v1/heatmap", 4, datetime.now(timezone.utc), "completed"))
+    assert ledger.remaining == 6
+    assert ledger.total_used == 4
+    with pytest.raises(ValueError, match="budget"):
+        ledger.record(UsageRecord("activity-2", "/v1/env_params", 7, datetime.now(timezone.utc), "completed"))
+
+
+def test_ledger_separates_planned_optional_usage_from_actual_usage() -> None:
+    ledger = CreditLedger(budget=10)
+    ledger.plan_optional("hotel-a", 3)
+    ledger.record(UsageRecord("activity-1", "/v1/satellite", 2, datetime.now(timezone.utc), "completed"))
+    assert ledger.planned_optional == {"hotel-a": 3}
+    assert ledger.total_used == 2
+    assert ledger.records[0].activity_id == "activity-1"

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -21,3 +21,12 @@ def test_ledger_separates_planned_optional_usage_from_actual_usage() -> None:
     assert ledger.planned_optional == {"hotel-a": 3}
     assert ledger.total_used == 2
     assert ledger.records[0].activity_id == "activity-1"
+
+
+def test_ledger_does_not_double_count_replayed_activity_completion() -> None:
+    ledger = CreditLedger(budget=5)
+    usage = UsageRecord("activity-1", "/v1/heatmap", 4, datetime.now(timezone.utc), "completed")
+    ledger.record(usage)
+    ledger.record(usage)
+    assert ledger.total_used == 4
+    assert len(ledger.records) == 1

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -8,7 +8,6 @@ from app.fortyguard import (
     EnvParamsRequest,
     HeatmapRequest,
     HttpFortyGuardTransport,
-    ProviderErrorKind,
     normalize_env_params_response,
 )
 
@@ -86,6 +85,15 @@ def test_http_transport_sends_auth_json_and_classifies_http_errors() -> None:
         raise HttpFortyGuardTransport.HttpError(ErrorResponse())
 
     failing = HttpFortyGuardTransport("https://api.example.test", opener=error_opener)
-    with pytest.raises(Exception) as error:
-        failing.get("/v1/status/a1", "secret")
-    assert error.value.kind is ProviderErrorKind.RATE_LIMIT
+    assert failing.get("/v1/status/a1", "secret") == {"status_code": 429}
+
+
+def test_status_transport_returns_transient_status_for_bounded_poller() -> None:
+    class ErrorResponse:
+        status = 404
+
+    def opener(request: object, timeout: float) -> object:
+        raise HttpFortyGuardTransport.HttpError(ErrorResponse())
+
+    transport = HttpFortyGuardTransport("https://api.example.test", opener=opener)
+    assert transport.get("/v1/status/a1", "secret") == {"status_code": 404}

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -81,6 +81,19 @@ def test_area_request_rejects_malformed_polygon_coordinates() -> None:
         )
 
 
+def test_area_request_rejects_unclosed_polygon_ring() -> None:
+    from app.fortyguard import AreaHeatmapRequest
+
+    with pytest.raises(ValueError, match="polygon geometry"):
+        AreaHeatmapRequest(
+            {"type": "Polygon", "coordinates": [[[1, 1], [2, 1], [2, 2], [1, 2]]]},
+            (AnalyticType.TCM,),
+            "district",
+            "C",
+            "explicit",
+        )
+
+
 def test_area_request_accepts_valid_multipolygon_coordinates() -> None:
     from app.fortyguard import AreaHeatmapRequest
 

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -1,5 +1,7 @@
 from datetime import date
 import json
+import socket
+from urllib.error import URLError
 
 import pytest
 
@@ -172,3 +174,12 @@ def test_status_transport_returns_transient_status_for_bounded_poller() -> None:
 
 def test_http_408_is_classified_as_timeout() -> None:
     assert classify_provider_error(408).kind is ProviderErrorKind.TIMEOUT
+
+
+def test_wrapped_socket_timeout_is_classified_as_timeout() -> None:
+    def opener(request: object, timeout: float) -> object:
+        raise URLError(socket.timeout("timed out"))
+
+    with pytest.raises(Exception) as error:
+        HttpFortyGuardTransport("https://api.example.test", opener=opener).get("/v1/status/a1", "secret")
+    assert error.value.kind is ProviderErrorKind.TIMEOUT

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -55,6 +55,19 @@ def test_env_params_fixture_preserves_anchor_warning_and_heat_index_metric() -> 
     assert "not a real 24-hour forecast" in result.warning
 
 
+def test_area_request_rejects_unknown_analytic_members() -> None:
+    with pytest.raises(ValueError, match="analytic types"):
+        from app.fortyguard import AreaHeatmapRequest
+
+        AreaHeatmapRequest(
+            {"type": "Polygon", "coordinates": [[[1, 1], [2, 1], [2, 2], [1, 1]]]},
+            ("unknown",),  # type: ignore[arg-type]
+            "district",
+            "C",
+            "explicit",
+        )
+
+
 def test_http_transport_sends_auth_json_and_classifies_http_errors() -> None:
     calls: list[tuple[str, dict[str, object], dict[str, str]]] = []
 

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -8,6 +8,8 @@ from app.fortyguard import (
     EnvParamsRequest,
     HeatmapRequest,
     HttpFortyGuardTransport,
+    ProviderErrorKind,
+    classify_provider_error,
     normalize_env_params_response,
 )
 
@@ -166,3 +168,7 @@ def test_status_transport_returns_transient_status_for_bounded_poller() -> None:
 
     transport = HttpFortyGuardTransport("https://api.example.test", opener=opener)
     assert transport.get("/v1/status/a1", "secret") == {"status_code": 404}
+
+
+def test_http_408_is_classified_as_timeout() -> None:
+    assert classify_provider_error(408).kind is ProviderErrorKind.TIMEOUT

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -39,6 +39,8 @@ def test_env_params_requires_temperature_anchor_and_marks_anchor_series() -> Non
     assert request.is_real_forecast is False
     with pytest.raises(ValueError, match="temperature anchor"):
         EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), temperature_anchor_celsius=None)
+    with pytest.raises(ValueError, match="real forecast"):
+        EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), 35, is_real_forecast=True)
 
 
 def test_env_params_fixture_preserves_anchor_warning_and_heat_index_metric() -> None:

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -41,6 +41,8 @@ def test_env_params_requires_temperature_anchor_and_marks_anchor_series() -> Non
         EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), temperature_anchor_celsius=None)
     with pytest.raises(ValueError, match="real forecast"):
         EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), 35, is_real_forecast=True)
+    with pytest.raises(ValueError, match="temperature anchor"):
+        EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), float("nan"))
 
 
 def test_env_params_fixture_preserves_anchor_warning_and_heat_index_metric() -> None:

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -94,6 +94,19 @@ def test_area_request_rejects_unclosed_polygon_ring() -> None:
         )
 
 
+def test_area_request_rejects_self_intersecting_polygon() -> None:
+    from app.fortyguard import AreaHeatmapRequest
+
+    with pytest.raises(ValueError, match="polygon geometry"):
+        AreaHeatmapRequest(
+            {"type": "Polygon", "coordinates": [[[1, 1], [2, 2], [2, 1], [1, 2], [1, 1]]]},
+            (AnalyticType.TCM,),
+            "district",
+            "C",
+            "explicit",
+        )
+
+
 def test_area_request_accepts_valid_multipolygon_coordinates() -> None:
     from app.fortyguard import AreaHeatmapRequest
 

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -68,6 +68,32 @@ def test_area_request_rejects_unknown_analytic_members() -> None:
         )
 
 
+def test_area_request_rejects_malformed_polygon_coordinates() -> None:
+    from app.fortyguard import AreaHeatmapRequest
+
+    with pytest.raises(ValueError, match="polygon geometry"):
+        AreaHeatmapRequest(
+            {"type": "Polygon", "coordinates": [[[1, 1], [2, 1]]]},
+            (AnalyticType.TCM,),
+            "district",
+            "C",
+            "explicit",
+        )
+
+
+def test_area_request_accepts_valid_multipolygon_coordinates() -> None:
+    from app.fortyguard import AreaHeatmapRequest
+
+    request = AreaHeatmapRequest(
+        {"type": "MultiPolygon", "coordinates": [[[[1, 1], [2, 1], [2, 2], [1, 1]]]]},
+        (AnalyticType.TCM,),
+        "district",
+        "C",
+        "explicit",
+    )
+    assert request.to_payload()["context"] == "district"
+
+
 def test_http_transport_sends_auth_json_and_classifies_http_errors() -> None:
     calls: list[tuple[str, dict[str, object], dict[str, str]]] = []
 

--- a/tests/test_provider_http.py
+++ b/tests/test_provider_http.py
@@ -1,0 +1,91 @@
+from datetime import date
+import json
+
+import pytest
+
+from app.fortyguard import (
+    AnalyticType,
+    EnvParamsRequest,
+    HeatmapRequest,
+    HttpFortyGuardTransport,
+    ProviderErrorKind,
+    normalize_env_params_response,
+)
+
+
+def test_heatmap_payload_preserves_forecast_history_and_threshold_contract() -> None:
+    payload = HeatmapRequest(
+        AnalyticType.EXCEEDANCE,
+        29.4241,
+        -98.4936,
+        date(2026, 8, 20),
+        forecast=False,
+        threshold_celsius=35,
+        direction="above",
+    ).to_payload()
+    assert payload == {
+        "analytic_type": "exceedance",
+        "latitude": 29.4241,
+        "longitude": -98.4936,
+        "start_date": "2026-08-20",
+        "forecast": False,
+        "threshold_celsius": 35,
+        "direction": "above",
+    }
+
+
+def test_env_params_requires_temperature_anchor_and_marks_anchor_series() -> None:
+    request = EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), temperature_anchor_celsius=35)
+    assert request.to_payload()["temperature_anchor_celsius"] == 35
+    assert request.is_real_forecast is False
+    with pytest.raises(ValueError, match="temperature anchor"):
+        EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), temperature_anchor_celsius=None)
+
+
+def test_env_params_fixture_preserves_anchor_warning_and_heat_index_metric() -> None:
+    result = normalize_env_params_response(
+        json.loads(open("fixtures/env-params.json", encoding="utf-8").read()),
+        request=EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 23), 35),
+    )
+    assert result.heat_index_celsius == 38.1
+    assert result.forecast is False
+    assert "not a real 24-hour forecast" in result.warning
+
+
+def test_http_transport_sends_auth_json_and_classifies_http_errors() -> None:
+    calls: list[tuple[str, dict[str, object], dict[str, str]]] = []
+
+    class Response:
+        def read(self) -> bytes:
+            return json.dumps({"activity_id": "a1"}).encode()
+
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    def opener(request: object, timeout: float) -> Response:
+        calls.append((request.full_url, json.loads(request.data), dict(request.headers)))  # type: ignore[attr-defined]
+        return Response()
+
+    transport = HttpFortyGuardTransport("https://api.example.test", opener=opener)
+    assert transport.post("/v1/heatmap", {"analytic_type": "tcm"}, "secret") == {"activity_id": "a1"}
+    assert calls[0][0] == "https://api.example.test/v1/heatmap"
+    assert calls[0][1] == {"analytic_type": "tcm"}
+    assert calls[0][2]["X-api-key"] == "secret"
+
+    class ErrorResponse:
+        status = 429
+        reason = "too many requests"
+
+        def read(self) -> bytes:
+            return b"ignored"
+
+    def error_opener(request: object, timeout: float) -> ErrorResponse:
+        raise HttpFortyGuardTransport.HttpError(ErrorResponse())
+
+    failing = HttpFortyGuardTransport("https://api.example.test", opener=error_opener)
+    with pytest.raises(Exception) as error:
+        failing.get("/v1/status/a1", "secret")
+    assert error.value.kind is ProviderErrorKind.RATE_LIMIT

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -1,0 +1,43 @@
+import pytest
+from shapely.geometry import Point, Polygon
+
+from app.analysis import TileGeometry, build_aoi, join_point_to_tiles, join_polygon_to_tiles
+
+
+def test_polygon_join_area_weights_partial_overlap_in_projected_crs() -> None:
+    target = Polygon([(-98.50, 29.42), (-98.48, 29.42), (-98.48, 29.44), (-98.50, 29.44)])
+    tiles = [
+        TileGeometry("west", Polygon([(-98.50, 29.42), (-98.49, 29.42), (-98.49, 29.44), (-98.50, 29.44)]), 30),
+        TileGeometry("east-half", Polygon([(-98.49, 29.42), (-98.485, 29.42), (-98.485, 29.44), (-98.49, 29.44)]), 40),
+    ]
+    result = join_polygon_to_tiles(target, tiles)
+    assert result.value == pytest.approx(100 / 3, rel=0.01)
+    assert result.coverage == pytest.approx(0.75, rel=0.01)
+    assert result.quality == "partial"
+    assert result.projected_crs.startswith("EPSG:326")
+
+
+def test_polygon_join_rejects_invalid_geometry_and_reports_no_overlap() -> None:
+    invalid = Polygon([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)])
+    with pytest.raises(ValueError, match="invalid"):
+        join_polygon_to_tiles(invalid, [])
+    target = Polygon([(-98.5, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.5, 29.43)])
+    distant = TileGeometry("far", Polygon([(-97, 30), (-96.9, 30), (-96.9, 30.1), (-97, 30.1)]), 30)
+    assert join_polygon_to_tiles(target, [distant]).quality == "no_overlap"
+
+
+def test_point_join_distinguishes_containing_boundary_and_nearest_fallback() -> None:
+    tile = TileGeometry("tile", Polygon([(-98.50, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.50, 29.43)]), 35)
+    assert join_point_to_tiles(Point(-98.495, 29.425), [tile]).quality == "containing_tile"
+    assert join_point_to_tiles(Point(-98.50, 29.425), [tile]).quality == "boundary"
+    fallback = join_point_to_tiles(Point(-98.4899, 29.425), [tile], nearest_max_distance_m=20)
+    assert fallback.quality == "nearest_fallback"
+    assert fallback.distance_m is not None and fallback.distance_m > 0
+    assert join_point_to_tiles(Point(-98.40, 29.425), [tile], nearest_max_distance_m=20).quality == "outside_aoi"
+
+
+def test_build_aoi_handles_district_points_and_route_corridors() -> None:
+    district = build_aoi([Point(-98.50, 29.42), Point(-98.49, 29.43)], buffer_m=100)
+    corridor = build_aoi([Point(-98.50, 29.42), Point(-98.49, 29.43)], buffer_m=25, corridor=True)
+    assert district.is_valid and corridor.is_valid
+    assert district.area > corridor.area

--- a/tests/test_trip_domain.py
+++ b/tests/test_trip_domain.py
@@ -1,0 +1,68 @@
+from app.trip import (
+    HotelCandidate,
+    HotelRanker,
+    RouteCandidate,
+    RouteComparator,
+)
+from app.fortyguard import AnalyticType, AreaHeatmapRequest
+
+
+def test_hotel_ranker_exposes_components_percentiles_and_ties() -> None:
+    ranked = HotelRanker().rank(
+        [
+            HotelCandidate("a", {"night": 30, "hot_hours": 5, "persistence": 2, "day": 32}),
+            HotelCandidate("b", {"night": 30, "hot_hours": 5, "persistence": 2, "day": 32}),
+            HotelCandidate("c", {"night": 35, "hot_hours": 9, "persistence": 5, "day": 38}),
+        ]
+    )
+    assert [hotel.identity for hotel in ranked] == ["a", "b", "c"]
+    assert ranked[0].tie_group == ranked[1].tie_group
+    assert ranked[0].percentile == ranked[1].percentile
+    assert ranked[0].components["night"] == 30
+
+
+def test_route_comparator_fetches_routes_once_and_uses_shortest_when_heat_is_low() -> None:
+    calls = 0
+
+    def routes() -> list[RouteCandidate]:
+        nonlocal calls
+        calls += 1
+        return [RouteCandidate("short", 1000, 600), RouteCandidate("long", 1300, 700)]
+
+    result = RouteComparator(representative_threshold_m=1500).compare(
+        routes, heat_value=30, heat_threshold=35, shade=lambda route: 90
+    )
+    assert calls == 1
+    assert result.recommended_id == "short"
+    assert result.shade_was_computed is False
+
+
+def test_route_comparator_uses_maximum_heat_and_weak_coverage_shortest_fallback() -> None:
+    result = RouteComparator().compare(
+        lambda: [RouteCandidate("short", 1000, 600), RouteCandidate("shady", 1200, 700)],
+        heat_values=[34, 38],
+        heat_threshold=35,
+        shade=lambda route: 80 if route.identity == "shady" else 20,
+        building_coverage=0.5,
+    )
+    assert result.corridor_heat_value == 38
+    assert result.recommended_id == "short"
+    assert result.reason == "insufficient shade coverage"
+    assert result.shade_was_computed is True
+
+
+def test_area_request_supports_district_and_corridor_properties_without_sample_geometry() -> None:
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[-98.50, 29.42], [-98.49, 29.42], [-98.49, 29.43], [-98.50, 29.42]]],
+    }
+    request = AreaHeatmapRequest(
+        geometry=geometry,
+        analytic_types=(AnalyticType.TCM, AnalyticType.EXCEEDANCE),
+        context="district",
+        unit="C",
+        unit_source="explicit",
+    )
+    assert request.to_payload()["geometry"] == geometry
+    assert request.to_payload()["analytic_types"] == ["tcm", "exceedance"]
+    assert request.to_payload()["unit_source"] == "explicit"

--- a/tests/test_trip_domain.py
+++ b/tests/test_trip_domain.py
@@ -40,6 +40,7 @@ def test_route_comparator_fetches_routes_once_and_uses_shortest_when_heat_is_low
 def test_route_comparator_uses_maximum_heat_and_weak_coverage_shortest_fallback() -> None:
     result = RouteComparator().compare(
         lambda: [RouteCandidate("short", 1000, 600), RouteCandidate("shady", 1200, 700)],
+        heat_value=38,
         heat_values=[34, 38],
         heat_threshold=35,
         shade=lambda route: 80 if route.identity == "shady" else 20,
@@ -49,6 +50,28 @@ def test_route_comparator_uses_maximum_heat_and_weak_coverage_shortest_fallback(
     assert result.recommended_id == "short"
     assert result.reason == "insufficient shade coverage"
     assert result.shade_was_computed is True
+
+
+def test_route_comparator_uses_landmark_heat_for_short_and_corridor_max_for_long() -> None:
+    comparator = RouteComparator(representative_threshold_m=1500)
+    short = comparator.compare(
+        lambda: [RouteCandidate("short", 1000, 600)],
+        heat_value=30,
+        heat_values=[40],
+        heat_threshold=35,
+        shade=lambda route: 50,
+    )
+    long = comparator.compare(
+        lambda: [RouteCandidate("long", 1600, 900)],
+        heat_value=30,
+        heat_values=[34, 40],
+        heat_threshold=35,
+        shade=lambda route: 50,
+    )
+    assert short.corridor_heat_value == 30
+    assert short.shade_was_computed is False
+    assert long.corridor_heat_value == 40
+    assert long.shade_was_computed is True
 
 
 def test_area_request_supports_district_and_corridor_properties_without_sample_geometry() -> None:

--- a/tests/test_trip_domain.py
+++ b/tests/test_trip_domain.py
@@ -4,6 +4,7 @@ from app.trip import (
     RouteCandidate,
     RouteComparator,
 )
+import pytest
 from app.fortyguard import AnalyticType, AreaHeatmapRequest
 
 
@@ -19,6 +20,17 @@ def test_hotel_ranker_exposes_components_percentiles_and_ties() -> None:
     assert ranked[0].tie_group == ranked[1].tie_group
     assert ranked[0].percentile == ranked[1].percentile
     assert ranked[0].components["night"] == 30
+
+
+def test_hotel_ranker_rejects_invalid_weights_and_components() -> None:
+    candidate = HotelCandidate("a", {"night": 30, "hot_hours": 5, "persistence": 2, "day": float("nan")})
+    with pytest.raises(ValueError, match="components"):
+        HotelRanker().rank([candidate])
+    with pytest.raises(ValueError, match="weights"):
+        HotelRanker().rank(
+            [HotelCandidate("a", {"night": 30, "hot_hours": 5, "persistence": 2, "day": 32})],
+            {"night": -0.35, "hot_hours": 0.25, "persistence": 0.2, "day": 0.9},
+        )
 
 
 def test_route_comparator_fetches_routes_once_and_uses_shortest_when_heat_is_low() -> None:


### PR DESCRIPTION
## Summary

- add the authenticated FortyGuard transport, validated request contracts, bounded async polling, normalized heatmap data, exact-match cache fallback, and explicit provenance
- add projected spatial analysis, historical exposure context, readiness reasons, hotel ranking, route comparison, enrichment planning, and idempotent credit accounting
- expose fixture-backed and server-controlled live execution through FastAPI, with committed provider fixtures, offline integration tests, CI quality gates, and extraction documentation

## Verification

- `python -m pytest -q` (77 passed)
- `python -m ruff check app tests`
- `npm run python:typecheck`
- `npx prettier --check app tests fixtures docs/design/fortyguard-extraction.md .lintstagedrc`
- `git diff main...HEAD --check`
- final two-axis code review found no actionable Issue #6 findings

Live provider calls remain excluded from pull-request CI because they are metered. The final npm audit retry was blocked by intermittent npm registry DNS resolution; an earlier successful audit reported 0 vulnerabilities.

Closes #6