### PR TITLE
Implement curated trip setup flow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,25 @@ directly.
 
 ## Glossary
 
+- **Canonical trip** — The validated demonstration journey from Menger Hotel
+  to The Alamo, with hotel decisions scoped to Downtown San Antonio / Alamo
+  Plaza. Synonyms to avoid: "default walk", "demo location".
+- **Trip setup** — The traveler-selected inputs shared by the best-time, hotel,
+  and route decisions for one trip. It is one setup, not separate walk and
+  hotel configurations.
+- **Curated trip** — A trip whose places are fixed to the canonical trip while
+  the traveler may choose its date, hour, and guidance preference. An
+  **exploratory trip** permits place selection and is outside the curated flow.
+- **Cautious guidance** — An optional traveler preference requesting the
+  product's more conservative heat interpretation. The interpretation policy
+  belongs to the heat-classification domain; trip setup only captures the
+  preference. Synonym to avoid: "cautious mode".
+- **Trip analysis request** — One product-level request containing a complete
+  trip setup and asking for the connected best-time, hotel, and route
+  decisions. It is not a collection of traveler-visible provider requests.
+- **Supported live-data geography** — The United States, the geographic area
+  in which the product may request live provider data. This is distinct from
+  the canonical trip's San Antonio location and from fixture replay.
 - **Activity** — One asynchronous FortyGuard job. Submission returns an
   `activity_id`; the result is polled from `GET /v1/status/{activity_id}`.
   A heatmap activity is billable on completion. Synonyms to avoid: "task",

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -76,9 +76,7 @@ def _fixture_scenario(
 
 
 class LiveTripAnalysisAdapter:
-    def __init__(
-        self, loader: Callable[[TripAnalysisRequest], Mapping[str, object]]
-    ) -> None:
+    def __init__(self, loader: Callable[[TripAnalysisRequest], Mapping[str, object]]) -> None:
         self.loader = loader
 
     def analyze(
@@ -146,9 +144,21 @@ def normalize_trip_analysis(
     _require_section_reason("hotels", hotel_value, degraded_reasons)
     _require_section_reason("routes", route_value, degraded_reasons)
 
-    best_time = _best_time(_mapping(best_value, "best_time"), execution_mode, request.date) if best_value is not None else None
-    hotels = _hotels(_mapping(hotel_value, "hotels"), execution_mode, request.date) if hotel_value is not None else None
-    routes = _routes(_mapping(route_value, "routes"), execution_mode, request.date) if route_value is not None else None
+    best_time = (
+        _best_time(_mapping(best_value, "best_time"), execution_mode, request.date)
+        if best_value is not None
+        else None
+    )
+    hotels = (
+        _hotels(_mapping(hotel_value, "hotels"), execution_mode, request.date)
+        if hotel_value is not None
+        else None
+    )
+    routes = (
+        _routes(_mapping(route_value, "routes"), execution_mode, request.date)
+        if route_value is not None
+        else None
+    )
     expected_reasons = {
         name
         for name, value in (
@@ -207,7 +217,9 @@ def _best_time(
     return BestTimeResult(
         hourly=hourly,
         recommendation_hour=_integer(best_payload["recommendation_hour"], "recommendation_hour"),
-        recommendation_reason=_string(best_payload["recommendation_reason"], "recommendation_reason"),
+        recommendation_reason=_string(
+            best_payload["recommendation_reason"], "recommendation_reason"
+        ),
         metric_label=metric_label,
         provenance=best_provenance,
         hourly_coverage=_number(best_payload["hourly_coverage"], "hourly_coverage"),
@@ -284,7 +296,9 @@ def _routes(
         confidence=confidence,
         comparison_scope="returned alternatives",
         provenance=route_provenance,
-        fallback_reason=_string(fallback_reason, "fallback_reason") if fallback_reason is not None else None,
+        fallback_reason=_string(fallback_reason, "fallback_reason")
+        if fallback_reason is not None
+        else None,
     )
 
 
@@ -307,18 +321,22 @@ def _route_option(
         heat_unit=unit,
         heat_metric=metric,
         heat_status=status,
-        modeled_shade_percent=_number(shade, "modeled_shade_percent") if shade is not None else None,
+        modeled_shade_percent=_number(shade, "modeled_shade_percent")
+        if shade is not None
+        else None,
         shade_confidence=confidence if shade is not None else None,
         building_coverage=_number(item["building_coverage"], "building_coverage"),
         recommended=identity == recommended_id,
-        recommendation_reason=_string(item["recommendation_reason"], "recommendation_reason") if item.get("recommendation_reason") is not None else None,
-        shade_model_label="modeled shade estimate based on OSM building data" if shade is not None else None,
+        recommendation_reason=_string(item["recommendation_reason"], "recommendation_reason")
+        if item.get("recommendation_reason") is not None
+        else None,
+        shade_model_label="modeled shade estimate based on OSM building data"
+        if shade is not None
+        else None,
     )
 
 
-def _provenance(
-    section: Mapping[str, object], execution_mode: ExecutionMode
-) -> Provenance:
+def _provenance(section: Mapping[str, object], execution_mode: ExecutionMode) -> Provenance:
     raw = _mapping(section.get("provenance"), "provenance")
     return Provenance(
         source=execution_mode.value,
@@ -328,7 +346,9 @@ def _provenance(
         retrieved_at=_string(raw["retrieved_at"], "retrieved_at"),
         transformation_version=_string(raw["transformation_version"], "transformation_version"),
         provider=_string(raw["provider"], "provider"),
-        activity_id=_string(raw["activity_id"], "activity_id") if raw.get("activity_id") is not None else None,
+        activity_id=_string(raw["activity_id"], "activity_id")
+        if raw.get("activity_id") is not None
+        else None,
         response_status=_string(raw["response_status"], "response_status"),
         request_configuration=dict(_mapping(raw["request_configuration"], "request_configuration")),
         fresh=_boolean(raw["fresh"], "fresh"),
@@ -342,9 +362,7 @@ def _mapping(value: object, field: str) -> Mapping[str, object]:
     return value
 
 
-def _require_section_reason(
-    name: str, value: object, reasons: dict[str, str]
-) -> None:
+def _require_section_reason(name: str, value: object, reasons: dict[str, str]) -> None:
     if value is None and name not in reasons:
         raise ValueError(f"missing {name} without degraded reason")
 
@@ -394,19 +412,21 @@ def _request_identity(request: TripAnalysisRequest) -> str:
     return f"{request.mode.value}:{request.date}:{request.hour}"
 
 
-def _fixture_matches(
-    scenario: Mapping[str, object], request: TripAnalysisRequest
-) -> bool:
+def _fixture_matches(scenario: Mapping[str, object], request: TripAnalysisRequest) -> bool:
     origin = _mapping(scenario.get("origin"), "scenario origin")
     destination = _mapping(scenario.get("destination"), "scenario destination")
     return (
-        _string(scenario.get("landmark_name"), "scenario landmark_name")
-        == request.landmark_name
+        _string(scenario.get("landmark_name"), "scenario landmark_name") == request.landmark_name
         and _string(scenario.get("district_name"), "scenario district_name")
         == request.district_name
         and _string(scenario.get("date"), "scenario date") == request.date
-        and math.isclose(_number(origin.get("latitude"), "origin latitude"), request.origin.latitude)
-        and math.isclose(_number(origin.get("longitude"), "origin longitude"), request.origin.longitude)
+        and _integer(scenario.get("hour"), "scenario hour") == request.hour
+        and math.isclose(
+            _number(origin.get("latitude"), "origin latitude"), request.origin.latitude
+        )
+        and math.isclose(
+            _number(origin.get("longitude"), "origin longitude"), request.origin.longitude
+        )
         and math.isclose(
             _number(destination.get("latitude"), "destination latitude"),
             request.destination.latitude,

--- a/fixtures/trip-analysis.acquisition.json
+++ b/fixtures/trip-analysis.acquisition.json
@@ -5,6 +5,7 @@
     "landmark_name": "The Alamo",
     "district_name": "Downtown San Antonio",
     "date": "2026-08-23",
+    "hour": 8,
     "origin": {
       "latitude": 29.421,
       "longitude": -98.491

--- a/fixtures/trip-analysis.json
+++ b/fixtures/trip-analysis.json
@@ -3,6 +3,7 @@
     "landmark_name": "The Alamo",
     "district_name": "Downtown San Antonio",
     "date": "2026-08-23",
+    "hour": 8,
     "origin": { "latitude": 29.421, "longitude": -98.491 },
     "destination": { "latitude": 29.425, "longitude": -98.484 }
   },

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -13,7 +13,7 @@ import {
   WalkDateScreen,
   WalkLocationScreen,
 } from "../features/walk/WalkScreens";
-import { WelcomeScreen } from "../screens/WelcomeScreen";
+import { TripSetupScreen } from "../screens/TripSetupScreen";
 
 export function App() {
   return (
@@ -21,7 +21,7 @@ export function App() {
       <AppProvider>
         <Routes>
           <Route element={<AppShell />}>
-            <Route index element={<WelcomeScreen />} />
+            <Route index element={<TripSetupScreen />} />
             <Route path="walk/location" element={<WalkLocationScreen />} />
             <Route path="walk/date" element={<WalkDateScreen />} />
             <Route path="walk/result" element={<BestTimeScreen />} />

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Footprints, Hotel, MapPin, SunMedium } from "lucide-react";
+import { ArrowLeft, MapPin, SunMedium } from "lucide-react";
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAppState } from "./AppState";
 import type { MockMode } from "../types";
@@ -21,14 +21,6 @@ export function AppShell() {
           </span>
           <span>Heat-Aware Tourism Guide</span>
         </Link>
-        <nav aria-label="Primary navigation">
-          <Link to="/walk/location">
-            <Footprints size={16} /> Plan a walk
-          </Link>
-          <Link to="/hotels/location">
-            <Hotel size={16} /> Rank hotels
-          </Link>
-        </nav>
       </header>
       {!isHome && (
         <div className="context-bar">
@@ -49,7 +41,7 @@ export function AppShell() {
       <main>
         <Outlet />
       </main>
-      {import.meta.env.DEV && (
+      {import.meta.env.DEV && !isHome && (
         <aside className="dev-panel" aria-label="Development data state">
           <label htmlFor="mock-state">Preview state</label>
           <select

--- a/frontend/src/app/AppState.tsx
+++ b/frontend/src/app/AppState.tsx
@@ -6,10 +6,12 @@ import {
   type ReactNode,
 } from "react";
 import type {
+  CuratedTripSetup,
   HotelResponse,
   LocationSelection,
   MockMode,
   TripResponse,
+  TripAnalysisResponse,
 } from "../types";
 
 type AppState = {
@@ -19,6 +21,8 @@ type AppState = {
   hotelLocation: LocationSelection | null;
   ranking: HotelResponse | null;
   mode: MockMode;
+  tripAnalysis: TripAnalysisResponse | null;
+  curatedTripSetup: CuratedTripSetup;
 };
 type AppContextValue = AppState & {
   setWalkLocation: (value: LocationSelection) => void;
@@ -27,6 +31,8 @@ type AppContextValue = AppState & {
   setHotelLocation: (value: LocationSelection) => void;
   setRanking: (value: HotelResponse | null) => void;
   setMode: (value: MockMode) => void;
+  setTripAnalysis: (value: TripAnalysisResponse | null) => void;
+  setCuratedTripSetup: (value: CuratedTripSetup) => void;
 };
 const AppContext = createContext<AppContextValue | null>(null);
 
@@ -41,6 +47,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
     hotelLocation: null,
     ranking: null,
     mode: queryMode ?? "success",
+    tripAnalysis: null,
+    curatedTripSetup: { date: "2026-08-23", hour: 8, cautious: false },
   });
   const value = useMemo<AppContextValue>(
     () => ({
@@ -59,6 +67,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
           mode,
           trip: null,
           ranking: null,
+        })),
+      setTripAnalysis: (tripAnalysis) =>
+        setState((current) => ({ ...current, tripAnalysis })),
+      setCuratedTripSetup: (curatedTripSetup) =>
+        setState((current) => ({
+          ...current,
+          curatedTripSetup,
+          tripAnalysis: null,
         })),
     }),
     [state]

--- a/frontend/src/screens/TripSetupScreen.tsx
+++ b/frontend/src/screens/TripSetupScreen.tsx
@@ -1,0 +1,330 @@
+import { AlertTriangle, CheckCircle2, Database, Radio } from "lucide-react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useAppState } from "../app/AppState";
+import { dataClient } from "../services/dataClient";
+import type { ExecutionMode, TripAnalysisRequest } from "../types";
+
+const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
+
+type HealthState =
+  | { status: "checking" | "unavailable" }
+  | { status: "available"; mode: ExecutionMode };
+type RequestState = "idle" | "submitting" | "failed";
+
+function validDate(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return (
+    !Number.isNaN(date.valueOf()) && date.toISOString().slice(0, 10) === value
+  );
+}
+
+export function TripSetupScreen() {
+  const {
+    curatedTripSetup,
+    setCuratedTripSetup,
+    tripAnalysis,
+    setTripAnalysis,
+  } = useAppState();
+  const { date, hour, cautious } = curatedTripSetup;
+  const [dateError, setDateError] = useState("");
+  const [health, setHealth] = useState<HealthState>({ status: "checking" });
+  const [requestState, setRequestState] = useState<RequestState>("idle");
+  const dateRef = useRef<HTMLInputElement>(null);
+
+  async function checkHealth(signal?: AbortSignal) {
+    setHealth({ status: "checking" });
+    try {
+      const mode = await dataClient.getHealth(signal);
+      setHealth({ status: "available", mode });
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        setHealth({ status: "unavailable" });
+      }
+    }
+  }
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void checkHealth(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    if (
+      health.status === "available" &&
+      tripAnalysis &&
+      tripAnalysis.execution_mode !== health.mode
+    ) {
+      setTripAnalysis(null);
+    }
+  }, [health, setTripAnalysis, tripAnalysis]);
+
+  function clearOutcome() {
+    setTripAnalysis(null);
+    setRequestState("idle");
+  }
+
+  async function submit(event?: FormEvent) {
+    event?.preventDefault();
+    if (!validDate(date)) {
+      setDateError("Enter a valid date.");
+      dateRef.current?.focus();
+      return;
+    }
+    setDateError("");
+    if (health.status !== "available" || requestState === "submitting") return;
+
+    const request: TripAnalysisRequest = {
+      mode: "curated",
+      origin_latitude: 29.421,
+      origin_longitude: -98.491,
+      destination_latitude: 29.425,
+      destination_longitude: -98.484,
+      landmark_name: "The Alamo",
+      district_name: "Downtown San Antonio",
+      date,
+      hour,
+      cautious,
+      execution_mode: health.mode,
+    };
+    setTripAnalysis(null);
+    setRequestState("submitting");
+    try {
+      const response = await dataClient.analyzeCuratedTrip(request);
+      if (response.state === "error") {
+        setRequestState("failed");
+      } else {
+        setTripAnalysis(response);
+        setRequestState("idle");
+      }
+    } catch {
+      setRequestState("failed");
+    }
+  }
+
+  const busy = requestState === "submitting";
+  const mode = health.status === "available" ? health.mode : null;
+
+  return (
+    <section className="screen trip-setup">
+      <header className="trip-setup-heading">
+        <span className="step-label">Curated San Antonio trip</span>
+        <h1>Trip Setup</h1>
+        <p>
+          Configure one analysis for the best time, nearby hotels, and walking
+          route for this fixed journey.
+        </p>
+      </header>
+
+      <div className="setup-layout">
+        <form
+          className="setup-card"
+          onSubmit={submit}
+          aria-busy={busy}
+          noValidate
+        >
+          <div className="curated-trip" aria-label="Curated trip places">
+            <div>
+              <span>Origin</span>
+              <strong>Menger Hotel</strong>
+            </div>
+            <div>
+              <span>Destination</span>
+              <strong>The Alamo</strong>
+            </div>
+            <div>
+              <span>Area</span>
+              <strong>Downtown San Antonio / Alamo Plaza</strong>
+            </div>
+          </div>
+
+          <div className="setup-fields">
+            <div className="field">
+              <label htmlFor="trip-date">Date</label>
+              <input
+                ref={dateRef}
+                id="trip-date"
+                type="date"
+                value={date}
+                disabled={busy}
+                aria-invalid={Boolean(dateError)}
+                aria-describedby={dateError ? "date-error" : undefined}
+                onChange={(event) => {
+                  setCuratedTripSetup({
+                    ...curatedTripSetup,
+                    date: event.target.value,
+                  });
+                  setDateError("");
+                  setRequestState("idle");
+                }}
+              />
+              {dateError && (
+                <span id="date-error" className="field-error">
+                  {dateError}
+                </span>
+              )}
+            </div>
+            <div className="field">
+              <label htmlFor="trip-hour">Hour</label>
+              <select
+                id="trip-hour"
+                value={hour}
+                disabled={busy}
+                onChange={(event) => {
+                  setCuratedTripSetup({
+                    ...curatedTripSetup,
+                    hour: Number(event.target.value),
+                  });
+                  setRequestState("idle");
+                }}
+              >
+                {HOURS.map((value) => (
+                  <option key={value} value={value}>
+                    {String(value).padStart(2, "0")}:00
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <label className="cautious-option">
+            <input
+              type="checkbox"
+              checked={cautious}
+              disabled={busy}
+              onChange={(event) => {
+                setCuratedTripSetup({
+                  ...curatedTripSetup,
+                  cautious: event.target.checked,
+                });
+                setRequestState("idle");
+              }}
+            />
+            <span>
+              <strong>Cautious guidance</strong>
+              <small>
+                Request a more conservative interpretation of heat conditions.
+              </small>
+            </span>
+          </label>
+
+          {busy ? (
+            <div className="busy-status" role="status">
+              Analyzing trip...
+            </div>
+          ) : (
+            <button type="submit" disabled={health.status !== "available"}>
+              Analyze trip
+            </button>
+          )}
+        </form>
+
+        <aside className="mode-card" aria-live="polite">
+          <span className="mode-label">Application mode</span>
+          {health.status === "checking" && (
+            <p role="status">Checking application mode...</p>
+          )}
+          {mode && (
+            <>
+              <div className={`mode-value ${mode}`}>
+                {mode === "fixture" ? (
+                  <Database size={18} />
+                ) : (
+                  <Radio size={18} />
+                )}
+                <strong>
+                  {mode === "fixture" ? "Fixture replay" : "Live data"}
+                </strong>
+              </div>
+              <p>
+                {mode === "fixture"
+                  ? "This analysis replays the committed San Antonio scenario."
+                  : "This analysis requests current provider data."}
+              </p>
+            </>
+          )}
+          {health.status === "unavailable" && (
+            <div className="mode-unavailable">
+              <AlertTriangle size={20} />
+              <strong>Application mode unavailable</strong>
+              <p>
+                We could not confirm whether analysis uses fixture replay or
+                live data.
+              </p>
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={() => void checkHealth()}
+              >
+                Check again
+              </button>
+            </div>
+          )}
+          <div className="geography-note">
+            <strong>Supported live-data geography</strong>
+            <p>
+              Live provider requests are supported in the United States. This is
+              separate from this curated San Antonio trip and fixture replay.
+            </p>
+          </div>
+        </aside>
+      </div>
+
+      {tripAnalysis && mode === tripAnalysis.execution_mode && (
+        <section
+          className={`setup-outcome ${tripAnalysis.state}`}
+          role="status"
+          aria-label="Trip analysis outcome"
+        >
+          <CheckCircle2 size={24} />
+          <div>
+            {tripAnalysis.state === "success" && <h2>Trip analysis ready</h2>}
+            {tripAnalysis.state === "degraded" && (
+              <>
+                <h2>Trip analysis ready with limitations</h2>
+                <ul>
+                  {Object.values(tripAnalysis.degraded_reasons ?? {}).map(
+                    (reason) => (
+                      <li key={reason}>{reason}</li>
+                    )
+                  )}
+                </ul>
+              </>
+            )}
+            {(tripAnalysis.state === "unavailable" ||
+              tripAnalysis.state === "error") && (
+              <>
+                <h2>Trip analysis unavailable</h2>
+                <p>{tripAnalysis.unavailable?.reason}</p>
+              </>
+            )}
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={() => {
+                clearOutcome();
+                dateRef.current?.focus();
+              }}
+            >
+              Edit setup
+            </button>
+          </div>
+        </section>
+      )}
+
+      {requestState === "failed" && (
+        <section className="setup-outcome failed" role="alert">
+          <AlertTriangle size={24} />
+          <div>
+            <h2>We could not analyze this trip.</h2>
+            <p>Please try the request again.</p>
+            <button type="button" onClick={() => void submit()}>
+              Try again
+            </button>
+          </div>
+        </section>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -1,9 +1,129 @@
 import { scenarioLocations } from "../mocks/data";
 import { mockHotelRanking } from "../mocks/mockHotelRanking";
 import { mockTripAnalyze } from "../mocks/mockTripAnalyze";
+import type {
+  ExecutionMode,
+  TripAnalysisRequest,
+  TripAnalysisResponse,
+} from "../types";
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isResultSection(value: unknown) {
+  return value === null || isObject(value);
+}
+
+function validUnavailable(value: unknown) {
+  return (
+    isObject(value) &&
+    typeof value.reason === "string" &&
+    value.reason.length > 0 &&
+    typeof value.recoverable === "boolean"
+  );
+}
+
+function validReasons(value: unknown): value is Record<string, string> {
+  return (
+    isObject(value) &&
+    Object.keys(value).length > 0 &&
+    Object.entries(value).every(
+      ([key, reason]) =>
+        ["best_time", "hotels", "routes"].includes(key) &&
+        typeof reason === "string" &&
+        reason.length > 0
+    )
+  );
+}
+
+function isTripAnalysisResponse(
+  value: unknown,
+  request: TripAnalysisRequest
+): value is TripAnalysisResponse {
+  if (
+    !isObject(value) ||
+    value.request_identity !==
+      `${request.mode}:${request.date}:${request.hour}` ||
+    value.mode !== request.mode ||
+    value.execution_mode !== request.execution_mode ||
+    !["success", "degraded", "unavailable", "error"].includes(
+      String(value.state)
+    ) ||
+    !isResultSection(value.best_time) ||
+    !isResultSection(value.hotels) ||
+    !isResultSection(value.routes)
+  ) {
+    return false;
+  }
+  const hasResults = Boolean(value.best_time || value.hotels || value.routes);
+  if (value.state === "success") {
+    return Boolean(
+      value.best_time &&
+      value.hotels &&
+      value.routes &&
+      value.unavailable === null &&
+      value.degraded_reasons === null
+    );
+  }
+  if (value.state === "degraded") {
+    const reasons = value.degraded_reasons;
+    if (!validReasons(reasons)) return false;
+    const expectedReasons = [
+      ...(!value.best_time ? ["best_time"] : []),
+      ...(!value.hotels ? ["hotels"] : []),
+      ...(!value.routes ? ["routes"] : []),
+      ...(isObject(value.routes) && value.routes.confidence === "insufficient"
+        ? ["routes"]
+        : []),
+    ];
+    return (
+      hasResults &&
+      value.unavailable === null &&
+      Object.keys(reasons).length === expectedReasons.length &&
+      expectedReasons.every((section) => section in reasons)
+    );
+  }
+  return (
+    !hasResults &&
+    validUnavailable(value.unavailable) &&
+    value.degraded_reasons === null
+  );
+}
+
+async function readJson(response: Response) {
+  if (!response.ok) throw new Error("Request failed");
+  return response.json() as Promise<unknown>;
+}
 
 export const dataClient = {
   analyzeTrip: mockTripAnalyze,
+  async getHealth(signal?: AbortSignal): Promise<ExecutionMode> {
+    const value = await readJson(await fetch("/health", { signal }));
+    if (
+      !isObject(value) ||
+      value.status !== "ok" ||
+      (value.mode !== "fixture" && value.mode !== "live")
+    ) {
+      throw new Error("Invalid health response");
+    }
+    return value.mode;
+  },
+  async analyzeCuratedTrip(
+    request: TripAnalysisRequest
+  ): Promise<TripAnalysisResponse> {
+    const value = await readJson(
+      await fetch("/api/trip/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      })
+    );
+    if (!isTripAnalysisResponse(value, request)) {
+      throw new Error("Invalid trip analysis response");
+    }
+    return value;
+  },
   rankHotels: mockHotelRanking,
   searchLocations(query: string) {
     const normalized = query.trim().toLowerCase();

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -627,6 +627,198 @@ dd {
 .validation-message {
   color: var(--accent);
 }
+.trip-setup {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+.trip-setup-heading {
+  max-width: 720px;
+  margin-bottom: 34px;
+}
+.trip-setup-heading h1 {
+  font-size: clamp(42px, 6vw, 68px);
+}
+.trip-setup-heading p {
+  max-width: 620px;
+  font-size: 17px;
+}
+.setup-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(270px, 0.85fr);
+  gap: 22px;
+  align-items: start;
+}
+.setup-card,
+.mode-card,
+.setup-outcome {
+  min-width: 0;
+  padding: clamp(22px, 4vw, 34px);
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+.setup-card {
+  display: grid;
+  gap: 26px;
+}
+.curated-trip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+.curated-trip > div {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+  padding: 17px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+.curated-trip > div:last-child {
+  grid-column: 1 / -1;
+}
+.curated-trip span,
+.mode-label {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.curated-trip strong,
+.setup-outcome p,
+.setup-outcome li,
+.mode-card p {
+  overflow-wrap: anywhere;
+}
+.setup-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+.field {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+}
+.field input,
+.field select {
+  min-height: 46px;
+}
+.field-error {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 700;
+}
+.cautious-option {
+  align-items: flex-start;
+  padding: 18px;
+  border: 1px solid var(--line);
+  background: #f7f8f2;
+  cursor: pointer;
+}
+.cautious-option input {
+  width: 20px;
+  height: 20px;
+  margin: 2px 4px 0 0;
+  flex: none;
+  accent-color: var(--accent);
+}
+.cautious-option span {
+  display: grid;
+  gap: 5px;
+}
+.setup-card > button,
+.busy-status {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+}
+.busy-status {
+  background: var(--ink);
+  color: #fff;
+  font-weight: 750;
+}
+.mode-card {
+  display: grid;
+  gap: 15px;
+  border-top: 4px solid var(--ink);
+}
+.mode-card p {
+  margin: 0;
+  font-size: 14px;
+}
+.mode-value {
+  display: flex;
+  gap: 9px;
+  align-items: center;
+  padding: 14px;
+  background: #edf2eb;
+  color: var(--ink);
+}
+.mode-value.live {
+  background: #e5f1f0;
+  color: #1f655b;
+}
+.mode-unavailable {
+  display: grid;
+  gap: 10px;
+  color: var(--accent);
+}
+.mode-unavailable button {
+  margin-top: 3px;
+}
+.geography-note {
+  display: grid;
+  gap: 8px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+}
+.setup-outcome {
+  display: flex;
+  gap: 16px;
+  margin-top: 22px;
+  border-left: 4px solid #287158;
+}
+.setup-outcome > svg {
+  flex: none;
+  color: #287158;
+}
+.setup-outcome > div {
+  min-width: 0;
+}
+.setup-outcome h2 {
+  margin: 0 0 8px;
+}
+.setup-outcome p {
+  margin: 0 0 14px;
+}
+.setup-outcome ul {
+  margin: 10px 0 18px;
+  padding-left: 20px;
+  color: var(--muted);
+}
+.setup-outcome.degraded {
+  border-left-color: #c18320;
+  background: #fffaf0;
+}
+.setup-outcome.degraded > svg {
+  color: #c18320;
+}
+.setup-outcome.unavailable,
+.setup-outcome.error,
+.setup-outcome.failed {
+  border-left-color: var(--accent);
+  background: var(--accent-soft);
+}
+.setup-outcome.unavailable > svg,
+.setup-outcome.error > svg,
+.setup-outcome.failed > svg {
+  color: var(--accent);
+}
+.setup-outcome button {
+  min-height: 44px;
+}
 .dev-panel {
   position: fixed;
   right: 14px;
@@ -696,5 +888,30 @@ dd {
   .provenance dl {
     display: grid;
     grid-template-columns: 1fr 1fr;
+  }
+  .trip-setup {
+    padding-top: 42px;
+    padding-bottom: 54px;
+  }
+  .setup-layout,
+  .setup-fields,
+  .curated-trip {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .curated-trip > div:last-child {
+    grid-column: auto;
+  }
+  .setup-card,
+  .mode-card,
+  .setup-outcome {
+    padding: 20px;
+  }
+  .setup-outcome {
+    align-items: flex-start;
+  }
+  .setup-card > button,
+  .setup-outcome button,
+  .mode-unavailable button {
+    width: 100%;
   }
 }

--- a/frontend/src/test/tripSetup.test.tsx
+++ b/frontend/src/test/tripSetup.test.tsx
@@ -1,0 +1,324 @@
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { App } from "../app/App";
+
+const successResponse = {
+  request_identity: "curated:2026-08-23:8",
+  mode: "curated",
+  execution_mode: "fixture",
+  state: "success",
+  best_time: { hourly: [] },
+  hotels: { ranked: [] },
+  routes: { alternatives: [] },
+  unavailable: null,
+  degraded_reasons: null,
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockFetch(...responses: Array<Response | Promise<Response>>) {
+  const fetchMock = vi.fn();
+  responses.forEach((response) => fetchMock.mockResolvedValueOnce(response));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("curated Trip Setup", () => {
+  it("loads fixture mode and submits the complete setup exactly once", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse(successResponse)
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(await screen.findByText("Fixture replay")).toBeInTheDocument();
+    expect(screen.getByText("Menger Hotel")).toBeInTheDocument();
+    expect(screen.getByText("The Alamo")).toBeInTheDocument();
+    expect(
+      screen.getByText("Downtown San Antonio / Alamo Plaza")
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Date")).toHaveValue("2026-08-23");
+    expect(screen.getByLabelText("Hour")).toHaveValue("8");
+    expect(screen.getByLabelText(/Cautious guidance/)).not.toBeChecked();
+    expect(screen.getByText(/United States/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    expect(await screen.findByText("Trip analysis ready")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/health", expect.any(Object));
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/trip/analyze",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "curated",
+          origin_latitude: 29.421,
+          origin_longitude: -98.491,
+          destination_latitude: 29.425,
+          destination_longitude: -98.484,
+          landmark_name: "The Alamo",
+          district_name: "Downtown San Antonio",
+          date: "2026-08-23",
+          hour: 8,
+          cautious: false,
+          execution_mode: "fixture",
+        }),
+      })
+    );
+  });
+
+  it("preserves edits and retries when application mode is unavailable", async () => {
+    const fetchMock = mockFetch(
+      Promise.reject(new Error("offline")),
+      jsonResponse({ status: "ok", mode: "live" })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(
+      await screen.findByText("Application mode unavailable")
+    ).toBeInTheDocument();
+    const date = screen.getByLabelText("Date");
+    await user.clear(date);
+    await user.type(date, "2026-09-01");
+    expect(screen.getByRole("button", { name: "Analyze trip" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Check again" }));
+
+    expect(await screen.findByText("Live data")).toBeInTheDocument();
+    expect(date).toHaveValue("2026-09-01");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("validates fields without submitting or auto-submitting edits", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    const date = screen.getByLabelText("Date");
+    await user.clear(date);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    expect(screen.getByText("Enter a valid date.")).toBeInTheDocument();
+    expect(date).toHaveAttribute("aria-invalid", "true");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces busy state and disables setup controls", async () => {
+    let resolveAnalysis!: (response: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      resolveAnalysis = resolve;
+    });
+    mockFetch(jsonResponse({ status: "ok", mode: "fixture" }), pending);
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    expect(screen.getByRole("status")).toHaveTextContent("Analyzing trip...");
+    expect(screen.getByLabelText("Date")).toBeDisabled();
+    expect(screen.getByLabelText("Hour")).toBeDisabled();
+    expect(screen.getByLabelText(/Cautious guidance/)).toBeDisabled();
+    resolveAnalysis(jsonResponse(successResponse));
+    expect(await screen.findByText("Trip analysis ready")).toBeInTheDocument();
+  });
+
+  it("retains degraded detail and clears it when setup changes", async () => {
+    mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse({
+        ...successResponse,
+        state: "degraded",
+        hotels: null,
+        degraded_reasons: {
+          hotels: "Hotel ranking is temporarily unavailable.",
+        },
+      })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    const outcome = await screen.findByRole("status", {
+      name: "Trip analysis outcome",
+    });
+    expect(
+      within(outcome).getByText("Trip analysis ready with limitations")
+    ).toBeInTheDocument();
+    expect(
+      within(outcome).getByText("Hotel ranking is temporarily unavailable.")
+    ).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Hour"), "9");
+    expect(screen.queryByText(/Trip analysis ready/)).not.toBeInTheDocument();
+  });
+
+  it("shows domain unavailability and returns to editing", async () => {
+    mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse({
+        ...successResponse,
+        state: "unavailable",
+        best_time: null,
+        hotels: null,
+        routes: null,
+        unavailable: {
+          reason: "No fixture matches that date and hour.",
+          recoverable: true,
+        },
+      })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    expect(
+      await screen.findByText("No fixture matches that date and hour.")
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit setup" }));
+    expect(
+      screen.queryByText("No fixture matches that date and hour.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Date")).toHaveFocus();
+  });
+
+  it("keeps analyzed setup values aligned across route remounts", async () => {
+    mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse({
+        ...successResponse,
+        request_identity: "curated:2026-08-23:9",
+      }),
+      jsonResponse({ status: "ok", mode: "fixture" })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.selectOptions(screen.getByLabelText("Hour"), "9");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+    await screen.findByText("Trip analysis ready");
+
+    window.history.pushState({}, "", "/walk/date");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await screen.findByText("Choose a place");
+    await user.click(
+      screen.getByRole("link", { name: "Heat-Aware Tourism Guide home" })
+    );
+
+    expect(await screen.findByText("Trip analysis ready")).toBeInTheDocument();
+    expect(screen.getByLabelText("Hour")).toHaveValue("9");
+  });
+
+  it("clears a retained result when application mode changes", async () => {
+    mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse(successResponse),
+      jsonResponse({ status: "ok", mode: "live" })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+    await screen.findByText("Trip analysis ready");
+
+    window.history.pushState({}, "", "/walk/date");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await screen.findByText("Choose a place");
+    await user.click(
+      screen.getByRole("link", { name: "Heat-Aware Tourism Guide home" })
+    );
+
+    expect(await screen.findByText("Live data")).toBeInTheDocument();
+    expect(screen.queryByText("Trip analysis ready")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "malformed response",
+      jsonResponse({ ...successResponse, execution_mode: "live" }),
+    ],
+    [
+      "mismatched request identity",
+      jsonResponse({
+        ...successResponse,
+        request_identity: "curated:2026-08-23:9",
+      }),
+    ],
+    [
+      "inconsistent degraded response",
+      jsonResponse({
+        ...successResponse,
+        state: "degraded",
+        hotels: null,
+        degraded_reasons: { routes: "Route confidence is limited." },
+      }),
+    ],
+    ["request failure", jsonResponse({ detail: "failed" }, 503)],
+    [
+      "domain error",
+      jsonResponse({
+        ...successResponse,
+        state: "error",
+        best_time: null,
+        hotels: null,
+        routes: null,
+        unavailable: { reason: "Provider timeout", recoverable: true },
+      }),
+    ],
+  ])("offers a retry after %s", async (_name, failedResponse) => {
+    const fetchMock = mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      failedResponse,
+      jsonResponse(successResponse)
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    expect(
+      await screen.findByText("We could not analyze this trip.")
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByText("Trip analysis ready")).toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+  });
+});

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -69,3 +69,37 @@ export type RequestOptions = {
   mode?: MockMode;
   signal?: AbortSignal;
 };
+
+export type ExecutionMode = "fixture" | "live";
+
+export type TripAnalysisRequest = {
+  mode: "curated";
+  origin_latitude: number;
+  origin_longitude: number;
+  destination_latitude: number;
+  destination_longitude: number;
+  landmark_name: "The Alamo";
+  district_name: "Downtown San Antonio";
+  date: string;
+  hour: number;
+  cautious: boolean;
+  execution_mode: ExecutionMode;
+};
+
+export type TripAnalysisResponse = {
+  request_identity: string;
+  mode: "curated";
+  execution_mode: ExecutionMode;
+  state: "success" | "degraded" | "unavailable" | "error";
+  best_time: Record<string, unknown> | null;
+  hotels: Record<string, unknown> | null;
+  routes: Record<string, unknown> | null;
+  unavailable: { reason: string; recoverable: boolean } | null;
+  degraded_reasons: Record<string, string> | null;
+};
+
+export type CuratedTripSetup = {
+  date: string;
+  hour: number;
+  cautious: boolean;
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,5 +5,9 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    proxy: {
+      "/health": "http://127.0.0.1:8000",
+      "/api": "http://127.0.0.1:8000",
+    },
   },
 });

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -63,7 +63,11 @@ def test_invalid_boolean_returns_client_error() -> None:
             }
         ).encode()
         try:
-            urlopen(Request(f"http://127.0.0.1:{server.server_port}/api/heatmap", data=body, method="POST"))
+            urlopen(
+                Request(
+                    f"http://127.0.0.1:{server.server_port}/api/heatmap", data=body, method="POST"
+                )
+            )
         except HTTPError as error:
             assert error.code == 400
             assert json.load(error)["status"] == "error"
@@ -79,7 +83,11 @@ def test_non_object_json_body_returns_client_error() -> None:
     thread.start()
     try:
         try:
-            urlopen(Request(f"http://127.0.0.1:{server.server_port}/api/heatmap", data=b"[]", method="POST"))
+            urlopen(
+                Request(
+                    f"http://127.0.0.1:{server.server_port}/api/heatmap", data=b"[]", method="POST"
+                )
+            )
         except HTTPError as error:
             assert error.code == 400
             assert json.load(error)["status"] == "error"
@@ -107,7 +115,7 @@ def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> No
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown San Antonio",
                 "date": "2026-08-23",
-                "hour": 14,
+                "hour": 8,
             }
         ).encode()
         response = urlopen(
@@ -136,6 +144,45 @@ def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> No
         thread.join(timeout=2)
 
 
+def test_trip_analysis_endpoint_returns_unavailable_for_unmatched_hour() -> None:
+    server = create_fixture_server(
+        Path("fixtures/heatmap-historical.json"),
+        trip_adapter=FixtureTripAnalysisAdapter(Path("fixtures/trip-analysis.json")),
+    )
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = json.dumps(
+            {
+                "origin_latitude": 29.421,
+                "origin_longitude": -98.491,
+                "destination_latitude": 29.425,
+                "destination_longitude": -98.484,
+                "mode": "curated",
+                "landmark_name": "The Alamo",
+                "district_name": "Downtown San Antonio",
+                "date": "2026-08-23",
+                "hour": 9,
+            }
+        ).encode()
+        response = urlopen(
+            Request(
+                f"http://127.0.0.1:{server.server_port}/api/trip/analyze",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+        )
+
+        result = json.load(response)
+        assert result["state"] == "unavailable"
+        assert result["unavailable"]["reason"] == ("no matching fixture for the requested trip")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_trip_analysis_returns_explicit_unavailable_contract() -> None:
     server = create_fixture_server(
         Path("fixtures/heatmap-historical.json"),
@@ -144,29 +191,36 @@ def test_trip_analysis_returns_explicit_unavailable_contract() -> None:
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        body = json.dumps({
-            "mode": "exploratory",
-            "execution_mode": "fixture",
-            "origin_latitude": 29.421,
-            "origin_longitude": -98.491,
-            "destination_latitude": 29.425,
-            "destination_longitude": -98.484,
-            "landmark_name": "The Alamo",
-            "district_name": "Downtown San Antonio",
-            "date": "2026-08-23",
-            "hour": 14,
-        }).encode()
-        response = urlopen(Request(
-            f"http://127.0.0.1:{server.server_port}/api/trip/analyze",
-            data=body,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        ))
+        body = json.dumps(
+            {
+                "mode": "exploratory",
+                "execution_mode": "fixture",
+                "origin_latitude": 29.421,
+                "origin_longitude": -98.491,
+                "destination_latitude": 29.425,
+                "destination_longitude": -98.484,
+                "landmark_name": "The Alamo",
+                "district_name": "Downtown San Antonio",
+                "date": "2026-08-23",
+                "hour": 14,
+            }
+        ).encode()
+        response = urlopen(
+            Request(
+                f"http://127.0.0.1:{server.server_port}/api/trip/analyze",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+        )
         result = json.load(response)
         assert result["state"] == "unavailable"
         assert result["mode"] == "exploratory"
         assert result["best_time"] is None
-        assert result["unavailable"]["reason"] == "no matching fixture for the requested exploratory trip"
+        assert (
+            result["unavailable"]["reason"]
+            == "no matching fixture for the requested exploratory trip"
+        )
     finally:
         server.shutdown()
         server.server_close()
@@ -181,30 +235,41 @@ def test_trip_analysis_rejects_untrusted_metric_and_provenance_fields() -> None:
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        body = json.dumps({
-            "origin_latitude": 29.4210,
-            "origin_longitude": -98.4906,
-            "destination_latitude": 29.4255,
-            "destination_longitude": -98.4836,
-            "mode": "curated",
-            "landmark_name": "The Alamo",
-            "district_name": "Downtown San Antonio",
-            "date": "2026-08-23",
-            "hour": 14,
-            "heat_metric": "heat_index_celsius",
-            "heat_value": 38,
-            "heat_threshold": 35,
-            "building_coverage": 0.9,
-            "hotels": [
-                {"identity": "a", "components": {"night": 30, "hot_hours": 5, "persistence": 2, "day": 32}},
-            ],
-            "routes": [
-                {"identity": "r1", "distance_m": 1000, "duration_s": 600},
-            ],
-            "shade": {"r1": 50},
-        }).encode()
+        body = json.dumps(
+            {
+                "origin_latitude": 29.4210,
+                "origin_longitude": -98.4906,
+                "destination_latitude": 29.4255,
+                "destination_longitude": -98.4836,
+                "mode": "curated",
+                "landmark_name": "The Alamo",
+                "district_name": "Downtown San Antonio",
+                "date": "2026-08-23",
+                "hour": 14,
+                "heat_metric": "heat_index_celsius",
+                "heat_value": 38,
+                "heat_threshold": 35,
+                "building_coverage": 0.9,
+                "hotels": [
+                    {
+                        "identity": "a",
+                        "components": {"night": 30, "hot_hours": 5, "persistence": 2, "day": 32},
+                    },
+                ],
+                "routes": [
+                    {"identity": "r1", "distance_m": 1000, "duration_s": 600},
+                ],
+                "shade": {"r1": 50},
+            }
+        ).encode()
         with pytest.raises(HTTPError) as caught:
-            urlopen(Request(f"http://127.0.0.1:{server.server_port}/api/trip/analyze", data=body, method="POST"))
+            urlopen(
+                Request(
+                    f"http://127.0.0.1:{server.server_port}/api/trip/analyze",
+                    data=body,
+                    method="POST",
+                )
+            )
         assert caught.value.code == 400
         assert json.load(caught.value)["status"] == "error"
     finally:
@@ -221,14 +286,27 @@ def test_trip_analysis_rejects_malformed_adapter_response() -> None:
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        body = json.dumps({
-            "origin_latitude": 29.421, "origin_longitude": -98.491,
-            "destination_latitude": 29.425, "destination_longitude": -98.484,
-            "mode": "curated", "landmark_name": "The Alamo",
-            "district_name": "Downtown San Antonio", "date": "2026-08-23", "hour": 14,
-        }).encode()
+        body = json.dumps(
+            {
+                "origin_latitude": 29.421,
+                "origin_longitude": -98.491,
+                "destination_latitude": 29.425,
+                "destination_longitude": -98.484,
+                "mode": "curated",
+                "landmark_name": "The Alamo",
+                "district_name": "Downtown San Antonio",
+                "date": "2026-08-23",
+                "hour": 14,
+            }
+        ).encode()
         with pytest.raises(HTTPError) as caught:
-            urlopen(Request(f"http://127.0.0.1:{server.server_port}/api/trip/analyze", data=body, method="POST"))
+            urlopen(
+                Request(
+                    f"http://127.0.0.1:{server.server_port}/api/trip/analyze",
+                    data=body,
+                    method="POST",
+                )
+            )
         assert caught.value.code == 400
         assert "invalid response" in json.load(caught.value)["error"]
     finally:
@@ -253,7 +331,9 @@ def test_missing_fixture_returns_service_unavailable_not_client_error() -> None:
         ).encode()
         with pytest.raises(HTTPError) as caught:
             urlopen(
-                Request(f"http://127.0.0.1:{server.server_port}/api/heatmap", data=body, method="POST")
+                Request(
+                    f"http://127.0.0.1:{server.server_port}/api/heatmap", data=body, method="POST"
+                )
             )
         assert caught.value.code == 503
         assert json.load(caught.value)["status"] == "unavailable"

--- a/tests/test_trip_adapters.py
+++ b/tests/test_trip_adapters.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from dataclasses import asdict
+from dataclasses import asdict, replace
 import json
 from pathlib import Path
 
@@ -28,7 +28,7 @@ def _request() -> TripAnalysisRequest:
         landmark_name="The Alamo",
         district_name="Downtown San Antonio",
         date="2026-08-23",
-        hour=14,
+        hour=8,
         cautious=False,
     )
 
@@ -45,9 +45,7 @@ def test_fixture_and_live_adapters_return_the_same_domain_shape() -> None:
     fixture = FixtureTripAnalysisAdapter(Path("fixtures/trip-analysis.json")).analyze(
         _request(), ExecutionMode.FIXTURE
     )
-    live = LiveTripAnalysisAdapter(lambda request: payload).analyze(
-        _request(), ExecutionMode.LIVE
-    )
+    live = LiveTripAnalysisAdapter(lambda request: payload).analyze(_request(), ExecutionMode.LIVE)
 
     fixture_dict = asdict(fixture)
     live_dict = asdict(live)
@@ -64,6 +62,16 @@ def test_fixture_and_live_adapters_return_the_same_domain_shape() -> None:
     assert live.best_time.provenance.source == "live"
 
 
+def test_fixture_adapter_returns_unavailable_for_unmatched_hour() -> None:
+    response = FixtureTripAnalysisAdapter(Path("fixtures/trip-analysis.json")).analyze(
+        replace(_request(), hour=9), ExecutionMode.FIXTURE
+    )
+
+    assert response.state is ResultState.UNAVAILABLE
+    assert response.unavailable is not None
+    assert response.unavailable.reason == "no matching fixture for the requested trip"
+
+
 def test_live_adapter_rejects_non_object_payload() -> None:
     adapter = LiveTripAnalysisAdapter(lambda request: [])  # type: ignore[arg-type,return-value]
     with pytest.raises(ValueError, match="must return an object"):
@@ -78,9 +86,7 @@ def test_live_adapter_rejects_non_object_payload() -> None:
         ("routes", "recommended_id"),
     ],
 )
-def test_serialized_required_strings_are_not_coerced(
-    section: str, field: str
-) -> None:
+def test_serialized_required_strings_are_not_coerced(section: str, field: str) -> None:
     payload = _payload()
     section_payload = payload[section]
     assert isinstance(section_payload, dict)


### PR DESCRIPTION
## Summary
- make the curated Menger Hotel to The Alamo Trip Setup the root experience
- discover fixture/live execution mode and submit one validated product-level trip request
- represent loading, ready, degraded, unavailable, malformed, and retry states responsively
- match fixture replay by hour so unmatched valid inputs return explicit unavailability

## Verification
- frontend typecheck
- frontend tests: 16 passed
- frontend production build
- Ruff and mypy
- Python tests: 331 passed
- repository formatting
- two-axis code review with findings addressed

## Limitation
- focused runtime browser checks at 375px and 1024px were not run because no browser executable or existing browser automation framework is available in the workspace

Closes #15