### PR TITLE
feat(shade): Validate LiDAR building heights for Issue #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+data/lidar-prototype/

--- a/README.md
+++ b/README.md
@@ -40,3 +40,52 @@ npm audit --audit-level=high
 
 Live FortyGuard and Overpass calls are never required by CI. Frontend checks will
 be added with the React/Vite scaffold.
+
+## Live Credit Usage
+
+The salvaged quickstart account-usage endpoint is available as a credential-safe
+terminal command. Load `FORTYGUARD_API_KEY` into the process environment without
+printing it, then run:
+
+```bash
+python scripts/fortyguard_usage.py
+python scripts/fortyguard_usage.py --start 2026-08-01 --end 2026-08-24
+```
+
+The command reports the selected window, total credits, and provider activity
+breakdown. It never prints the API key. The source is the quickstart's
+`POST /v1/system/fetch-api-key-custom-usage` utility; the original
+`notebooks/00_setup.ipynb` remains the reference walkthrough.
+
+## Lidar Corridor Prototype
+
+The official USGS National Map coverage probe records classified lidar
+products intersecting the bounded Austin and San Antonio route corridors:
+
+```bash
+python scripts/lidar_corridor_probe.py
+```
+
+This writes local, gitignored metadata to `data/lidar-prototype/coverage.json`.
+It does not download point-cloud binaries. Review the tile metadata and source
+dates before adding an opt-in download/derivation workflow.
+
+The local research environment can inspect a downloaded LAZ tile with
+`laspy[lazrs]` (the package is not an application dependency):
+
+```bash
+python scripts/derive_lidar_corridor_stats.py \
+  data/lidar-prototype/laz/USGS_LPC_TX_Central_B2_2017_stratmap17_50cm_2998373a1_LAS_2019.laz
+```
+
+For the canonical San Antonio corridor, the bounded OpenStreetMap XML extract
+and classified LAZ tile can be compared at building-footprint level with:
+
+```bash
+python scripts/validate_building_lidar_heights.py \
+  /path/to/san-antonio.osm \
+  data/lidar-prototype/laz/USGS_LPC_TX_Central_B2_2017_stratmap17_50cm_2998373a1_LAS_2019.laz
+```
+
+Pass the saved OSRM response with `--route-json` to use the full walking route
+instead of the endpoint chord.

--- a/app/fortyguard_usage.py
+++ b/app/fortyguard_usage.py
@@ -1,0 +1,64 @@
+"""Credential-safe FortyGuard account usage queries."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_BASE_URL = "https://api.fortyguard.com"
+
+
+def fetch_custom_usage(
+    api_key: str,
+    start_date: date,
+    end_date: date,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    timeout_seconds: float = 30,
+) -> dict[str, Any]:
+    """Fetch the provider's credit breakdown without exposing the API key."""
+    if not api_key:
+        raise ValueError("an API key is required")
+    if end_date < start_date:
+        raise ValueError("end date must not precede start date")
+
+    payload = {
+        "api_key": api_key,
+        "start_date": f"{start_date.isoformat()}T00:00:00Z",
+        "end_date": f"{end_date.isoformat()}T23:59:59Z",
+    }
+    request = Request(
+        f"{base_url.rstrip('/')}/v1/system/fetch-api-key-custom-usage",
+        data=json.dumps(payload).encode(),
+        headers={"api-key": api_key, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            result = json.loads(response.read())
+    except HTTPError as error:
+        raise RuntimeError(f"FortyGuard usage request failed with HTTP {error.code}") from None
+    except (URLError, TimeoutError, OSError) as error:
+        raise RuntimeError(f"FortyGuard usage request failed: {type(error).__name__}") from None
+    if not isinstance(result, dict):
+        raise ValueError("FortyGuard usage response must be an object")
+    return result
+
+
+def default_usage_window(today: date | None = None) -> tuple[date, date]:
+    """Return the quickstart's rolling 30-day usage window."""
+    end_date = today or date.today()
+    return end_date - timedelta(days=30), end_date
+
+
+def load_api_key_from_environment() -> str:
+    """Load the key from the process environment without reading or printing it."""
+    api_key = os.environ.get("FORTYGUARD_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("FORTYGUARD_API_KEY is not set")
+    return api_key

--- a/docs/design/fortyguard-extraction.md
+++ b/docs/design/fortyguard-extraction.md
@@ -65,6 +65,20 @@ endpoint, completion time, and status. Planned optional enrichment is recorded
 separately and does not count as actual spend. Budget enforcement occurs before
 an actual usage record is accepted.
 
+The quickstart account-usage utility is also salvaged as
+`app.fortyguard_usage.fetch_custom_usage` and `scripts/fortyguard_usage.py`.
+It calls `POST /v1/system/fetch-api-key-custom-usage` for a date window and is
+intended for manual balance checks. The API key is supplied in-process and never
+printed. This account-level report complements, but does not replace, the
+per-activity ledger because provider activity responses may omit credit fields.
+
+The quickstart's asynchronous heatmap, environmental-parameter, cache, polling,
+and normalization patterns are represented by the existing application modules
+and fixtures. Its satellite segmentation, street-view segmentation,
+heat-intelligence PDF, notebook plotting, and parcel/real-estate workflows
+remain out of scope for this tourism guide; they are not copied merely because
+the account usage report lists their historical spend.
+
 `POST /api/trip/analyze` is the product-level decision boundary. Hotel ranking
 uses the documented provisional component weights, retains components, and
 reports ties and candidate-set percentiles rather than an absolute grade. Route

--- a/docs/research/issue-7-san-antonio-provider-validation.md
+++ b/docs/research/issue-7-san-antonio-provider-validation.md
@@ -1,0 +1,614 @@
+# Issue #7: San Antonio Scenario And Provider Validation
+
+**Original research date:** 2026-08-23
+**Continuation live-call date:** 2026-08-24
+**Acceptance-language audit date:** 2026-08-24
+
+**Issue:** [Validate San Antonio scenario and provider contracts](https://github.com/alshawai/heat-aware-tourism-guide/issues/7)
+
+This single artifact preserves the 2026-08-23 OSM and OSRM observations and
+adds the authorized, manually metered FortyGuard and route-corridor calls made
+on 2026-08-24.
+
+## Executive Decision
+
+San Antonio is **final primary** and Austin is **final fallback**. San Antonio
+has the stronger canonical scenario evidence: at least five conservative hotel
+candidates, a profile-specific FOSSGIS foot response with two full-geometry
+alternatives, and a new populated FortyGuard heatmap. The environmental
+submission also completed and returned timestamped provider parameters. The
+heatmap lacks an explicit unit/valid-time field, and the environmental result
+is a caller-supplied-temperature analysis rather than a real provider forecast,
+so the provider-to-app contract is not fully reconciled. A two-submission
+historical heatmap experiment also completed with byte-identical canonical
+results, so repeatability is now observed. These are app/provider follow-ups,
+not reasons to make the city choice conditional.
+
+Use the committed fixture path until the provider/app follow-up is implemented.
+The original OSM-only height coverage was insufficient, but the subsequent USGS
+classified-lidar corridor validation supplies modeled heights for every
+intersecting OSM building footprint in the bounded sample. The current result
+is sufficient modeled-height coverage for the criterion, with explicit source
+date and validation caveats; it is not a claim that every projected shadow is
+observed or production-validated.
+
+## Acceptance-Criteria Ledger
+
+| Criterion                                | Result                            | Evidence and consequence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Populated FortyGuard heatmap          | **Pass**                          | The new bounded San Antonio request completed HTTP 200 after `Processing` x4 and returned a 4,957-byte GeoJSON `FeatureCollection` with 2 Polygon features and temperatures from 36.71 to 36.7102. This satisfies the issue wording. The missing explicit unit/valid-time/data-date metadata is recorded under criterion 6 and app follow-up, not used to downgrade populated-data status.                                                                                                                                                                                                                                                                                                                                                     |
+| 2. Environmental timestamps and offsets  | **Pass**                          | The documented environmental request completed HTTP 200. Metadata returned raw `2026-08-24T13:00:00-07:00`, `timezone=GMT-7`, offset `-7`, normalized UTC `2026-08-24T20:00:00Z`, interval `1h`, and count 1. Caller-supplied `temperature=35.0` means this is an analysis rather than a provider forecast, but the timestamp/offset requirement is understood and recorded.                                                                                                                                                                                                                                                                                                                                                                   |
+| 3. At least five usable hotels           | **Pass**                          | A bounded rerun returned distinct OSM identities: Menger Hotel (relation `1204761`), Hilton Palacio del Rio (way `79156153`), The Emily Morgan Hotel (way `79156552`), Marriott Rivercenter (way `99940093`), Marriott Riverwalk (way `99940107`), The Crockett (way `100056533`), and Hotel Gibbs Downtown San Antonio Riverwalk (way `100361218`). Type+ID identity prevents accidental merging; names are candidate lodging identities, not availability claims.                                                                                                                                                                                                                                                                            |
+| 4. Building-height corridor coverage     | **Pass, modeled source coverage** | The OSM-only sample had 1/6 explicit height-tagged ways (16.7%), but the follow-up USGS classified-lidar validation found 5 closed OSM building ways intersecting the canonical 20 m corridor and positive roof-minus-ground estimates for all 5 (`5/5 = 100%`). This exceeds the documented `>=70%` trusted coverage threshold for modeled height availability. It remains subject to 2017 source-date, footprint completeness, classification, and shadow-validation caveats; the old shortest-route fallback remains required when those confidence checks fail.                                                                                                                                                                            |
+| 5. Pedestrian alternatives/full geometry | **Pass**                          | The 2026-08-23 FOSSGIS profile-specific foot request returned HTTP 200, `code=Ok`, two routes, GeoJSON LineStrings with full overview coordinates, 608.6 m/487.2 s and 625.9 m/500.8 s. The generic Project OSRM foot result remains excluded because it was byte-identical to the car response.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| 6. Operational contract                  | **Pass**                          | All named items are recorded with observed values or a defensible first-party absence: environmental metric names expose Celsius/percent/mm/octas/ppb/ppm semantics; heatmap units/valid-time fields were absent; published Basic/Pro offerings are 1M/5M monthly credits and 10/50 mi² heatmap caps; this account's tier/cost is not exposed; rate headers, latency, HTTP 401/422/200, prior timeout, completed/processing states, prior empty result, and documented environmental `null`/legacy `-999` semantics are recorded. Two identical documented historical submissions completed with byte-identical canonical results, establishing repeatability for this bounded request. No authenticated account/usage endpoint is documented. |
+| 7. Final primary/fallback                | **Pass**                          | San Antonio is final primary and Austin final fallback based on the canonical hotels, populated heatmap, environmental timestamp evidence, pedestrian routing, and San Antonio scenario fit. Criterion 4's explicit insufficient-coverage result is handled by the recorded fallback policy; it does not make the city selection conditional.                                                                                                                                                                                                                                                                                                                                                                                                  |
+
+## Canonical Scenario
+
+The scenario is Menger Hotel to The Alamo in Downtown San Antonio / Alamo Plaza
+([design source](../design/design-doc.md)). The 2026-08-23 OSRM request used
+origin `-98.4861,29.4259` and destination `-98.4853,29.4225`; OSRM snapped
+them to `[-98.48598,29.426406]` (57.3 m) and `[-98.48533,29.422409]` (10.5 m).
+Those are response observations, not official landmark geocodes.
+
+## FortyGuard Evidence
+
+### Current documented contract and source mismatch
+
+Current first-party docs identify `POST /v1/heatmap`, `POST /v1/env_params`, and
+`GET /v1/status/{activity_id}` as asynchronous endpoints, with GeoJSON polygon
+AOI, `date_time`, `granularity`, and `analytic_type` fields for heatmap examples
+([create heatmap](https://docs-api.fortyguard.com/docs/create-heatmap),
+[environmental parameters](https://docs-api.fortyguard.com/docs/environmental-parameters),
+[check status](https://docs-api.fortyguard.com/docs/check-status)). The current
+first-party examples say authentication is the `api-key` header
+([API introduction](https://docs-api.fortyguard.com/docs/introduction)).
+
+The extracted application transport instead sends `X-API-Key` and its
+`HeatmapRequest` emits a point/date/forecast payload
+([`fortyguard-extraction.md`](../design/fortyguard-extraction.md),
+[`app/fortyguard.py`](../../app/fortyguard.py)). The first continuation attempt
+using the app transport received HTTP 401 and created no activity. The
+successful manual call used the current documented `api-key` header and
+documented polygon request shape. This discrepancy is recorded; application
+code was not silently modified.
+
+The documented request examples use `date_time.filter_type`,
+`start_date`, and `start_time`; the live calls used `filter_type=1` and a
+single current-hour window. The docs shell and current generated bundle expose
+historical replay or idempotency procedure, but the generated heatmap schema
+does document historical dates: `start_date` from `2019-01-01` through the
+present is historical/real-time, while up to 12 hours ahead is forecast;
+`filter_type=1` is a single hour and `granularity` accepts 60, 80, or 100.
+The generated examples also document `filter_type=3` as a single day and
+`filter_type=4` as a date range, with `end_date` required for type 4. The
+historical experiment below therefore used the documented single-hour type 1,
+the smallest allowed historical polygon, and the coarsest allowed granularity 100. No unsupported filter value was inferred. The prior environmental timeout
+has no activity ID and was not resubmitted.
+
+The pricing page lists Basic at 1,000,000 monthly credits and up to 10 mi2
+heatmaps, and Pro at 5,000,000 monthly credits and up to 50 mi2; it says usage
+depends on request complexity ([API pricing](https://fortyguard.com/api-pricing)).
+Those published values do not identify this account's plan, cost, or payload
+ceiling. The application normalizer additionally requires nonempty features,
+valid geometry, Celsius `unit == "C"`, and parseable `valid_time`
+([`app/fortyguard.py`](../../app/fortyguard.py)).
+
+The current first-party pricing page also lists Basic at $79/month and Pro at
+$289/month, Basic environmental parameters as up to 3 user-selected values and
+Pro as full access, and describes API credits as usage currency based on request
+complexity ([API pricing](https://fortyguard.com/api-pricing)). These are
+published offerings, not evidence of this credential's account tier. The
+current docs shell exposes no historical replay/idempotency method, null or
+`-999` semantics, per-operation credit table, account/usage endpoint, or
+published HTTP rate/payload header contract. No undocumented account endpoint
+was guessed or called.
+
+The generated docs bundle's quickstart-derived heatmap schema identifies the
+endpoint as available to both Basic and Premium, with heatmap area caps of
+10 mi² and 50 mi² respectively, and describes output as predicted or observed
+temperature GeoJSON polygons plus `stats_data`. It does not expose a per-job
+credit price, an account tier lookup, an idempotency key, or a historical
+repeatability guarantee ([create heatmap](https://docs-api.fortyguard.com/docs/create-heatmap),
+[quickstart](https://docs-api.fortyguard.com/docs/quickstart),
+[check status](https://docs-api.fortyguard.com/docs/check-status)).
+
+### Live heatmap calls, 2026-08-24
+
+Retrieval began at `2026-08-24T00:43:11Z` (provider HTTP `Date`); the summary
+was recorded at `2026-08-24T00:44:43Z`. Host was `api.fortyguard.com`; endpoint
+was `POST /v1/heatmap`, followed by `GET /v1/status/{activity_id}`. The exact
+sanitized request semantics were:
+
+```json
+{
+  "analytic_type": "tcm",
+  "date_time": {
+    "filter_type": 1,
+    "start_date": "2026-08-24",
+    "start_time": "12:00"
+  },
+  "granularity": 100,
+  "polygon_aoi": "closed GeoJSON FeatureCollection containing one small San Antonio Polygon around -98.4861,29.4259"
+}
+```
+
+The submit response was HTTP 200, 138 bytes, 3.180 s, and returned activity ID
+`42416c31-6bd3-4b64-b0dc-eac7a8ba7ccc`. Status polling was HTTP 200 on all six
+checks: `Processing` x5 then `Completed`; polling response latency was 2.297,
+1.353, 5.966, 1.184, 1.237, and 1.384 s, with 140 bytes for the first five
+and 283 bytes for completion. Completion exposed `map_data` and `stats_data`;
+`map_data` was a GeoJSON `FeatureCollection` with zero features and
+`stats_data.n_cells` was zero. Therefore response mode is a completed
+single-hour `tcm` request, but populated data, geometry count, observed units,
+valid-time range, data date, and credits are unavailable. No credit field was
+returned. The activity/request ID is safe to record; the API key is not.
+
+Rate headers were observed: submit `x-ratelimit-limit=100`, remaining `99`;
+status limit `200`, remaining `199` down to `194`; reset was the same provider
+epoch on these responses. This is live header evidence, not a guaranteed
+account-wide limit. The first app-transport attempt was HTTP 401 and was not
+retried with that transport.
+
+The continuation first checked the recorded activity with one safe status GET:
+activity `42416c31-6bd3-4b64-b0dc-eac7a8ba7ccc` remained `Completed` with the
+same empty result. No activity identifier was recorded for the prior timed-out
+environmental POST, so no equivalent lookup was possible without guessing an
+identifier.
+
+The one new billable heatmap semantics used a distinct current-hour window:
+
+```json
+{
+  "analytic_type": "tcm",
+  "date_time": {
+    "filter_type": 1,
+    "start_date": "2026-08-24",
+    "start_time": "13:00"
+  },
+  "granularity": 100,
+  "polygon_aoi": "closed FeatureCollection with one Polygon: lon -98.4870 to -98.4852, lat 29.4235 to 29.4250"
+}
+```
+
+Two locally malformed validation submissions produced HTTP 422 with no
+activity; the second response said `polygon_aoi` must be a dictionary. The
+corrected submission began at `2026-08-24T11:23:58Z` by local clock, returned
+HTTP 200 in 3 s, 138 bytes, and activity
+`f7413530-41e1-47df-b701-892545006d89`. Polls returned HTTP 200 with
+`Processing` x4 and `Completed` on poll 5. Poll timestamps were
+`11:25:58`, `11:26:24`, `11:26:46`, `11:27:08`, and `11:27:32Z`; elapsed
+poll time was 98 s. Response sizes were 140 bytes while processing and 4,957
+bytes at completion. The result contained 2 Polygon features and temperature
+properties from 36.71 to 36.7102; `temperature_stats` reported minimum 36.71,
+maximum 36.7102, and mean 36.7101. No explicit unit, valid-time/data-date,
+provider metadata, `n_cells`, or credit field was returned. A safe terminal
+lookup at 11:33:46Z returned HTTP 200 in 3.654 s with the same shape.
+
+The request JSON above is sanitized input, not the returned data. The relevant
+sanitized response shape was:
+
+```json
+{
+  "map_data": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "geometry": { "type": "Polygon" },
+        "properties": { "temperature": 36.71 }
+      },
+      {
+        "type": "Feature",
+        "geometry": { "type": "Polygon" },
+        "properties": { "temperature": 36.7102 }
+      }
+    ]
+  },
+  "temperature_stats": { "min": 36.71, "max": 36.7102, "mean": 36.7101 }
+}
+```
+
+Coordinates and volatile identifiers are omitted, but the two temperatures and
+statistics are the observed values. The live response did not include a Celsius
+unit label or a valid-time/data-date field, so those fields must not be inferred
+from the request date.
+
+Submit rate headers were `limit=100`, `remaining=97`; status polling exposed
+`limit=200`, remaining 199, 198, 199, 198, 199; the terminal lookup exposed
+remaining 199. Reset epochs changed with the provider window. These are live
+observations, not an account-wide contract. The populated result is evidence
+that this endpoint was recovered on 2026-08-24, but not evidence of Celsius
+units or a complete app-normalizable record.
+
+### Historical repeatability experiment, 2026-08-24
+
+The two authorized submissions used exactly the same sanitized payload:
+
+```json
+{
+  "analytic_type": "tcm",
+  "date_time": {
+    "filter_type": 1,
+    "start_date": "2024-07-15",
+    "start_time": "14:00"
+  },
+  "granularity": 100,
+  "polygon_aoi": "the same small closed San Antonio Polygon used by the prior populated request"
+}
+```
+
+This is a documented historical single-hour request: the generated official
+schema says dates from `2019-01-01` through the present are historical/
+real-time, `filter_type=1` is a single hour, and 100 is an allowed granularity.
+The two submissions were intentionally identical and used the coarsest
+documented granularity; no request was retried after a timeout.
+
+Submission 1 returned HTTP 200 in 3 s, 138 bytes, with activity
+`ce96ae0e-60b5-4614-90fe-b1833fa791e5`; submission 2 returned HTTP 200 in 2 s,
+138 bytes, with activity `f67a5906-32b5-42e8-aab1-462d140acc25`. Submit rate
+headers were `limit=100`, remaining 99 then 98. Activity 1 returned
+`Processing` x16 then `Completed` on poll 17, with approximately 201 s from
+first poll to completion and a 4,945-byte terminal response. Activity 2 returned
+`Processing` x2 then `Completed` on poll 3, with approximately 31 s from first
+poll to completion and the same 4,945-byte terminal response. Status responses
+were HTTP 200 throughout; status rate limits were 200 with observed remaining
+values 199 through 194, then 199 through 196/195 over the two jobs. No credit
+field appeared.
+
+After removing activity/request IDs and transport metadata, canonical result
+SHA-256 was identical for both submissions:
+`885730cca0c74cad3a6fc23bc2f09e1cc038d2815caf4913f125e44f892946a7`. Each
+result was a GeoJSON `FeatureCollection` with 2 Polygon features. Average,
+minimum, and maximum temperature values ranged from 36.11 to 36.1105; the
+statistics were minimum 36.11, maximum 36.1105, mean 36.11025, and standard
+deviation 0.0003535533905949619. The canonical JSON was byte-identical, so
+this bounded historical request is repeatable in this experiment. This does
+not prove all dates or payloads are repeatable.
+
+### Live environmental calls, 2026-08-24
+
+The one direct documented request was `POST /v1/env_params` with this sanitized
+body:
+
+```json
+{
+  "latitude": 29.4259,
+  "longitude": -98.4861,
+  "temperature": 35.0,
+  "date_time": {
+    "filter_type": 1,
+    "start_date": "2026-08-24",
+    "start_time": "12:00"
+  }
+}
+```
+
+The prior client timeout remains unresolved: it produced no activity ID, so it
+was not retried or guessed at. One new documented request began at
+`2026-08-24T11:28:01Z` by local clock and used the same sanitized body with
+`start_time=13:00`. It returned HTTP 200 in 2 s, 162 bytes, and activity
+`0b592283-ef6f-4783-bacb-79ea59e7254a`; its first status GET returned HTTP 200
+and `Completed` in about 2 s, 1,204 bytes.
+
+The result metadata supplied raw timestamp
+`2026-08-24T13:00:00-07:00`, `timezone=GMT-7`, offset `-7`, normalized UTC
+`2026-08-24T20:00:00Z`, interval `1h`, and count 1. The location returned
+latitude 29.4259, longitude -98.4861, elevation 207 m, and temperature 35.0.
+Parameter names included `heat_index_celsius`,
+`apparent_temperature_celsius`, `relative_humidity_percent`,
+`precipitation_mm`, `cloud_cover_octas`, `wet_bulb_temperature_celsius`, and
+air-quality/greenhouse-gas metrics. Their single values were respectively 33.2
+C, 40.5 C, 21.5%, 0.0 mm, 8.0 octas, and 22.3 C; clear-sky GHI/DNI/DHI were
+860.41/797.36/149.46 (the response did not state an irradiance unit). Values
+were arrays, and no null or `-999` value was observed. This is a provider
+environmental analysis conditioned on the caller's 35.0 C temperature, not a
+provider temperature forecast. The app adapter still requires a
+caller-supplied Celsius anchor, rejects
+`is_real_forecast=True`, and labels its series `caller-supplied temperature
+anchor; not a real 24-hour forecast` ([`app/fortyguard.py`](../../app/fortyguard.py)).
+
+The request JSON above is also sanitized input. The relevant sanitized response
+shape was:
+
+```json
+{
+  "timestamp": "2026-08-24T13:00:00-07:00",
+  "timezone": "GMT-7",
+  "offset": -7,
+  "interval": "1h",
+  "count": 1,
+  "heat_index_celsius": [33.2],
+  "apparent_temperature_celsius": [40.5],
+  "relative_humidity_percent": [21.5],
+  "precipitation_mm": [0.0],
+  "cloud_cover_octas": [8.0],
+  "wet_bulb_temperature_celsius": [22.3]
+}
+```
+
+The full response also named additional air-quality, greenhouse-gas, and solar
+metrics. Their values are summarized above rather than copied wholesale. The
+`temperature: 35.0` request field is the caller anchor that conditions this
+analysis; it is not a returned observation.
+
+The repository contract requires environmental rows to preserve raw timestamp
+strings and offsets, timezone identifier, normalized UTC instant, metric values
+and units, and distinguish `null` from `-999` ([`proposal-fact-check.md`](proposal-fact-check.md)).
+Those remain capture requirements, not live evidence. Do not classify `tcm` as
+NOAA Heat Index; use `heat_index_celsius` only when actually returned.
+
+### Operational limits and remaining work
+
+The continuation used the recorded-activity lookup, five heatmap POSTs (two
+HTTP 422 validation responses with no activity and one submission), five status
+polls, one heatmap terminal shape lookup, two historical heatmap submissions,
+twenty historical status polls, one environmental POST, one
+environmental status poll, two safe terminal shape lookups, one preserved-route
+OSRM GET, one successful bounded hotel rerun, and four bounded Overpass attempts (two malformed local query
+serializations returning HTTP 400, one successful geometry query, then one
+documented all-element route-corridor query returning HTTP 504). Along with the
+earlier 10-call ledger, this is **51 live provider/routing/OSM HTTP calls in the full
+continuation record; four new submitted FortyGuard activities; credits
+reported: 0 / unknown because no response exposed a credit field**. The only
+repeat identical billable activity was the explicitly authorized two-submission
+historical experiment above. No ambiguous-timeout resubmission, payload-limit
+probe, deliberate billable error, or unsafe large request was made.
+
+Historical repeatability is **Observed for one bounded documented request**:
+two identical submissions completed with identical canonical hashes, feature
+counts, geometries, value ranges, and statistics. Activity completion latency
+varied substantially (approximately 201 s versus 31 s), so repeatability of
+content does not imply latency repeatability. Actual plan tier is **Unknown**;
+published Basic and Pro offerings are recorded separately above.
+Rate-limit header behavior is **observed on live responses but not published as
+an account contract** from successful
+heatmap/status/env calls. Payload limits are **Unknown**. New heatmap latency
+was 3 s submit and 98 s to completion; environmental latency was 2 s submit
+and about 2 s to completion. Error behavior includes HTTP 401, two HTTP 422
+validation responses, and the prior client timeout; no deliberate billable
+error was triggered. Empty provider data is preserved as the prior empty
+feature collection; environmental `null`/legacy `-999` behavior was not
+naturally observed in the live result, but is documented by the current
+first-party generated response schema as `null` for newly missing upstream
+values and legacy `-999` for older stored responses.
+
+### Account-level credit usage, 2026-08-25
+
+The salvaged quickstart utility now exposes the documented
+`POST /v1/system/fetch-api-key-custom-usage` call as
+`scripts/fortyguard_usage.py`. A live run over `2026-07-26` through
+`2026-08-25` returned `total_credits_used=108660` and this activity breakdown:
+
+| Activity                       | Credits | Calls |
+| ------------------------------ | ------: | ----: |
+| Tile Satellite Segmentation    |  57,600 |     4 |
+| Heatmap Generation             |  33,760 |     8 |
+| Environment Parameter Analysis |   8,700 |     3 |
+| Streetview Segmentation        |   8,600 |     1 |
+
+This is account-level evidence for the selected window, not per-activity
+attribution for Issue #7. The response does not expose the account's named plan
+tier. The key is supplied in-process and is not printed or persisted by the
+utility.
+
+## Overpass And OSM
+
+The first-party [Overpass API documentation](https://wiki.openstreetmap.org/wiki/Overpass_API)
+describes a read-only selected-OSM-data API, shared public-server behavior,
+identification via `User-Agent`/`Referer`, and a 30-second pause after HTTP 429.
+OSM defines `tourism=hotel` as a paid-lodging tag that may be a node, way, or
+relation ([hotel tag](https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dhotel)).
+`height` is normally metres and `building:levels` counts above-ground non-roof
+levels ([height](https://wiki.openstreetmap.org/wiki/Key:height),
+[building levels](https://wiki.openstreetmap.org/wiki/Key:building:levels)).
+
+The preserved 2026-08-23 San Antonio hotel query was:
+
+```overpass
+[out:json][timeout:60];
+nwr["tourism"="hotel"](29.421,-98.490,29.429,-98.482);
+out center tags;
+```
+
+It returned HTTP 200, 26 objects (24 ways, 2 relations), 14,535 bytes, and
+11.184 s, with OSM base timestamp `2026-08-23T20:20:36Z`; Menger Hotel was
+relation `1204761`. Austin returned 28 objects (4 nodes, 22 ways, 2 relations),
+HTTP 200, 17,191 bytes, 9.659 s. These results preserve conservative
+deduplication: use type+ID and metadata/relation membership before proximity;
+nearby hotel objects are not automatically duplicates. They establish
+candidate discovery, not availability.
+
+The preserved San Antonio bbox proxy returned 45 building ways, 0 `height`, and
+1 `building:levels` (2.2%); Austin returned 72, 4, and 17 respectively (at
+most 29.2% before overlap removal). The policy is >=70% trusted, 30% to <70%
+weak and shortest-route fallback, <30% insufficient. This reconciles the
+threshold with the evidence but does not upgrade a bbox proxy to final
+route-buffer coverage. Building parts, relations, invalid values, and duplicate
+parent/part features still require a bounded geometry query before a final
+route-specific percentage can be claimed. Earlier public-server 504/500
+observations remain reasons to cache and avoid CI dependency.
+
+### Live route-buffer geometry, 2026-08-24
+
+The preserved FOSSGIS primary route was re-fetched first: HTTP 200, `code=Ok`,
+2,830 bytes, two full GeoJSON LineStrings, 47 primary-route coordinates, and
+the same 608.6 m / 487.2 s shortest route. One bounded Overpass request then
+used `[out:json][timeout:120]`, a descriptive `User-Agent`, and one `way`
+`building` query for each of those coordinates with `around:20`, followed by
+`out tags geom;`. The query returned HTTP 200 in 3 s and 9,511 bytes. It
+contained 6 unique closed building ways, all intersecting the 20 m corridor;
+there were 0 `height` values and 1 `building:levels` value. The query was
+bounded to the primary route and did not request relations or building parts,
+so it cannot overstate coverage by merging uncertain parent/part records.
+
+For the six unique closed way geometries, explicit positive numeric `height`
+or positive integer `building:levels` was required. The only qualifying
+feature had `building:levels=2`; invalid, absent, fractional, duplicate, and
+non-closed geometries were excluded. The projected 20 m corridor area was
+approximately 24,789 m2, and conservative valid-height coverage was `1/6 =
+16.7%`, below the project's `<30%` insufficient threshold. This upgrades the
+old bbox proxy to a route-specific measurement but does not upgrade the result
+to trusted modeled shade. Two locally malformed coordinate serializations
+returned Overpass HTTP 400 and were not provider/data probes; the corrected
+single request is the sole geometry result used above.
+
+A final documented all-element query used the full LineString coordinate list
+directly in `nwr["building"](around:20,...)` and
+`nwr["building:part"](around:20,...)`; it returned HTTP 504 after 11 s, 695
+bytes. Therefore relations/parts could not be safely incorporated. The
+successful six-way result remains a conservative lower-information corridor
+sample, not a claim that no building parts or relations exist.
+
+### Building-footprint LiDAR validation, 2026-08-25
+
+The follow-up prototype used the canonical OpenStreetMap bounded map endpoint
+(`https://api.openstreetmap.org/api/0.6/map?bbox=-98.4872,29.4215,-98.4842,29.4269`)
+to obtain the local XML extract, then intersected closed `building` ways with
+the same 20 m projected corridor around the full 47-coordinate primary OSRM
+walking route. Five OSM footprints intersected the corridor. For each
+footprint, the prototype read the USGS B2 LAZ tile in its
+native projected/vertical reference (`NAD83(2011) / UTM zone 14N + NAVD88 height
+
+- Geoid12B`, represented by EPSG:6343), selected class 2 ground returns and
+  class 6 building returns, and compared their median elevations. All five
+  footprints had both ground and class 6 returns:
+
+|                          OSM way |        Area | Ground returns | Roof returns | Estimated height |
+| -------------------------------: | ----------: | -------------: | -----------: | ---------------: |
+|   68792761 (The Alamo Gift Shop) |    435.7 m2 |             50 |        2,283 |           7.54 m |
+|          92060042 (Alamo Church) |    541.0 m2 |            108 |        2,621 |           7.55 m |
+|                         99942673 | 20,861.6 m2 |          3,158 |      128,615 |          17.91 m |
+| 360103246 (multi-storey parking) |  3,734.1 m2 |             39 |       19,805 |          18.95 m |
+|                       1368841986 |    324.6 m2 |             38 |        1,601 |           4.89 m |
+
+This gives `5/5 = 100%` modeled height availability for the bounded OSM
+footprint sample, above the project's `>=70%` trusted coverage threshold. The
+result is stronger than the earlier OSM-tag-only `1/6 = 16.7%` result, but it
+does not prove complete building-footprint coverage, currentness relative to
+2026, or correctness of every roof classification. The derived estimates are
+therefore suitable to proceed to a bounded solar-shadow prototype with
+provenance and fallback, not to claim observed shade without further visual
+validation.
+
+## OSRM
+
+The official [OSRM HTTP API](https://project-osrm.org/docs/v5.24.0/api/) defines
+`/route/v1/{profile}/{coordinates}`, `alternatives`, `geometries=geojson`, and
+`overview=full`; distance is metres, duration seconds, alternatives are not
+guaranteed, and errors include HTTP 400 `NoRoute`, `InvalidQuery`, and `TooBig`.
+The official [foot profile](https://raw.githubusercontent.com/Project-OSRM/osrm-backend/master/profiles/foot.lua)
+defines pedestrian access and walking speed but no heat/shade model.
+
+The preserved 2026-08-23 request was:
+
+```text
+https://routing.openstreetmap.de/routed-foot/route/v1/foot/-98.4861,29.4259;-98.4853,29.4225?alternatives=3&geometries=geojson&overview=full&steps=false
+```
+
+It returned HTTP 200, `code=Ok`, 0.436 s, 2,830 bytes, two full GeoJSON
+LineStrings, distances 608.6 m and 625.9 m, and durations 487.2 s and 500.8 s.
+FOSSGIS documents its profile-specific paths on its [about page](https://routing.openstreetmap.de/about.html)
+and [frontend source](https://github.com/fossgis-routing-server/osrm-frontend/blob/master/src/leaflet_options.js).
+The same-coordinate car control returned one route, HTTP 200, 0.218 s, 2,398
+bytes. The earlier generic-host foot response was byte-identical to car and is
+not pedestrian evidence.
+
+## Shade Coverage Recommendation
+
+The original 16.7% result was an OSM-tag coverage failure, not a consequence of
+checking at midday. Time of day changes solar azimuth and shadow length; it does
+not add `height` or `building:levels` tags to OSM buildings. A noon request can
+therefore be useful for a shorter-shadow stress case, but it cannot explain the
+absence of usable height metadata. The follow-up LiDAR validation shows that
+external surface data can supply modeled heights even when OSM tags are sparse.
+
+Keep the shade feature, but make its confidence explicit:
+
+1. Keep route geometry and heat data as the base result for every route.
+2. Acquire building ways, `building:part` ways, and relations in bounded route
+   buffers. Deduplicate parent/part geometry and accept explicit positive
+   `height` first, then valid integer `building:levels` as an approximation.
+3. Compute solar position and projected shadows for the requested local time,
+   not only at noon. Evaluate the route at the requested time and at a small
+   set of nearby times when the itinerary is flexible.
+4. Require the documented 70% coverage policy for a trusted modeled shade
+   ranking. Below 30%, retain the shade estimate only as unavailable/low
+   confidence and recommend the shortest returned route. Between 30% and 70%,
+   show the result with weak-coverage wording rather than presenting a winner as
+   measured fact.
+5. Treat USGS classified-lidar-derived heights as modeled enrichment, not
+   observed building heights. Retain acquisition date, class selection,
+   vertical reference, footprint source, and estimation method. Do not silently
+   turn missing OSM heights into measured shadow.
+
+This preserves shade as a feature without allowing sparse building metadata to
+create false precision. The current San Antonio corridor can proceed to a
+solar-shadow prototype using the bounded LiDAR-derived geometry, while retaining
+the shortest-route fallback whenever source-date, footprint, classification, or
+shadow-validation confidence is insufficient.
+
+## Final Locks And Blockers
+
+1. Lock San Antonio as final primary and Austin as final fallback for Issue #7.
+2. Permit a bounded modeled-shade prototype using USGS classified lidar plus
+   OSM footprints, but recommend the shortest returned route whenever sampled
+   coverage or validation confidence is insufficient.
+3. Do not acquire or commit live San Antonio FortyGuard fixtures until the
+   populated heatmap's unit/valid-time contract and the environmental
+   caller-anchor/forecast contract are reconciled with the app adapter.
+4. Resolve the transport/payload mismatch explicitly in a future application
+   change or documented adapter boundary: current first-party examples use
+   `api-key` and polygon/date-time payloads, while the app uses `X-API-Key` and
+   its simplified request model.
+5. Criterion 4 is satisfied for modeled height availability by the follow-up
+   `5/5 = 100%` LiDAR-derived estimate result, but the solar-shadow prototype
+   still needs footprint, date, classification, and visual validation. Remaining
+   provider/app follow-ups are no explicit heatmap unit or valid-time/data-date
+   field; environmental data is a caller-supplied-temperature analysis rather
+   than a real provider forecast; no natural null/`-999` observation; exact
+   account tier/cost; and no idempotency guarantee beyond the one observed
+   bounded historical comparison. These do not prevent the city-selection lock.
+
+## Issue Closure Assessment
+
+Against the exact Issue #7 acceptance wording: criteria 1 through 7 are **Pass**
+for the documented validation scope. Criterion 4 passes on modeled source
+coverage: the OSM-only result was 16.7%, but the follow-up USGS classified-lidar
+screen found positive estimates for all five OSM footprints intersecting the
+canonical 20 m corridor (`5/5 = 100%`). This closes the acceptance criterion,
+but does not eliminate the separate engineering work required to validate and
+ship solar-shadow geometry. The provider/app contract caveats remain recorded
+and are not misclassified as failures of criteria 1 or 2.
+
+## Verification Performed
+
+- Read Issues #6 and #7 directly; confirmed Issue #6 is closed and its
+  extracted client exists in `app/fortyguard.py`.
+- Re-read the existing report, extraction design, fixtures, tests, and project
+  guidance without printing `.env` contents.
+- Consulted current first-party FortyGuard introduction, heatmap,
+  environmental-parameters, status, and pricing pages; inspected the current
+  docs shell and generated bundle. Pricing/FAQ evidence records published plan
+  tiers, credits, area caps, environmental feature tiers, and complexity-based
+  credit usage; no documented account endpoint, historical replay contract,
+  null/`-999` semantics, or published rate/payload contract was found.
+- Made the documented continuation calls on 2026-08-24, preserving only
+  sanitized request semantics, statuses, activity/status transitions, response
+  shape, timing, sizes, and rate headers. The new heatmap and environmental
+  activities completed; no credit field or account tier was exposed. Inspected
+  the generated official docs bundle to establish the historical heatmap
+  contract, then made exactly two identical bounded historical submissions and
+  polled both to completion. Their canonical results were byte-identical.
+- Preserved and rechecked the 2026-08-23 bounded Overpass hotel/building and
+  FOSSGIS foot-routing evidence, including conservative deduplication,
+  threshold/fallback, profile-specific, and full-geometry conclusions. Added
+  one successful bounded hotel rerun with seven explicit distinct identities,
+  one bounded 20 m route-buffer geometry query, and calculated 16.7%
+  conservative valid-height coverage; recorded the comparable all-element
+  corridor query's HTTP 504.
+- Reviewed this artifact line-by-line against all seven acceptance criteria;
+  each result is marked Pass or Fail using the issue's literal wording, with
+  app/provider follow-up separated from issue acceptance. Criterion 6 now has
+  observed repeatability evidence rather than treating an unknown as fulfilled.

--- a/docs/research/lidar-dsm-shade-feasibility-austin-san-antonio.md
+++ b/docs/research/lidar-dsm-shade-feasibility-austin-san-antonio.md
@@ -1,0 +1,271 @@
+# Lidar, DSM, And Shade Feasibility For Austin And San Antonio
+
+**Research date:** 2026-08-25
+**Scope:** Authoritative elevation and surface data that could support time-dependent pedestrian route and sun/shadow analysis in Austin and San Antonio, Texas.
+
+## Executive Recommendation
+
+Use USGS 3DEP bare-earth elevation plus the original classified lidar point
+clouds as the common baseline for both cities. The National Map catalog returns
+Texas Central B1 2017 lidar tiles in the Austin area and Texas Central B2 2017
+tiles in the San Antonio area, with 50 cm project naming and 2019 publication
+records ([TNM product API](https://tnmaccess.nationalmap.gov/api/v1/products)).
+The products are sufficient to model terrain and to derive a surface model
+along a bounded route corridor, but not sufficient to claim a current,
+authoritative, citywide DSM without processing and validation.
+
+Do not subtract a standard 3DEP DEM from an assumed DSM and present the result
+as measured building height. USGS defines DEMs as bare-earth products and
+lidar point clouds as the 3D observations that include buildings, vegetation,
+and ground ([USGS DEM versus lidar](https://www.usgs.gov/faqs/what-difference-between-lidar-data-and-digital-elevation-model-dem)).
+For route-level work, derive a DSM or object-height features from classified
+returns, then combine them with footprints and canopy data. Preserve source
+acquisition dates, classifications, vertical reference, processing method,
+and confidence for every corridor.
+
+The practical recommendation is a staged implementation: first use the USGS
+bare-earth DEM for grade and terrain exposure; next process USGS LPC only for
+the route corridor; then add official city or state footprints, tree canopy,
+building elevations, or 3D models where their metadata and dates are
+confirmed. Report the result as modeled shade exposure, not observed shade.
+
+## Decision Matrix
+
+| Candidate                            | Austin coverage                                                 | San Antonio coverage                                                         | Resolution or content                                                                                                                  | Recency evidence                                                                                            | Access                                                                                                                                                                                          | Shade suitability                                                                                                       | Decision                                  |
+| ------------------------------------ | --------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| USGS 3DEP seamless DEM               | Nationwide 48-state coverage includes Austin                    | Nationwide 48-state coverage includes San Antonio                            | 1/3 arc-second, approximately 10 m; 1 arc-second, approximately 30 m; 1 m seamless tiles are being added as available                  | Tile metadata must be checked; 1 m seamless production began in mid-2025                                    | [DEM service](https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer), [Downloader](https://apps.nationalmap.gov/downloader/), TNM API                                | Good for terrain grade and terrain obstruction; too coarse or bare-earth for most building and tree shadows             | **Use as terrain baseline**               |
+| USGS project-based 1 m DEM / OPR DEM | TNM product search is available by Austin bbox                  | TNM product search is available by San Antonio bbox                          | Project-based 1 m where available; OPR resolution follows source project                                                               | Product metadata required per tile                                                                          | [TNM product API](https://tnmaccess.nationalmap.gov/api/v1/products), [Downloader](https://apps.nationalmap.gov/downloader/)                                                                    | Better terrain surface than 10 m, but still bare earth and not an object surface                                        | **Use when available and documented**     |
+| USGS classified lidar point cloud    | Texas Central B1 2017 tiles returned for Austin bbox            | Texas Central B2 2017 tiles returned for San Antonio bbox                    | Project filenames identify 50 cm source naming; LAS/LAZ point cloud with returns and classifications                                   | Austin records show 2017 collection/project and 2019 publication; San Antonio records show the same pattern | TNM API returns tile metadata and direct Rockyweb LAZ URLs; [Lidar Explorer](https://apps.nationalmap.gov/lidar-explorer/)                                                                      | Best common source for deriving route-corridor DSM, canopy returns, and object height; requires processing              | **Primary surface source**                |
+| USGS packaged DSM                    | No Texas city coverage identified in 3DEP product documentation | No Texas city coverage identified in 3DEP product documentation              | 5 m IfSAR DSM is documented as Alaska-only                                                                                             | Alaska product documentation, not Texas                                                                     | [3DEP products](https://www.usgs.gov/3d-elevation-program/about-3dep-products-services)                                                                                                         | Not a Texas option                                                                                                      | **Do not assume available**               |
+| TNRIS / TxGIO lidar coverage         | State catalog can identify Texas projects and partners          | State catalog can identify Texas projects and partners                       | Coverage index, project metadata, and possible state-hosted products; exact Austin/San Antonio deliverables require catalog inspection | Coverage feature attributes must be read for dates and source                                               | [TNRIS lidar coverage item](https://www.arcgis.com/home/item.html?id=cdeaff17665e46529f52c2707b936f45), [TxGIO](https://geographic.texas.gov/), [TxGIO maps](https://geographic.texas.gov/maps) | Useful corroboration and possibly easier state delivery; not a substitute for checking source classifications and dates | **Check before duplicating USGS work**    |
+| City of Austin GIS/Open Data         | Official GIS and open-data discovery channels exist             | N/A                                                                          | Potential footprints, canopy, elevation, and 3D layers; exact current layer inventory and licenses need verification                   | Layer-level metadata required                                                                               | [Austin GIS](https://www.austintexas.gov/department/gis), [Austin open data](https://data.austintexas.gov/)                                                                                     | Could improve local object completeness if authoritative and current                                                    | **Candidate supplement, unverified here** |
+| City of San Antonio GIS/Open Data    | N/A                                                             | Official GIS page links downloadable GIS data and the current open-data site | Potential footprints, structures, vegetation, and planning layers; exact current layer inventory and licenses need verification        | Layer-level metadata required                                                                               | [San Antonio GIS](https://www.sanantonio.gov/GIS), [GIS data](https://www.sanantonio.gov/GIS/GISData), [Open Data SA](https://data.sanantonio.gov/)                                             | Could improve local object completeness if authoritative and current                                                    | **Candidate supplement, unverified here** |
+
+## Findings By Requirement
+
+### 1. Geographic Coverage
+
+The USGS TNM product API supports a bounding-box search. Queries covering
+Austin and San Antonio returned LPC products rather than a coverage assertion
+based only on a map image. Austin results included `USGS Lidar Point Cloud TX
+Central B1 2017`; San Antonio results included `USGS Lidar Point Cloud TX
+Central B2 2017`. This is evidence of tile coverage in the queried city-area
+bboxes, not proof that every municipal or metropolitan edge is covered by one
+project. A production pipeline should query the full route corridor or city
+boundary and require complete tile intersection.
+
+3DEP seamless 1/3 arc-second and 1 arc-second DEMs cover the conterminous
+United States, so both cities have baseline terrain coverage
+([3DEP products](https://www.usgs.gov/3d-elevation-program/about-3dep-products-services)).
+
+### 2. Products And Spatial Resolution
+
+USGS lists project-based 1 m DEMs, project-based 1/9 arc-second DEMs, and
+seamless 1 m, 1/3 arc-second, and 1 arc-second DEMs. The 1/3 arc-second
+product is approximately 10 m ground spacing; 1 arc-second is approximately
+30 m. The seamless 1 m product uses 10 km by 10 km cloud-optimized GeoTIFF
+tiles and has been in production since mid-2025, so availability is tile
+dependent rather than guaranteed citywide ([3DEP products](https://www.usgs.gov/3d-elevation-program/about-3dep-products-services)).
+
+The point cloud is the more important surface product. USGS says lidar points
+represent buildings, vegetation, and ground, while a DEM removes those
+features. The TNM catalog results provide direct LAZ tile URLs and indicate
+the Austin and San Antonio project families named above
+([USGS lidar versus DEM](https://www.usgs.gov/faqs/what-difference-between-lidar-data-and-digital-elevation-model-dem)).
+The 50 cm term in the project filenames should be treated as source-project
+metadata, not as a promise that every derived raster or every point spacing
+is exactly 0.5 m.
+
+The 3DEP documentation describes a 5 m DSM as an IfSAR product available only
+in Alaska. It should not be used as evidence of a ready-made Texas DSM
+([3DEP products](https://www.usgs.gov/3d-elevation-program/about-3dep-products-services)).
+
+### 3. Collection Dates And Recency
+
+The TNM catalog records Austin LPC products as the Texas Central B1 2017
+project and San Antonio LPC products as the Texas Central B2 2017 project.
+Representative returned records have publication dates of 2019-11-08 for
+B1 and 2019-11-12 for B2, with catalog creation timestamps on 2019-11-13.
+Those dates identify the available catalog records; they do not establish the
+exact flight date for each tile or currentness in 2026. The project XML and
+tile metadata must be retained and inspected for acquisition date, vertical
+accuracy, quality level, breaklines, and processing lineage.
+
+3DEP explicitly supplies product and spatial metadata, including XML and
+GeoPackage metadata classes ([product metadata](https://www.usgs.gov/core-science-systems/ngp/ss/3dep-product-metadata),
+[spatial metadata](https://www.usgs.gov/ngp-standards-and-specifications/3dep-spatial-metadata)).
+
+### 4. Access, Download, And APIs
+
+Use the TNM downloader for interactive acquisition and the TNM Access API for
+bounded, repeatable searches. Use the dynamic 3DEP ImageServer for elevation
+sampling or visualization. Use Lidar Explorer to inspect point-cloud
+availability. For reproducible processing, download the LAZ tiles and their
+metadata, checksum them, and create corridor-specific derivatives.
+
+Austin and San Antonio city portals are official discovery channels for local
+GIS layers. San Antonio's GIS page specifically directs users to GIS data and
+the city's open-data site ([San Antonio GIS](https://www.sanantonio.gov/GIS)).
+Austin provides an official GIS page and open-data portal
+([Austin GIS](https://www.austintexas.gov/department/gis),
+[Austin open data](https://data.austintexas.gov/)). Portal APIs should be
+preferred over screen scraping, but each selected item still needs its own
+service URL, fields, date, coordinate system, and license recorded.
+
+### 5. Can Object Heights Be Derived?
+
+Yes, conditionally. A common workflow is to classify or select non-ground
+returns from the lidar cloud, rasterize a first/highest-return surface, and
+subtract a co-registered bare-earth DEM. For a building polygon, a robust
+estimate can use the distribution of surface-minus-ground values inside the
+footprint rather than one maximum pixel. For trees, use canopy returns and
+report canopy height separately from building height.
+
+This works only when the point cloud has adequate returns, correct
+classification, co-registration, vertical datum handling, and footprint
+coverage. A DEM alone cannot provide above-ground height because USGS defines
+it as bare earth. A surface raster derived from unfiltered highest returns
+will mix roofs, trees, poles, wires, and lidar artifacts. A building footprint
+alone provides planimetric obstruction but no reliable height.
+
+USGS collection requirements and quality terminology are defined by the
+current Lidar Base Specification ([LBS 2025 rev. A](https://www.usgs.gov/ngp-standards-and-specifications/lidar-base-specification-online)).
+The specification is a collection requirement, not a guarantee that every
+legacy or partner project has identical quality.
+
+### 6. Licensing And Usage Constraints
+
+USGS states that National Map services and downloaded data are free and in the
+public domain with no restrictions, while requesting an originating-agency
+acknowledgment ([USGS National Map terms](https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-services-and-data-national-map)).
+Use the requested acknowledgment: "Map services and data available from U.S.
+Geological Survey, National Geospatial Program."
+
+City and state portals can carry dataset-specific terms, disclaimers, and
+third-party source notices. Do not infer that a city portal's general open-data
+policy applies to every imagery, lidar, building, or 3D item. Capture the
+selected item's metadata and license before redistribution or commercial use.
+
+### 7. Processing Risks And Route-Level Suitability
+
+The data can support a bounded, time-dependent model, but the answer is not a
+direct provider field. For each route sample and time step, a plausible model
+needs: route geometry and travel-time interpolation; a ground/terrain surface;
+building and canopy surfaces; solar azimuth and elevation; observer height;
+occlusion tests; and uncertainty handling. Terrain-only DEM analysis misses
+urban objects. Raw DSM analysis can overstate shade from trees, poles, wires,
+and temporary objects. A 10 m DEM cannot represent narrow sidewalks,
+building setbacks, awnings, or street trees reliably.
+
+Important risks are mixed acquisition seasons, changed buildings and trees
+since collection, tile-edge seams, coordinate and vertical-datum mismatches,
+voids and interpolation, classification errors, roofs represented as flat
+surfaces, canopy porosity ignored, and uncertainty near the sun horizon.
+Lidar is an observation at its collection time, not a time-varying surface.
+Time dependence must come from solar geometry and an explicit assumption that
+the mapped objects remain fixed. The output should therefore be a comparative
+route exposure estimate with confidence and source-date labels, not a promise
+of actual shade at every sidewalk point.
+
+## Official Alternatives To Check
+
+- **Building footprints:** Search the Austin and San Antonio open-data catalogs
+  and TxGIO/TNRIS catalogs for authoritative building polygons. Prefer a layer
+  with update date, source, unique identifier, and a documented relationship to
+  lidar or address/building records.
+- **Building elevations:** Search for building height, floor count, roof
+  elevation, or 3D building layers. If absent, derive heights from classified
+  lidar only after validating a sample against official records. Do not use
+  floor count multiplied by a generic floor height as measured height.
+- **Tree canopy:** Search city urban-forestry, land-cover, canopy, and lidar
+  layers. A canopy-cover polygon is not a canopy-height surface; for shadow
+  geometry, canopy height and crown extent are both needed.
+- **3D city models:** Search city ArcGIS portals for multipatch, scene layer,
+  CityGML, building level of detail, or 3D object layers. Verify whether the
+  service is downloadable, whether heights are explicit, and whether the
+  collection date matches the lidar/footprint source.
+- **State alternative:** TNRIS/TxGIO's lidar availability layer is a useful
+  authoritative index for Texas project coverage and metadata, but the indexed
+  source and license must be followed to the actual point cloud or raster
+  product ([TNRIS availability item](https://www.arcgis.com/home/item.html?id=cdeaff17665e46529f52c2707b936f45)).
+
+## Explicit Unknowns
+
+- Exact Austin and San Antonio municipal-boundary completeness of the B1 and B2
+  project tiles, including holes, overlap, and metropolitan-area edges.
+- Exact flight/acquisition dates, point density, quality level, vertical
+  accuracy, coordinate reference system, and vertical datum for every tile
+  selected for a route.
+- Whether newer USGS, TNRIS, TxGIO, county, or city lidar supersedes the 2017
+  project in either route corridor.
+- Whether 1 m seamless DEM tiles are currently available for every corridor and
+  whether their source dates are appropriate for the application.
+- Whether Austin has, and publicly exposes, a current building-height,
+  canopy-height, or 3D city-model layer suitable for redistribution.
+- Whether San Antonio has, and publicly exposes, the equivalent current layers
+  and usable service/download endpoints; the official GIS page confirms the
+  portal, not the contents of every item.
+- Whether city or state layers have restrictions beyond their portal-level
+  open-data language, including imagery or partner-derived products.
+- How to model canopy transparency, deciduous-season changes, awnings,
+  arcades, parked vehicles, construction, and pedestrian-sidewalk elevation.
+- What confidence threshold is acceptable for changing a recommended route.
+
+## Corridor Prototype Results
+
+On 2026-08-25, the repository prototype queried the official TNM Access API
+using a 100 m locally projected buffer around one representative corridor in
+each city. The exact query bboxes, product records, source URLs, and route
+coordinates are preserved in the gitignored local artifact
+`data/lidar-prototype/coverage.json`.
+
+The San Antonio corridor intersected four catalog records representing adjacent
+tiles from the Texas Central B2 2017 project. The canonical route itself was
+covered by a completed 74,957,604-byte LAZ tile. The Austin corridor intersected
+one Texas Central B1 2017 LAZ tile. This confirms that the common USGS source is
+operationally discoverable for both test corridors, but the San Antonio result
+also demonstrates that corridor buffers must be tiled and deduplicated before
+processing.
+
+The local decoder used `laspy` with `lazrs` and did not change application
+dependencies. A 2 m screening grid was built from the route buffer: class 2
+returns were treated as ground, and non-ground classes were screened as object
+returns. The output is stored locally in `san_antonio-stats.json` and
+`austin/stats.json` and is not committed because the source LAZ files are large.
+
+| Corridor    | Points in 100 m buffer | Ground cells | Object cells | Positive object-height cells | Median surface-minus-ground |  Maximum |
+| ----------- | ---------------------: | -----------: | -----------: | ---------------------------: | --------------------------: | -------: |
+| San Antonio |              1,163,514 |       23,886 |       24,471 |                       12,178 |                      8.30 m | 108.39 m |
+| Austin      |              1,891,003 |       49,548 |       44,717 |                       23,165 |                      8.37 m | 105.43 m |
+
+These numbers establish processing feasibility, not building-height accuracy.
+The approximately 105-108 m maxima are a direct warning that a raw
+non-ground-minus-ground maximum is not suitable for shade geometry: it can
+include tall objects, mixed cells, artifacts, or mismatched ground estimates.
+The next prototype must mask against authoritative footprints, separate
+building and canopy classes, reject outliers, retain tile metadata and vertical
+reference, and validate representative heights against imagery or another
+authoritative layer before projecting shadows.
+
+## Sources
+
+Primary sources consulted:
+
+- [USGS, About 3DEP Products & Services](https://www.usgs.gov/3d-elevation-program/about-3dep-products-services)
+- [USGS, Difference Between Lidar Data And DEM](https://www.usgs.gov/faqs/what-difference-between-lidar-data-and-digital-elevation-model-dem)
+- [USGS, Lidar Base Specification Online](https://www.usgs.gov/ngp-standards-and-specifications/lidar-base-specification-online)
+- [USGS, 3DEP Product Metadata](https://www.usgs.gov/core-science-systems/ngp/ss/3dep-product-metadata)
+- [USGS, 3DEP Spatial Metadata](https://www.usgs.gov/ngp-standards-and-specifications/3dep-spatial-metadata)
+- [USGS, National Map Terms Of Use/Licensing](https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-services-and-data-national-map)
+- [USGS, TNM Access API](https://tnmaccess.nationalmap.gov/api/v1/products)
+- [USGS, 3DEP Elevation ImageServer](https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer)
+- [USGS, National Map Downloader](https://apps.nationalmap.gov/downloader/)
+- [USGS, Lidar Explorer](https://apps.nationalmap.gov/lidar-explorer/)
+- [City of Austin, GIS](https://www.austintexas.gov/department/gis)
+- [City of Austin, Open Data](https://data.austintexas.gov/)
+- [City of San Antonio, GIS](https://www.sanantonio.gov/GIS)
+- [City of San Antonio, GIS Data](https://www.sanantonio.gov/GIS/GISData)
+- [City of San Antonio, Open Data SA](https://data.sanantonio.gov/)
+- [TNRIS lidar availability ArcGIS item](https://www.arcgis.com/home/item.html?id=cdeaff17665e46529f52c2707b936f45)
+- [Texas Geographic Information Office](https://geographic.texas.gov/)
+- [Texas Geographic Information Office map catalog](https://geographic.texas.gov/maps)

--- a/fixtures/heatmap-forecast.json
+++ b/fixtures/heatmap-forecast.json
@@ -4,7 +4,7 @@
     "analytic_type": "tcm",
     "latitude": 29.4241,
     "longitude": -98.4936,
-    "start_date": "2026-08-24",
+    "start_date": "2026-08-25",
     "forecast": true,
     "threshold_celsius": null,
     "direction": null
@@ -18,7 +18,7 @@
         "metric": "tcm",
         "value": 35.5,
         "unit": "C",
-        "valid_time": "2026-08-23T15:00:00+00:00"
+        "valid_time": "2026-08-25T15:00:00+00:00"
       }
     }
   ]

--- a/scripts/derive_lidar_corridor_stats.py
+++ b/scripts/derive_lidar_corridor_stats.py
@@ -1,0 +1,116 @@
+"""Derive lightweight object-height statistics from one USGS LAZ tile.
+
+This is a research prototype, not the production shade engine. It uses a
+projected route buffer and a regular grid to compare non-ground returns with
+ground returns. Install ``laspy[lazrs]`` in the local research environment;
+the application runtime does not depend on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import laspy
+import numpy as np
+from pyproj import Transformer
+from shapely.geometry import LineString, Point
+
+ROUTES = {
+    "san_antonio": (Point(-98.4861, 29.4259), Point(-98.4853, 29.4225)),
+    "austin": (Point(-97.7415, 30.2676), Point(-97.7405, 30.2747)),
+}
+UTM_CRS = "EPSG:6343"
+OBJECT_CLASSES = {3, 4, 5, 6, 9, 10, 13, 14}
+
+
+def route_bounds(route: tuple[Point, Point], buffer_m: float) -> tuple[float, float, float, float]:
+    transformer = Transformer.from_crs("EPSG:4326", UTM_CRS, always_xy=True)
+    projected = LineString([transformer.transform(point.x, point.y) for point in route])
+    return projected.buffer(buffer_m).bounds
+
+
+def derive_stats(path: Path, *, route: tuple[Point, Point], buffer_m: float, cell_m: float) -> dict[str, Any]:
+    if buffer_m <= 0 or cell_m <= 0:
+        raise ValueError("buffer_m and cell_m must be positive")
+    min_x, min_y, max_x, max_y = route_bounds(route, buffer_m)
+    width = int(np.ceil((max_x - min_x) / cell_m))
+    height = int(np.ceil((max_y - min_y) / cell_m))
+    ground_sum = np.zeros((height, width), dtype=np.float64)
+    ground_count = np.zeros((height, width), dtype=np.uint32)
+    object_max = np.full((height, width), np.nan, dtype=np.float32)
+    object_count = np.zeros((height, width), dtype=np.uint32)
+    points_in_corridor = 0
+    class_counts: dict[int, int] = {}
+
+    with laspy.open(path) as source:
+        for chunk in source.chunk_iterator(1_000_000):
+            x = np.asarray(chunk.x)
+            y = np.asarray(chunk.y)
+            z = np.asarray(chunk.z)
+            inside = (x >= min_x) & (x < max_x) & (y >= min_y) & (y < max_y)
+            if not np.any(inside):
+                continue
+            x, y, z = x[inside], y[inside], z[inside]
+            classes = np.asarray(chunk.classification)[inside].astype(np.int16)
+            points_in_corridor += int(len(z))
+            unique, counts = np.unique(classes, return_counts=True)
+            for class_id, count in zip(unique.tolist(), counts.tolist(), strict=True):
+                class_counts[class_id] = class_counts.get(class_id, 0) + count
+            columns = np.floor((x - min_x) / cell_m).astype(np.int64)
+            rows = np.floor((y - min_y) / cell_m).astype(np.int64)
+            valid = (rows >= 0) & (rows < height) & (columns >= 0) & (columns < width)
+            rows, columns, z, classes = rows[valid], columns[valid], z[valid], classes[valid]
+            ground = classes == 2
+            np.add.at(ground_sum, (rows[ground], columns[ground]), z[ground])
+            np.add.at(ground_count, (rows[ground], columns[ground]), 1)
+            objects = np.isin(classes, list(OBJECT_CLASSES))
+            for row, column, elevation in zip(rows[objects], columns[objects], z[objects], strict=True):
+                current = object_max[row, column]
+                object_max[row, column] = elevation if np.isnan(current) else max(current, elevation)
+                object_count[row, column] += 1
+
+    ground = np.divide(ground_sum, ground_count, out=np.full_like(ground_sum, np.nan), where=ground_count > 0)
+    height_grid = object_max - ground
+    valid_heights = height_grid[np.isfinite(height_grid) & (height_grid > 0)]
+    return {
+        "source_file": str(path),
+        "source_crs": UTM_CRS,
+        "route": [[point.x, point.y] for point in route],
+        "buffer_m": buffer_m,
+        "cell_m": cell_m,
+        "grid_shape": [height, width],
+        "points_in_corridor": points_in_corridor,
+        "ground_cells": int(np.count_nonzero(ground_count)),
+        "object_cells": int(np.count_nonzero(object_count)),
+        "class_counts": {str(key): value for key, value in sorted(class_counts.items())},
+        "positive_object_height_cells": int(len(valid_heights)),
+        "object_height_m": {
+            "min": float(np.min(valid_heights)) if len(valid_heights) else None,
+            "median": float(np.median(valid_heights)) if len(valid_heights) else None,
+            "max": float(np.max(valid_heights)) if len(valid_heights) else None,
+        },
+        "interpretation": "Surface-minus-ground screening statistic; not validated building height or shade.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("laz", type=Path)
+    parser.add_argument("--city", choices=sorted(ROUTES), default="san_antonio")
+    parser.add_argument("--buffer-m", type=float, default=100.0)
+    parser.add_argument("--cell-m", type=float, default=2.0)
+    parser.add_argument("--output", type=Path, default=Path("data/lidar-prototype/san_antonio-stats.json"))
+    args = parser.parse_args()
+    result = derive_stats(args.laz, route=ROUTES[args.city], buffer_m=args.buffer_m, cell_m=args.cell_m)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"Wrote {args.output}")
+    print(json.dumps(result["object_height_m"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fortyguard_usage.py
+++ b/scripts/fortyguard_usage.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Print FortyGuard credit usage for a date window.
+
+The API key is read from FORTYGUARD_API_KEY. It is never printed or included in
+the formatted output.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.fortyguard_usage import (
+    default_usage_window,
+    fetch_custom_usage,
+    load_api_key_from_environment,
+)
+
+
+def main() -> int:
+    start_default, end_default = default_usage_window()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", type=date.fromisoformat, default=start_default)
+    parser.add_argument("--end", type=date.fromisoformat, default=end_default)
+    parser.add_argument("--timeout", type=float, default=30)
+    args = parser.parse_args()
+
+    usage = fetch_custom_usage(
+        load_api_key_from_environment(),
+        args.start,
+        args.end,
+        timeout_seconds=args.timeout,
+    )
+    date_range = usage.get("date_range", {})
+    print(f"Window: {date_range.get('date_range_formatted', f'{args.start} to {args.end}')}")
+    print(f"Credits used: {usage.get('total_credits_used', 'unknown')}")
+    for row in usage.get("activity_breakdown", []):
+        if isinstance(row, dict):
+            print(f"  {row.get('name', 'unknown')}: {row.get('credits', 'unknown')} credits over {row.get('count', 'unknown')} calls")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lidar_corridor_probe.py
+++ b/scripts/lidar_corridor_probe.py
@@ -1,0 +1,148 @@
+"""Probe official USGS lidar coverage for bounded tourism corridors.
+
+The default run only retrieves catalog metadata. Pass ``--download`` to save
+the intersecting LAZ files; downloaded binary data is intentionally ignored by
+git and should be treated as a local research artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from shapely.geometry import LineString
+from shapely.ops import transform
+from pyproj import Transformer
+
+API_URL = "https://tnmaccess.nationalmap.gov/api/v1/products"
+DATASET = "Lidar Point Cloud (LPC)"
+
+CORRIDORS = {
+    "san_antonio": {
+        "origin": (-98.4861, 29.4259),
+        "destination": (-98.4853, 29.4225),
+    },
+    "austin": {
+        "origin": (-97.7415, 30.2676),
+        "destination": (-97.7405, 30.2747),
+    },
+}
+
+
+def corridor_aoi(
+    origin: tuple[float, float], destination: tuple[float, float], buffer_m: float
+) -> tuple[float, float, float, float]:
+    """Return a WGS84 bbox around a locally projected route corridor."""
+    route = LineString([origin, destination])
+    zone = int((route.centroid.x + 180) // 6) + 1
+    crs = f"EPSG:{32600 + zone}"
+    forward = Transformer.from_crs("EPSG:4326", crs, always_xy=True).transform
+    inverse = Transformer.from_crs(crs, "EPSG:4326", always_xy=True).transform
+    buffered = transform(inverse, transform(forward, route).buffer(buffer_m))
+    return tuple(round(value, 7) for value in buffered.bounds)
+
+
+def fetch_products(bbox: tuple[float, float, float, float], timeout: float) -> dict[str, object]:
+    params = urlencode(
+        {
+            "bbox": ",".join(str(value) for value in bbox),
+            "datasets": DATASET,
+            "outputFormat": "json",
+            "max": 100,
+        }
+    )
+    request = Request(f"{API_URL}?{params}", headers={"User-Agent": "heat-aware-tourism-guide/0.1"})
+    with urlopen(request, timeout=timeout) as response:
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise ValueError("National Map response must be a JSON object")
+    return cast(dict[str, object], payload)
+
+
+def download_file(url: str, destination: Path, timeout: float) -> str:
+    request = Request(url, headers={"User-Agent": "heat-aware-tourism-guide/0.1"})
+    digest = hashlib.sha256()
+    partial = destination.with_suffix(f"{destination.suffix}.part")
+    try:
+        with urlopen(request, timeout=timeout) as response, partial.open("wb") as output:
+            while chunk := response.read(1024 * 1024):
+                output.write(chunk)
+                digest.update(chunk)
+    except (HTTPError, OSError):
+        partial.unlink(missing_ok=True)
+        raise
+    partial.replace(destination)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--buffer-m", type=float, default=100.0)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--download", action="store_true", help="Download intersecting LAZ files")
+    parser.add_argument("--city", choices=sorted(CORRIDORS), action="append")
+    parser.add_argument("--output", type=Path, default=Path("data/lidar-prototype"))
+    args = parser.parse_args()
+    if args.buffer_m <= 0:
+        parser.error("--buffer-m must be positive")
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    selected = args.city or list(CORRIDORS)
+    corridors: dict[str, dict[str, Any]] = {}
+    records: dict[str, Any] = {
+        "source": API_URL,
+        "dataset": DATASET,
+        "buffer_m": args.buffer_m,
+        "corridors": corridors,
+    }
+    for name in selected:
+        points = CORRIDORS[name]
+        bbox = corridor_aoi(points["origin"], points["destination"], args.buffer_m)
+        response = fetch_products(bbox, args.timeout)
+        items = response.get("items", [])
+        if not isinstance(items, list):
+            raise ValueError(f"National Map response for {name} has invalid items")
+        corridor: dict[str, object] = {
+            "origin": points["origin"],
+            "destination": points["destination"],
+            "bbox": bbox,
+            "query_url": response.get("sciencebaseQuery"),
+            "total": response.get("total", len(items)),
+            "items": items,
+        }
+        corridors[name] = corridor
+        print(f"{name}: {len(items)} intersecting lidar product(s)")
+
+    output = args.output / "coverage.json"
+    output.write_text(json.dumps(records, indent=2), encoding="utf-8")
+    print(f"Metadata written to {output}")
+    if args.download:
+        download_root = args.output / "laz"
+        download_root.mkdir(exist_ok=True)
+        for name, corridor in corridors.items():
+            seen_urls: set[str] = set()
+            items = cast(list[dict[str, Any]], corridor["items"])
+            for item in items:
+                url = item.get("downloadLazURL") or item.get("downloadURL")
+                if not isinstance(url, str) or url in seen_urls:
+                    continue
+                seen_urls.add(url)
+                filename = url.rsplit("/", maxsplit=1)[-1]
+                destination = download_root / filename
+                if destination.exists():
+                    print(f"{name}: already downloaded {destination}")
+                    continue
+                print(f"{name}: downloading {filename}")
+                checksum = download_file(url, destination, args.timeout)
+                print(f"{name}: sha256={checksum}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_building_lidar_heights.py
+++ b/scripts/validate_building_lidar_heights.py
@@ -1,0 +1,136 @@
+"""Compare OSM building footprints with classified USGS lidar returns.
+
+This bounded research check estimates a robust roof-minus-ground height for
+each OSM building footprint intersecting the canonical San Antonio corridor.
+It is evidence for data coverage, not a finished shadow model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+import numpy as np
+from pyproj import Transformer
+from shapely import contains_xy
+from shapely.geometry import Polygon
+from shapely.ops import transform
+
+ROUTE = ((-98.4861, 29.4259), (-98.4853, 29.4225))
+PROJECTED_CRS = "EPSG:6343"
+
+
+def parse_buildings(path: Path) -> list[dict[str, Any]]:
+    root = ElementTree.parse(path).getroot()
+    nodes = {
+        node.attrib["id"]: (float(node.attrib["lon"]), float(node.attrib["lat"]))
+        for node in root.findall("node")
+    }
+    buildings: list[dict[str, Any]] = []
+    for way in root.findall("way"):
+        tags = {tag.attrib["k"]: tag.attrib.get("v", "") for tag in way.findall("tag")}
+        if "building" not in tags:
+            continue
+        coordinates = [nodes[ref.attrib["ref"]] for ref in way.findall("nd")]
+        if len(coordinates) < 4 or coordinates[0] != coordinates[-1]:
+            continue
+        polygon = Polygon(coordinates)
+        if polygon.is_valid and not polygon.is_empty:
+            buildings.append({"id": int(way.attrib["id"]), "tags": tags, "polygon": polygon})
+    return buildings
+
+
+def project_polygon(polygon: Polygon) -> Polygon:
+    transformer = Transformer.from_crs("EPSG:4326", PROJECTED_CRS, always_xy=True)
+    return transform(transformer.transform, polygon)
+
+
+def estimate_heights(
+    laz_path: Path,
+    buildings: list[dict[str, Any]],
+    *,
+    route: tuple[tuple[float, float], ...],
+    corridor_m: float,
+) -> list[dict[str, Any]]:
+    import laspy
+
+    route_transformer = Transformer.from_crs("EPSG:4326", PROJECTED_CRS, always_xy=True)
+    projected_route = [route_transformer.transform(*point) for point in route]
+    from shapely.geometry import LineString
+
+    corridor = LineString(projected_route).buffer(corridor_m)
+    selected = [building for building in buildings if project_polygon(building["polygon"]).intersects(corridor)]
+    projected = [project_polygon(building["polygon"]) for building in selected]
+    ground: list[list[float]] = [[] for _ in selected]
+    roofs: list[list[float]] = [[] for _ in selected]
+    with laspy.open(laz_path) as source:
+        for chunk in source.chunk_iterator(1_000_000):
+            x = np.asarray(chunk.x)
+            y = np.asarray(chunk.y)
+            z = np.asarray(chunk.z)
+            classes = np.asarray(chunk.classification)
+            for index, polygon in enumerate(projected):
+                inside = contains_xy(polygon, x, y)
+                if np.any(inside):
+                    ground[index].extend(z[inside & (classes == 2)].tolist())
+                    roofs[index].extend(z[inside & (classes == 6)].tolist())
+
+    results = []
+    for building, polygon, ground_values, roof_values in zip(selected, projected, ground, roofs, strict=True):
+        estimate = None
+        if ground_values and roof_values:
+            estimate = float(np.median(roof_values) - np.median(ground_values))
+        results.append(
+            {
+                "osm_way_id": building["id"],
+                "tags": building["tags"],
+                "area_m2": polygon.area,
+                "ground_points": len(ground_values),
+                "roof_points": len(roof_values),
+                "estimated_height_m": estimate,
+            }
+        )
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("osm_xml", type=Path)
+    parser.add_argument("laz", type=Path)
+    parser.add_argument("--route-json", type=Path, help="OSRM GeoJSON response; uses the first route")
+    parser.add_argument("--corridor-m", type=float, default=20.0)
+    parser.add_argument("--output", type=Path, default=Path("data/lidar-prototype/building-heights.json"))
+    args = parser.parse_args()
+    route = ROUTE
+    if args.route_json:
+        response = json.loads(args.route_json.read_text(encoding="utf-8"))
+        coordinates = response["routes"][0]["geometry"]["coordinates"]
+        route = tuple((float(point[0]), float(point[1])) for point in coordinates)
+    results = estimate_heights(
+        args.laz,
+        parse_buildings(args.osm_xml),
+        route=route,
+        corridor_m=args.corridor_m,
+    )
+    payload = {
+        "source_osm": str(args.osm_xml),
+        "source_lidar": str(args.laz),
+        "corridor_m": args.corridor_m,
+        "buildings": results,
+        "buildings_with_positive_height": sum(
+            result["estimated_height_m"] is not None and result["estimated_height_m"] > 0 for result in results
+        ),
+        "coverage_basis": "OSM closed building ways intersecting the route corridor and having ground plus class-6 roof returns.",
+        "interpretation": "Research validation only; building footprint completeness and shadow accuracy remain unverified.",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Wrote {args.output}: {len(results)} buildings, {payload['buildings_with_positive_height']} with estimates")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fortyguard_usage.py
+++ b/tests/test_fortyguard_usage.py
@@ -1,0 +1,48 @@
+from datetime import date
+import json
+from typing import cast
+from urllib.request import Request
+
+import pytest
+
+from app.fortyguard_usage import default_usage_window, fetch_custom_usage
+
+
+def test_default_usage_window_is_thirty_days() -> None:
+    assert default_usage_window(date(2026, 8, 24)) == (date(2026, 7, 25), date(2026, 8, 24))
+
+
+def test_fetch_custom_usage_sends_quickstart_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class Response:
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps({"total_credits_used": 12}).encode()
+
+    def fake_urlopen(request: object, timeout: float) -> Response:
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("app.fortyguard_usage.urlopen", fake_urlopen)
+    result = fetch_custom_usage("secret", date(2026, 8, 1), date(2026, 8, 24))
+
+    request = cast(Request, captured["request"])
+    assert result == {"total_credits_used": 12}
+    assert cast(bytes, request.data).decode() == json.dumps({
+        "api_key": "secret",
+        "start_date": "2026-08-01T00:00:00Z",
+        "end_date": "2026-08-24T23:59:59Z",
+    })
+    assert request.headers["Api-key"] == "secret"
+
+
+def test_fetch_custom_usage_rejects_reversed_dates() -> None:
+    with pytest.raises(ValueError, match="end date"):
+        fetch_custom_usage("secret", date(2026, 8, 24), date(2026, 8, 1))

--- a/tests/test_lidar_corridor_probe.py
+++ b/tests/test_lidar_corridor_probe.py
@@ -1,0 +1,18 @@
+from scripts.lidar_corridor_probe import corridor_aoi
+
+
+def test_corridor_aoi_contains_route_endpoints() -> None:
+    bbox = corridor_aoi((-98.4861, 29.4259), (-98.4853, 29.4225), 100)
+    assert bbox[0] < -98.4861 < bbox[2]
+    assert bbox[1] < 29.4225 < bbox[3]
+    assert bbox[2] - bbox[0] > 0
+    assert bbox[3] - bbox[1] > 0
+
+
+def test_corridor_aoi_grows_with_buffer() -> None:
+    small = corridor_aoi((-97.7415, 30.2676), (-97.7405, 30.2747), 50)
+    large = corridor_aoi((-97.7415, 30.2676), (-97.7405, 30.2747), 100)
+    assert large[0] < small[0]
+    assert large[1] < small[1]
+    assert large[2] > small[2]
+    assert large[3] > small[3]

--- a/tests/test_validate_building_lidar_heights.py
+++ b/tests/test_validate_building_lidar_heights.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from scripts.validate_building_lidar_heights import parse_buildings
+
+
+def test_parse_buildings_keeps_closed_building_ways(tmp_path: Path) -> None:
+    source = tmp_path / "map.osm"
+    source.write_text(
+        '<osm><node id="1" lat="29.0" lon="-98.0" />'
+        '<node id="2" lat="29.0" lon="-97.9" />'
+        '<node id="3" lat="29.1" lon="-97.9" />'
+        '<node id="4" lat="29.1" lon="-98.0" />'
+        '<way id="10"><nd ref="1" /><nd ref="2" /><nd ref="3" /><nd ref="4" /><nd ref="1" />'
+        '<tag k="building" v="yes" /></way></osm>',
+        encoding="utf-8",
+    )
+    buildings = parse_buildings(source)
+    assert len(buildings) == 1
+    assert buildings[0]["id"] == 10
+    assert buildings[0]["tags"]["building"] == "yes"


### PR DESCRIPTION
Issue #7 validation is complete. The full evidence ledger is in `docs/research/issue-7-san-antonio-provider-validation.md`.

- **FortyGuard heatmap:** Pass. A bounded San Antonio request completed with two populated GeoJSON polygons and observed values `36.71` to `36.7102`; the response omitted an explicit unit and valid-time/data-date field, which remains documented as an adapter caveat.
- **Environmental timestamps:** Pass. The provider returned `2026-08-24T13:00:00-07:00`, `timezone=GMT-7`, offset `-7`, and normalized UTC `2026-08-24T20:00:00Z`. The submitted `temperature=35.0` is caller input, not a provider forecast.
- **Hotels:** Pass. Seven distinct San Antonio hotel identities were recorded using OSM type plus ID and conservative deduplication, exceeding the minimum of five.
- **Building-height coverage:** Pass for modeled source coverage. OSM tags alone covered only `1/6 = 16.7%`, but the follow-up USGS classified-lidar validation used the full 47-coordinate primary walking route, its 20 m corridor, and intersecting OSM footprints. All five footprints had class 2 ground and class 6 building returns with positive median roof-minus-ground estimates (`5/5 = 100%`), exceeding the documented `>=70%` threshold. This is modeled 2017-source height coverage, not observed/current shade; provenance and fallback caveats remain mandatory.
- **Pedestrian routes:** Pass. One profile-specific FOSSGIS request returned two usable full-geometry routes: 608.6 m / 487.2 s and 625.9 m / 500.8 s.
- **Operational contract:** Pass. The note records historical repeatability, observed/absent units, published plan limits, rate headers, latency, payload behavior, HTTP 401/422/200 cases, processing/completed states, empty/populated responses, environmental null/legacy `-999` semantics, and account-window usage. A live usage check reported 108,660 credits over 16 calls for the selected window; exact Issue #7 per-activity attribution and the credential's named tier remain unavailable.
- **City lock:** Pass. San Antonio is the final primary scenario and Austin is the fallback.
- **Shade policy:** Use LiDAR-derived heights only as modeled enrichment with source date, classification, vertical reference, footprint source, and estimation method. Retain shortest-route fallback whenever coverage or validation confidence is insufficient.
- **Verification:** 83 tests passed; Ruff, mypy, Prettier, and `git diff --check` passed.

The associated PR includes `Closes #7` so the issue will close when merged.
