### PR TITLE
feat(heatmap): implement normalization and spatial lookup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
   "singleQuote": false,
   "trailingComma": "es5",
   "semi": true,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "endOfLine": "auto"
 }

--- a/app/api.py
+++ b/app/api.py
@@ -31,10 +31,13 @@ from app.services.execution import EnvParamsExecution, HeatmapExecution, Unavail
 
 
 def _result_json(result: Any) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "tiles": [asdict(tile) for tile in result.tiles],
         "provenance": asdict(result.provenance),
     }
+    if result.activity is not None:
+        payload["activity"] = asdict(result.activity)
+    return payload
 
 
 def _json_default(value: object) -> object:

--- a/app/conversion.py
+++ b/app/conversion.py
@@ -1,0 +1,50 @@
+"""Centralized temperature unit conversion with full provenance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TemperatureConversion:
+    """Result of a temperature unit normalization."""
+
+    original_value: float
+    original_unit: str
+    normalized_value: float
+    normalized_unit: str
+    converted: bool
+    unit_provenance: str  # "explicit" or "inferred"
+
+
+def fahrenheit_to_celsius(value: float) -> float:
+    """Convert Fahrenheit to Celsius without changing numerical precision."""
+    return (value - 32) * 5 / 9
+
+
+def normalize_temperature(
+    value: float,
+    *,
+    source_unit: str,
+    unit_provenance: str,
+) -> TemperatureConversion:
+    """Normalize a temperature value to Celsius, preserving original provenance."""
+    if source_unit == "F":
+        return TemperatureConversion(
+            original_value=value,
+            original_unit="F",
+            normalized_value=fahrenheit_to_celsius(value),
+            normalized_unit="C",
+            converted=True,
+            unit_provenance=unit_provenance,
+        )
+    if source_unit == "C":
+        return TemperatureConversion(
+            original_value=value,
+            original_unit="C",
+            normalized_value=value,
+            normalized_unit="C",
+            converted=False,
+            unit_provenance=unit_provenance,
+        )
+    raise ValueError(f"unsupported temperature unit: {source_unit}")

--- a/app/domain/analysis.py
+++ b/app/domain/analysis.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import math
 from typing import Mapping, Sequence
 
@@ -10,6 +10,7 @@ from pyproj import CRS, Transformer
 from shapely.ops import transform
 from shapely.geometry import LineString, Point
 from shapely.geometry.base import BaseGeometry
+from shapely.ops import polygonize, unary_union
 
 
 @dataclass(frozen=True)
@@ -52,6 +53,7 @@ def extract_exposure(
         raise ValueError("exposure response is missing freshness")
     if forecast:
         raise ValueError("historical exposure context cannot be forecast")
+
     expected_unit = "C" if metric == "tcm" else "hours"
     if payload.get("unit") != expected_unit:
         raise ValueError(f"{metric} exposure must use {expected_unit}")
@@ -70,11 +72,29 @@ def extract_exposure(
 
 
 @dataclass(frozen=True)
+class SpatialMetadata:
+    metric: str | None = None
+    unit: str | None = None
+    source: str | None = None
+    valid_time: str | None = None
+    forecast: bool | None = None
+    threshold_celsius: float | None = None
+    direction: str | None = None
+    activity_id: str | None = None
+    unit_source: str | None = None
+    source_value: float | None = None
+    source_unit: str | None = None
+    converted: bool | None = None
+
+
+@dataclass(frozen=True)
 class SpatialMatch:
     value: float | None
     coverage: float
     quality: str
     projected_crs: str
+    conflict_coverage: float = 0.0
+    metadata: SpatialMetadata | None = None
 
 
 def polygon_join_contract(
@@ -103,6 +123,7 @@ class PointMatch:
     value: float | None
     quality: str
     distance_m: float | None
+    metadata: SpatialMetadata | None = None
 
 
 @dataclass(frozen=True)
@@ -110,6 +131,7 @@ class TileGeometry:
     identity: str
     geometry: BaseGeometry
     value: float
+    metadata: SpatialMetadata = SpatialMetadata()
 
 
 def point_join_contract(
@@ -141,59 +163,186 @@ def _project(geometry: BaseGeometry, crs: CRS) -> BaseGeometry:
     return transform(transformer.transform, geometry)
 
 
+def _merged_metadata(tiles: Sequence[TileGeometry]) -> SpatialMetadata | None:
+    if not tiles:
+        return None
+    metadata = tiles[0].metadata
+    comparable = replace(metadata, source_value=None)
+    if any(replace(tile.metadata, source_value=None) != comparable for tile in tiles[1:]):
+        return None
+    source_value = metadata.source_value
+    if any(tile.metadata.source_value != source_value for tile in tiles[1:]):
+        source_value = None
+    return replace(metadata, source_value=source_value)
+
+
 def join_polygon_to_tiles(target: BaseGeometry, tiles: Sequence[TileGeometry]) -> SpatialMatch:
     if not target.is_valid or target.is_empty or target.area == 0:
         raise ValueError("target geometry is invalid")
     crs = _local_crs(target)
     projected_target = _project(target, crs)
-    weighted_value = 0.0
-    overlap_area = 0.0
-    for tile in tiles:
+    intersections: list[tuple[BaseGeometry, float, TileGeometry]] = []
+    for tile in _unique_tiles(tiles):
         if not tile.geometry.is_valid or tile.geometry.is_empty:
             raise ValueError(f"tile {tile.identity} geometry is invalid")
-        intersection_area = projected_target.intersection(_project(tile.geometry, crs)).area
-        if intersection_area > 0:
-            weighted_value += tile.value * intersection_area
-            overlap_area += intersection_area
-    if overlap_area == 0:
+        intersection = projected_target.intersection(_project(tile.geometry, crs))
+        if intersection.area > 0:
+            intersections.append((intersection, tile.value, tile))
+    if not intersections:
         return SpatialMatch(None, 0.0, "no_overlap", crs.to_string())
-    coverage = min(1.0, overlap_area / projected_target.area)
+    covered = unary_union([intersection for intersection, _, _ in intersections])
+    weighted_value = 0.0
+    weighted_source_value = 0.0
+    has_aggregate_source_value = True
+    conflict_area = 0.0
+    for region in _coverage_regions([(i, v) for i, v, _ in intersections]):
+        covering_tiles = [
+            (value, tile)
+            for intersection, value, tile in intersections
+            if intersection.covers(region.representative_point())
+        ]
+        covering_values = [value for value, _ in covering_tiles]
+        if len(set(covering_values)) > 1:
+            conflict_area += region.area
+        else:
+            weighted_value += covering_values[0] * region.area
+            source_value = covering_tiles[0][1].metadata.source_value
+            if source_value is None or any(
+                tile.metadata.source_value != source_value for _, tile in covering_tiles[1:]
+            ):
+                has_aggregate_source_value = False
+            else:
+                weighted_source_value += source_value * region.area
+    coverage = min(1.0, max(0.0, covered.area / projected_target.area))
+    conflict_coverage = min(1.0, max(0.0, conflict_area / projected_target.area))
+    if conflict_area > 0:
+        return SpatialMatch(
+            None,
+            coverage,
+            "conflicting_overlap",
+            crs.to_string(),
+            conflict_coverage,
+        )
     quality = "complete" if coverage >= 0.95 else "partial"
-    return SpatialMatch(weighted_value / overlap_area, coverage, quality, crs.to_string())
+    metadata = _merged_metadata([tile for _, _, tile in intersections])
+    if metadata is None:
+        return SpatialMatch(None, coverage, "mixed_provenance", crs.to_string())
+    if has_aggregate_source_value:
+        metadata = replace(metadata, source_value=weighted_source_value / covered.area)
+    return SpatialMatch(
+        weighted_value / covered.area,
+        coverage,
+        quality,
+        crs.to_string(),
+        metadata=metadata,
+    )
+
+
+def _coverage_regions(intersections: Sequence[tuple[BaseGeometry, float]]) -> list[BaseGeometry]:
+    covered = unary_union([intersection for intersection, _ in intersections])
+    boundaries = unary_union([intersection.boundary for intersection, _ in intersections])
+    return [
+        region for region in polygonize(boundaries) if covered.covers(region.representative_point())
+    ]
+
+
+def _unique_tiles(tiles: Sequence[TileGeometry]) -> list[TileGeometry]:
+    unique: list[TileGeometry] = []
+    identities: dict[str, TileGeometry] = {}
+    for tile in tiles:
+        existing = identities.get(tile.identity)
+        if existing is not None and (
+            not existing.geometry.equals(tile.geometry)
+            or existing.value != tile.value
+            or existing.metadata != tile.metadata
+        ):
+            raise ValueError(f"tile {tile.identity} has conflicting duplicates")
+        identities[tile.identity] = tile
+        if not any(
+            existing.geometry.equals(tile.geometry)
+            and existing.value == tile.value
+            and existing.metadata == tile.metadata
+            for existing in unique
+        ):
+            unique.append(tile)
+    return unique
 
 
 def join_point_to_tiles(
     point: Point,
     tiles: Sequence[TileGeometry],
     *,
+    aoi: BaseGeometry,
     nearest_max_distance_m: float | None = None,
 ) -> PointMatch:
-    if not point.is_valid or point.is_empty:
+    if nearest_max_distance_m is not None and (
+        not math.isfinite(nearest_max_distance_m) or nearest_max_distance_m < 0
+    ):
+        raise ValueError("nearest fallback distance must be finite and non-negative")
+    if not isinstance(point, Point) or not point.is_valid or point.is_empty:
         raise ValueError("point geometry is invalid")
-    for tile in tiles:
-        if not tile.geometry.is_valid:
+    if not aoi.is_valid or aoi.is_empty or aoi.area == 0:
+        raise ValueError("AOI geometry is invalid")
+    if not aoi.covers(point):
+        return PointMatch(None, "outside_aoi", None)
+    boundary_tiles: list[TileGeometry] = []
+    containing_tiles: list[TileGeometry] = []
+    unique_tiles = _unique_tiles(tiles)
+    for tile in unique_tiles:
+        if not tile.geometry.is_valid or tile.geometry.is_empty:
             raise ValueError(f"tile {tile.identity} geometry is invalid")
         if tile.geometry.boundary.covers(point):
-            return PointMatch(tile.value, "boundary", 0.0)
+            boundary_tiles.append(tile)
         if tile.geometry.contains(point):
-            return PointMatch(tile.value, "containing_tile", 0.0)
-    if nearest_max_distance_m is None or not tiles:
-        return PointMatch(None, "outside_aoi", None)
+            containing_tiles.append(tile)
+    matched_values = [t.value for t in containing_tiles] + [t.value for t in boundary_tiles]
+    all_matched = containing_tiles + boundary_tiles
+    if boundary_tiles:
+        value = matched_values[0] if len(set(matched_values)) == 1 else None
+        metadata = _merged_metadata(all_matched) if value is not None else None
+        quality = "mixed_provenance" if value is not None and metadata is None else "boundary"
+        return PointMatch(value if metadata is not None else None, quality, 0.0, metadata)
+    if containing_tiles:
+        value = (
+            containing_tiles[0].value if len(set(t.value for t in containing_tiles)) == 1 else None
+        )
+        quality = "containing_tile" if value is not None else "overlapping_tiles"
+        metadata = _merged_metadata(containing_tiles) if value is not None else None
+        if value is not None and metadata is None:
+            return PointMatch(None, "mixed_provenance", 0.0)
+        return PointMatch(value, quality, 0.0, metadata)
+    if nearest_max_distance_m is None or not unique_tiles:
+        return PointMatch(None, "no_match", None)
     crs = _local_crs(point)
     projected_point = _project(point, crs)
-    nearest_tile, distance = min(
-        ((tile, projected_point.distance(_project(tile.geometry, crs))) for tile in tiles),
-        key=lambda match: match[1],
-    )
+    distances = [
+        (tile, projected_point.distance(_project(tile.geometry, crs))) for tile in unique_tiles
+    ]
+    distance = min(candidate_distance for _, candidate_distance in distances)
     if distance <= nearest_max_distance_m:
-        return PointMatch(nearest_tile.value, "nearest_fallback", distance)
-    return PointMatch(None, "outside_aoi", distance)
+        nearest_tiles = [
+            tile
+            for tile, candidate_distance in distances
+            if math.isclose(candidate_distance, distance, abs_tol=1e-6)
+        ]
+        nearest_values = {tile.value for tile in nearest_tiles}
+        if len(nearest_values) > 1:
+            return PointMatch(None, "nearest_fallback_ambiguous", distance)
+        metadata = _merged_metadata(nearest_tiles)
+        if metadata is None:
+            return PointMatch(None, "mixed_provenance", distance)
+        return PointMatch(nearest_values.pop(), "nearest_fallback", distance, metadata)
+    return PointMatch(None, "no_match", distance)
 
 
 def build_aoi(points: Sequence[Point], *, buffer_m: float, corridor: bool = False) -> BaseGeometry:
     if not points or buffer_m <= 0:
         raise ValueError("AOI requires points and a positive buffer")
-    source: BaseGeometry = LineString(points) if corridor else LineString(points).convex_hull
+    if corridor and len(points) < 2:
+        raise ValueError("corridor AOI requires at least two points")
+    source: BaseGeometry = LineString(points) if len(points) > 1 else points[0]
+    if not corridor and len(points) > 1:
+        source = source.convex_hull
     crs = _local_crs(source)
     projected = _project(source, crs).buffer(buffer_m)
     inverse = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)

--- a/app/integrations/fortyguard/contracts.py
+++ b/app/integrations/fortyguard/contracts.py
@@ -6,12 +6,23 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from enum import Enum
 import math
-from typing import Mapping, Sequence
+from typing import Literal, Mapping, Sequence
 
-from shapely.geometry import shape
+from shapely.geometry import Point, shape
+from shapely.geometry.base import BaseGeometry
 
+from app.conversion import normalize_temperature
+from app.domain.analysis import (
+    PointMatch,
+    SpatialMatch,
+    SpatialMetadata,
+    TileGeometry,
+    join_point_to_tiles,
+    join_polygon_to_tiles,
+)
 from app.domain.provenance import Provenance, Transformation
 from app.domain.security import sanitize_payload
+from app.integrations.fortyguard.client import ActivityMetadata
 
 PROVIDER_CONFIG_VERSION = "fortyguard-config-v1"
 """Provider/request-construction semantics a response was produced under (ADR 0004)."""
@@ -301,18 +312,79 @@ class Tile:
     threshold_celsius: float | None = None
     direction: str | None = None
     activity_id: str | None = None
+    unit_source: Literal["explicit", "inferred"] = "explicit"
+    source_value: float | None = None
+    source_unit: str | None = None
+    converted: bool = False
 
 
 @dataclass(frozen=True)
 class HeatmapResult:
     tiles: tuple[Tile, ...]
     provenance: Provenance
+    activity: ActivityMetadata | None = None
+
+    def _spatial_tiles(self) -> list[TileGeometry]:
+        return [
+            TileGeometry(
+                tile.identity,
+                _tile_shape(tile),
+                tile.metric_value,
+                SpatialMetadata(
+                    metric=tile.metric.value,
+                    unit=tile.unit,
+                    source=tile.source,
+                    valid_time=tile.valid_time.isoformat(),
+                    forecast=tile.forecast,
+                    threshold_celsius=tile.threshold_celsius,
+                    direction=tile.direction,
+                    activity_id=tile.activity_id,
+                    unit_source=tile.unit_source,
+                    source_value=tile.source_value,
+                    source_unit=tile.source_unit,
+                    converted=tile.converted,
+                ),
+            )
+            for tile in self.tiles
+        ]
+
+    def point_lookup(
+        self,
+        point: Point,
+        *,
+        aoi: BaseGeometry,
+        nearest_max_distance_m: float | None = None,
+    ) -> PointMatch:
+        """Look up one point without making another provider request."""
+        return join_point_to_tiles(
+            point,
+            self._spatial_tiles(),
+            aoi=aoi,
+            nearest_max_distance_m=nearest_max_distance_m,
+        )
+
+    def polygon_lookup(self, target: BaseGeometry) -> SpatialMatch:
+        """Return an area-weighted lookup for a polygon in a local projected CRS."""
+        return join_polygon_to_tiles(target, self._spatial_tiles())
+
+
+def _tile_shape(tile: Tile) -> BaseGeometry:
+    try:
+        return shape(tile.geometry)
+    except (TypeError, ValueError):
+        raise ValueError(f"tile {tile.identity} geometry is invalid") from None
 
 
 def _parse_datetime(value: object) -> datetime:
     if not isinstance(value, str):
         raise ValueError("missing freshness metadata")
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError("malformed freshness metadata") from None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("malformed freshness metadata")
+    return parsed
 
 
 def normalize_heatmap_response(
@@ -321,6 +393,8 @@ def normalize_heatmap_response(
     request: HeatmapRequest,
     retrieved_at: datetime,
     activity_id: str | None = None,
+    activity: ActivityMetadata | None = None,
+    inferred_unit: str | None = None,
     source: str = "provider",
     data_date: str | None = None,
     transformations: tuple[Transformation, ...] = (),
@@ -332,7 +406,20 @@ def normalize_heatmap_response(
     stale-labelled fixture fallbacks and date-relaxed forecast replays
     (ADR 0004).
     """
-    features = payload.get("features")
+    if activity is not None:
+        if activity_id is not None and activity_id != activity.activity_id:
+            raise ValueError("activity metadata does not match activity id")
+        activity_id = activity.activity_id
+    map_data = payload.get("map_data")
+    if map_data is not None and not isinstance(map_data, Mapping):
+        raise ValueError("malformed heatmap map data")
+    feature_collection = map_data if isinstance(map_data, Mapping) else payload
+    if map_data is not None:
+        if feature_collection.get("type") != "FeatureCollection":
+            raise ValueError("malformed heatmap feature collection")
+    elif feature_collection.get("type") not in (None, "FeatureCollection"):
+        raise ValueError("malformed heatmap feature collection")
+    features = feature_collection.get("features")
     if not isinstance(features, Sequence) or isinstance(features, (str, bytes)) or not features:
         raise ValueError("heatmap response contains no features")
     payload_mode = payload.get("mode")
@@ -344,6 +431,15 @@ def normalize_heatmap_response(
     units: set[str] = set()
     for index, feature in enumerate(features):
         if not isinstance(feature, Mapping):
+            raise ValueError("malformed heatmap feature")
+        if map_data is not None and feature.get("type") != "Feature":
+            raise ValueError("malformed heatmap feature")
+        if map_data is None and "type" in feature and feature.get("type") != "Feature":
+            raise ValueError("malformed heatmap feature")
+        if (
+            feature_collection.get("type") == "FeatureCollection"
+            and feature.get("type") != "Feature"
+        ):
             raise ValueError("malformed heatmap feature")
         geometry = feature.get("geometry")
         properties = feature.get("properties")
@@ -359,19 +455,30 @@ def normalize_heatmap_response(
         metric = properties.get("metric", request.analytic_type.value)
         if metric != request.analytic_type.value:
             raise ValueError("unknown or mismatched metric")
-        value = properties.get("value")
-        unit = properties.get("unit")
+        valid_time = _parse_datetime(properties.get("valid_time"))
+        value, unit, unit_source = _metric_value(properties, request.analytic_type, inferred_unit)
         expected_unit = "C" if request.analytic_type is AnalyticType.TCM else "hours"
         if (
             isinstance(value, bool)
             or not isinstance(value, (int, float))
             or not math.isfinite(value)
-            or unit != expected_unit
         ):
             raise ValueError("mixed or unsupported units")
-        valid_time = _parse_datetime(properties.get("valid_time"))
-        units.add(unit)
         numeric_value = float(value)
+        source_value = numeric_value
+        source_unit = _canonical_unit(unit, request.analytic_type)
+        converted = False
+        if request.analytic_type is AnalyticType.TCM and source_unit == "F":
+            conversion = normalize_temperature(
+                numeric_value,
+                source_unit=source_unit,
+                unit_provenance=unit_source,
+            )
+            numeric_value = conversion.normalized_value
+            converted = conversion.converted
+        elif source_unit != expected_unit:
+            raise ValueError("mixed or unsupported units")
+        units.add(source_unit)
         tiles.append(
             Tile(
                 str(properties.get("id", index)),
@@ -379,13 +486,17 @@ def normalize_heatmap_response(
                 request.analytic_type,
                 numeric_value if request.analytic_type is AnalyticType.TCM else None,
                 numeric_value,
-                unit,
+                expected_unit,
                 source,
                 valid_time,
                 request.forecast,
                 request.threshold_celsius,
                 request.direction,
                 activity_id,
+                unit_source,
+                source_value,
+                source_unit,
+                converted,
             )
         )
     if len(units) != 1:
@@ -405,7 +516,65 @@ def normalize_heatmap_response(
             sanitized_payload,
             transformations,
         ),
+        activity,
     )
+
+
+def _metric_value(
+    properties: Mapping[str, object],
+    analytic_type: AnalyticType,
+    inferred_unit: str | None,
+) -> tuple[object, object, Literal["explicit", "inferred"]]:
+    value = properties.get("value")
+    temperature_present = analytic_type is AnalyticType.TCM and "temperature" in properties
+    temperature = properties.get("temperature") if temperature_present else None
+    if temperature_present and (
+        isinstance(temperature, bool)
+        or not isinstance(temperature, (int, float))
+        or not math.isfinite(temperature)
+    ):
+        raise ValueError("malformed properties.temperature")
+    if value is not None and temperature_present:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+        ):
+            raise ValueError("conflicting properties.value and properties.temperature")
+        if value != temperature:
+            raise ValueError("conflicting properties.value and properties.temperature")
+    if value is None and temperature_present:
+        value = temperature
+    if value is None:
+        raise ValueError("malformed heatmap metric")
+    temperature_unit = properties.get("temperature_unit")
+    ordinary_unit = properties.get("unit")
+    if temperature_unit is not None and ordinary_unit is not None:
+        if _canonical_unit(temperature_unit, analytic_type) != _canonical_unit(
+            ordinary_unit, analytic_type
+        ):
+            raise ValueError("conflicting metric units")
+    unit = temperature_unit if temperature_unit is not None else ordinary_unit
+    if unit is None:
+        if inferred_unit is None:
+            raise ValueError("missing metric unit")
+        return value, inferred_unit, "inferred"
+    if not isinstance(unit, str) or not unit.strip():
+        raise ValueError("mixed or unsupported units")
+    return value, unit, "explicit"
+
+
+def _canonical_unit(unit: object, analytic_type: AnalyticType) -> str:
+    if not isinstance(unit, str):
+        raise ValueError("mixed or unsupported units")
+    normalized = unit.strip().lower().replace("°", "")
+    if analytic_type is AnalyticType.TCM and normalized in {"c", "celsius"}:
+        return "C"
+    if analytic_type is AnalyticType.TCM and normalized in {"f", "fahrenheit"}:
+        return "F"
+    if analytic_type is not AnalyticType.TCM and normalized == "hours":
+        return "hours"
+    raise ValueError("mixed or unsupported units")
 
 
 def _valid_geometry_coordinates(geometry: Mapping[str, object]) -> bool:

--- a/app/integrations/fortyguard/live.py
+++ b/app/integrations/fortyguard/live.py
@@ -19,7 +19,7 @@ from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform as shapely_ops_transform
 
 from app.domain.provenance import Transformation
-from app.integrations.fortyguard.client import FortyGuardClient
+from app.integrations.fortyguard.client import ActivityMetadata, FortyGuardClient
 from app.integrations.fortyguard.contracts import AnalyticType, EnvParamsRequest, HeatmapRequest
 from app.integrations.fortyguard.errors import ProviderError, ProviderErrorKind
 from app.integrations.fortyguard.transport import HttpFortyGuardTransport
@@ -38,6 +38,8 @@ class LivePayload:
     payload: Mapping[str, object]
     activity_id: str | None = None
     transformations: tuple[Transformation, ...] = ()
+    activity: ActivityMetadata | None = None
+    inferred_unit: str | None = None
 
 
 # The heatmap and env-params loaders share one payload shape; the two names
@@ -280,6 +282,7 @@ class LiveHeatmapAdapter:
             translated,
             metadata.activity_id,
             request_transformations(request),
+            metadata,
         )
 
 

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -8,12 +8,15 @@ from typing import Any, Mapping
 
 from app.domain.provenance import CacheKey, Provenance
 from app.domain.security import sanitize_payload
+from app.integrations.fortyguard.client import ActivityMetadata
 
 
 @dataclass(frozen=True)
 class CacheEntry:
     payload: Mapping[str, Any]
     provenance: Provenance
+    activity: ActivityMetadata | None = None
+    inferred_unit: str | None = None
 
 
 class CacheService:
@@ -30,16 +33,24 @@ class CacheService:
         retrieved_at: datetime,
         data_date: str,
         activity_id: str | None = None,
+        activity: ActivityMetadata | None = None,
+        inferred_unit: str | None = None,
         forecast: bool = False,
         provider_config_version: str,
     ) -> CacheKey:
         key = CacheKey.create(endpoint, schema_version, request_payload, provider_config_version)
         sanitized = sanitize_payload(response_payload)
+        if activity is not None:
+            if activity_id is not None and activity_id != activity.activity_id:
+                raise ValueError("activity metadata does not match activity id")
+            activity_id = activity.activity_id
         self._entries[key.value] = CacheEntry(
             sanitized,
             Provenance(
                 "provider", retrieved_at, data_date, False, forecast, activity_id, sanitized
             ),
+            activity,
+            inferred_unit,
         )
         return key
 
@@ -56,4 +67,6 @@ class CacheService:
                 raw_payload=entry.provenance.raw_payload,
                 forecast=entry.provenance.forecast,
             ),
+            entry.activity,
+            entry.inferred_unit,
         )

--- a/app/services/execution.py
+++ b/app/services/execution.py
@@ -106,11 +106,15 @@ class HeatmapExecution:
             transformations = (
                 loaded.transformations if isinstance(loaded, LiveHeatmapPayload) else ()
             )
+            activity = loaded.activity if isinstance(loaded, LiveHeatmapPayload) else None
+            inferred_unit = loaded.inferred_unit if isinstance(loaded, LiveHeatmapPayload) else None
             result = normalize_heatmap_response(
                 payload,
                 request=request,
                 retrieved_at=datetime.now().astimezone(),
                 activity_id=activity_id,
+                activity=activity,
+                inferred_unit=inferred_unit,
                 source="provider",
                 data_date=_fixture_data_date(payload),
                 transformations=transformations,
@@ -132,6 +136,8 @@ class HeatmapExecution:
                 retrieved_at=result.provenance.retrieved_at,
                 data_date=result.provenance.data_date,
                 activity_id=result.provenance.activity_id,
+                activity=result.activity,
+                inferred_unit=inferred_unit,
                 forecast=request.forecast,
                 provider_config_version=self.provider_config_version,
             )
@@ -155,6 +161,8 @@ class HeatmapExecution:
                     request=request,
                     retrieved_at=cached.provenance.retrieved_at,
                     activity_id=cached.provenance.activity_id,
+                    activity=cached.activity,
+                    inferred_unit=cached.inferred_unit,
                     source="cache",
                     data_date=cached.provenance.data_date,
                 )
@@ -296,7 +304,9 @@ def _fixture_data_date(payload: Mapping[str, object]) -> str:
     data_date = payload.get("data_date")
     if isinstance(data_date, str):
         return data_date
-    features = payload.get("features")
+    map_data = payload.get("map_data")
+    feature_collection = map_data if isinstance(map_data, Mapping) else payload
+    features = feature_collection.get("features")
     if isinstance(features, list) and features and isinstance(features[0], Mapping):
         properties = features[0].get("properties")
         if isinstance(properties, Mapping) and isinstance(properties.get("valid_time"), str):

--- a/docs/design/fortyguard-extraction.md
+++ b/docs/design/fortyguard-extraction.md
@@ -11,9 +11,10 @@ immediately. The client never resubmits a billable activity.
 All heat values are stored in Celsius. `tcm` is a provider temperature metric and
 is not silently labeled as NOAA Heat Index. Forecast and historical results retain
 separate status in the request and normalized provenance. Normalized tiles require
-geometry, Celsius units, and a `valid_time` freshness field. The raw sanitized
-provider payload is retained on the result for fixture/debugging use and is not
-ordinary log output.
+geometry, a provider-supplied or explicitly caller-declared unit, and a timezone-aware
+`valid_time` freshness field. Converted values retain their source value and unit;
+caller-declared units are marked inferred. The raw sanitized provider payload is
+retained on the result for fixture/debugging use and is not ordinary log output.
 
 `app.cache.CacheService` hashes the complete canonical request payload together
 with endpoint and schema version. Cache hits are explicitly marked `source=cache`
@@ -21,8 +22,13 @@ and `stale=true`; a replay is never presented as a current forecast. Activity ID
 retrieval timestamps, and data dates remain available in provenance.
 
 Spatial joins are behind an adapter boundary. Polygon joins must be area-weighted
-in a projected CRS and report coverage. Point joins distinguish containing-tile,
-boundary, outside-AOI, and nearest-distance fallback results. The base product
+in a projected CRS, avoid double-counting overlapping tiles, and report coverage.
+Conflicting values in overlapping tiles produce no aggregate value and report
+`conflicting_overlap` quality with separate conflict coverage. Contributors must
+also agree on freshness, source, activity, and conversion provenance; otherwise
+the lookup produces no aggregate value and reports `mixed_provenance` quality.
+Point joins require the requested AOI so they can distinguish containing-tile,
+boundary, coverage gaps, outside-AOI, and nearest-distance fallback results. The base product
 flow does not depend on optional enrichment: `EnrichmentPlanner` bounds selection
 by top-N and available credits, and readiness reason codes are deterministic local
 logic.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "format:check": "prettier --check .",
     "python:format:check": "uv run ruff format --check app tests",
     "python:lint": "uv run ruff check app tests",
-    "python:test": "uv run python -m pytest -q -m 'not integration'",
+    "python:test": "uv run python -m pytest -q -m \"not integration\"",
     "python:test:integration": "uv run python -m pytest -q -m integration",
     "python:typecheck": "uv run mypy app tests",
     "frontend:format:check": "prettier --check frontend",

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -317,6 +317,66 @@ def test_trip_analysis_rejects_malformed_adapter_response() -> None:
         thread.join(timeout=2)
 
 
+def test_heatmap_response_includes_complete_activity_metadata() -> None:
+    from datetime import datetime, timezone
+    from app.integrations.fortyguard.client import ActivityMetadata
+    from app.integrations.fortyguard.live import LiveHeatmapPayload
+    from app.services.execution import HeatmapExecution
+
+    payload = json.loads(Path("fixtures/heatmap-historical.json").read_text())
+    activity = ActivityMetadata(
+        "act-42",
+        datetime(2026, 8, 23, 14, tzinfo=timezone.utc),
+        "/v1/heatmap",
+        ("analytic_type", "latitude"),
+        ("Processing", "Completed"),
+        {"request_id": "req-1"},
+    )
+    execution = HeatmapExecution(
+        fixture_path=Path("fixtures/heatmap-historical.json"),
+        live_loader=lambda _: LiveHeatmapPayload(payload, activity=activity),
+    )
+    server = create_fixture_server(
+        Path("fixtures/heatmap-historical.json"),
+        execution=execution,
+        allow_live=True,
+    )
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = json.dumps(
+            {
+                "analytic_type": "tcm",
+                "latitude": 29.4241,
+                "longitude": -98.4936,
+                "start_date": "2026-08-23",
+                "forecast": False,
+                "execution_mode": "live",
+            }
+        ).encode()
+        response = urlopen(
+            Request(
+                f"http://127.0.0.1:{server.server_port}/api/heatmap",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+        )
+        result = json.load(response)
+        assert "activity" in result
+        act = result["activity"]
+        assert act["activity_id"] == "act-42"
+        assert act["endpoint"] == "/v1/heatmap"
+        assert act["request_fields"] == ["analytic_type", "latitude"]
+        assert act["status_transitions"] == ["Processing", "Completed"]
+        assert act["response_metadata"] == {"request_id": "req-1"}
+        assert "submitted_at" in act
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_missing_fixture_returns_service_unavailable_not_client_error() -> None:
     server = create_fixture_server(Path("fixtures/missing.json"))
     thread = Thread(target=server.serve_forever, daemon=True)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,45 @@
+import math
+
+import pytest
+
+from app.conversion import TemperatureConversion, fahrenheit_to_celsius, normalize_temperature
+
+
+def test_fahrenheit_to_celsius_known_values() -> None:
+    assert fahrenheit_to_celsius(32) == pytest.approx(0.0)
+    assert fahrenheit_to_celsius(212) == pytest.approx(100.0)
+    assert fahrenheit_to_celsius(95) == pytest.approx(35.0)
+
+
+def test_fahrenheit_to_celsius_preserves_precision() -> None:
+    result = fahrenheit_to_celsius(98.6)
+    assert math.isfinite(result)
+    assert result == pytest.approx(37.0, abs=0.01)
+
+
+def test_normalize_temperature_celsius_passthrough() -> None:
+    conv = normalize_temperature(35.0, source_unit="C", unit_provenance="explicit")
+    assert conv == TemperatureConversion(35.0, "C", 35.0, "C", False, "explicit")
+    assert not conv.converted
+    assert conv.unit_provenance == "explicit"
+
+
+def test_normalize_temperature_fahrenheit_conversion() -> None:
+    conv = normalize_temperature(95.0, source_unit="F", unit_provenance="explicit")
+    assert conv.original_value == 95.0
+    assert conv.original_unit == "F"
+    assert conv.normalized_value == pytest.approx(35.0)
+    assert conv.normalized_unit == "C"
+    assert conv.converted is True
+    assert conv.unit_provenance == "explicit"
+
+
+def test_normalize_temperature_inferred_provenance() -> None:
+    conv = normalize_temperature(35.0, source_unit="C", unit_provenance="inferred")
+    assert conv.unit_provenance == "inferred"
+    assert not conv.converted
+
+
+def test_normalize_temperature_rejects_unsupported_unit() -> None:
+    with pytest.raises(ValueError, match="unsupported temperature unit"):
+        normalize_temperature(300.0, source_unit="K", unit_provenance="explicit")

--- a/tests/test_fortyguard_contracts.py
+++ b/tests/test_fortyguard_contracts.py
@@ -5,7 +5,7 @@ from typing import Iterator
 
 import pytest
 
-from app.integrations.fortyguard.client import FortyGuardClient, poll_activity
+from app.integrations.fortyguard.client import ActivityMetadata, FortyGuardClient, poll_activity
 from app.integrations.fortyguard.contracts import (
     AnalyticType,
     HeatmapRequest,
@@ -89,6 +89,381 @@ def test_normalizer_accepts_valid_multipolygon_geometry() -> None:
         retrieved_at=datetime.now(timezone.utc),
     )
     assert result.tiles[0].geometry["type"] == "MultiPolygon"
+
+
+def test_normalizer_accepts_flat_analytic_value_and_preserves_conversion() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {"type": "Point", "coordinates": [-98.49, 29.42]},
+                    "properties": {
+                        "metric": "tcm",
+                        "value": 95,
+                        "unit": "F",
+                        "valid_time": "2026-08-23T15:00:00+00:00",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+    )
+    assert result.tiles[0].value_celsius == pytest.approx((95 - 32) * 5 / 9)
+    assert result.tiles[0].unit == "C"
+    assert result.tiles[0].unit_source == "explicit"
+    assert result.tiles[0].source_value == 95
+    assert result.tiles[0].source_unit == "F"
+    assert result.tiles[0].converted is True
+
+
+def test_normalizer_rejects_missing_temperature_unit_instead_of_inferring() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    with pytest.raises(ValueError, match="unit"):
+        normalize_heatmap_response(
+            {
+                "features": [
+                    {
+                        "geometry": {"type": "Point", "coordinates": [1, 1]},
+                        "properties": {"value": 35, "valid_time": "2026-08-23T15:00:00+00:00"},
+                    }
+                ]
+            },
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
+def test_normalizer_marks_caller_declared_unit_as_inferred() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {"value": 35, "valid_time": "2026-08-23T15:00:00Z"},
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+        inferred_unit="C",
+    )
+    assert result.tiles[0].unit_source == "inferred"
+    assert result.tiles[0].converted is False
+
+
+def test_normalizer_rejects_mixed_temperature_source_units() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    features = [
+        {
+            "geometry": {"type": "Point", "coordinates": [1, 1]},
+            "properties": {"value": 35, "unit": "C", "valid_time": "2026-08-23T15:00:00Z"},
+        },
+        {
+            "geometry": {"type": "Point", "coordinates": [2, 2]},
+            "properties": {"value": 95, "unit": "F", "valid_time": "2026-08-23T15:00:00Z"},
+        },
+    ]
+    with pytest.raises(ValueError, match="mixed"):
+        normalize_heatmap_response(
+            {"features": features},
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
+def test_normalizer_rejects_conflicting_unit_fields_on_one_feature() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    properties = {
+        "value": 35,
+        "unit": "F",
+        "temperature_unit": "C",
+        "valid_time": "2026-08-23T15:00:00Z",
+    }
+    with pytest.raises(ValueError, match="conflicting metric units"):
+        normalize_heatmap_response(
+            {
+                "features": [
+                    {"geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": properties}
+                ]
+            },
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
+def test_normalizer_accepts_equivalent_unit_fields_on_one_feature() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {
+                        "value": 35,
+                        "unit": "Celsius",
+                        "temperature_unit": "°C",
+                        "valid_time": "2026-08-23T15:00:00Z",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+    )
+    assert result.tiles[0].source_unit == "C"
+
+
+def test_normalizer_reads_recorded_map_data_temperature_shape() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "map_data": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [[[1, 1], [2, 1], [2, 2], [1, 1]]],
+                        },
+                        "properties": {
+                            "temperature": 36.71,
+                            "unit": "C",
+                            "valid_time": "2026-08-23T15:00:00Z",
+                        },
+                    }
+                ],
+            }
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+    )
+    assert result.tiles[0].metric_value == 36.71
+
+
+def test_recorded_map_data_without_provider_unit_or_freshness_is_rejected() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    payload = {
+        "map_data": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[1, 1], [2, 1], [2, 2], [1, 1]]],
+                    },
+                    "properties": {"temperature": 36.71},
+                }
+            ],
+        }
+    }
+    with pytest.raises(ValueError, match="freshness"):
+        normalize_heatmap_response(
+            payload, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+
+
+def test_map_data_rejects_non_feature_members() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    payload = {
+        "map_data": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Garbage",
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {
+                        "temperature": 35,
+                        "unit": "C",
+                        "valid_time": "2026-08-23T15:00:00Z",
+                    },
+                }
+            ],
+        }
+    }
+    with pytest.raises(ValueError, match="feature"):
+        normalize_heatmap_response(
+            payload, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+
+
+def test_map_data_requires_feature_collection_type() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    map_data: dict[str, object] = {
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [1, 1]},
+                "properties": {"value": 35, "unit": "C", "valid_time": "2026-08-23T15:00:00Z"},
+            }
+        ],
+    }
+    payload: dict[str, object] = {"map_data": map_data}
+    with pytest.raises(ValueError, match="feature collection"):
+        normalize_heatmap_response(
+            payload, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+    map_data["type"] = "NotAFeatureCollection"
+    with pytest.raises(ValueError, match="feature collection"):
+        normalize_heatmap_response(
+            payload, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+
+
+def test_normalizer_rejects_conflicting_value_and_temperature() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    payload = {
+        "features": [
+            {
+                "geometry": {"type": "Point", "coordinates": [1, 1]},
+                "properties": {
+                    "value": 35,
+                    "temperature": 37,
+                    "unit": "C",
+                    "valid_time": "2026-08-23T15:00:00Z",
+                },
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="conflicting properties.value and properties.temperature"):
+        normalize_heatmap_response(
+            payload, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+
+
+def test_normalizer_accepts_matching_value_and_temperature() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {
+                        "value": 35,
+                        "temperature": 35,
+                        "unit": "C",
+                        "valid_time": "2026-08-23T15:00:00Z",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+    )
+    assert result.tiles[0].metric_value == 35
+
+
+@pytest.mark.parametrize("temperature", [None, "35", {"value": 35}, [35]])  # type: ignore[misc]
+def test_normalizer_rejects_malformed_temperature_when_value_is_present(
+    temperature: object,
+) -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    payload = {
+        "features": [
+            {
+                "geometry": {"type": "Point", "coordinates": [1, 1]},
+                "properties": {
+                    "value": 35,
+                    "temperature": temperature,
+                    "unit": "C",
+                    "valid_time": "2026-08-23T15:00:00Z",
+                },
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="properties.temperature"):
+        normalize_heatmap_response(
+            payload,
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
+@pytest.mark.parametrize("feature_type", ["Garbage", None])  # type: ignore[misc]
+def test_root_features_reject_present_non_feature_type(feature_type: object) -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    payload = {
+        "features": [
+            {
+                "type": feature_type,
+                "geometry": {"type": "Point", "coordinates": [1, 1]},
+                "properties": {"value": 35, "unit": "C", "valid_time": "2026-08-23T15:00:00Z"},
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="feature"):
+        normalize_heatmap_response(
+            payload, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+
+
+def test_normalizer_rejects_missing_freshness_and_unknown_temperature_unit() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    base = {
+        "geometry": {"type": "Point", "coordinates": [1, 1]},
+        "properties": {"value": 35, "unit": "K"},
+    }
+    with pytest.raises(ValueError, match="freshness"):
+        normalize_heatmap_response(
+            {"features": [base]}, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+    base = {
+        "geometry": {"type": "Point", "coordinates": [1, 1]},
+        "properties": {"value": 35, "unit": "K", "valid_time": "2026-08-23T15:00:00+00:00"},
+    }
+    with pytest.raises(ValueError, match="units"):
+        normalize_heatmap_response(
+            {"features": [base]}, request=request, retrieved_at=datetime.now(timezone.utc)
+        )
+
+
+@pytest.mark.parametrize("valid_time", ["2026-08-23T15:00:00", "not-a-date"])  # type: ignore[misc]
+def test_normalizer_rejects_ambiguous_or_malformed_freshness(valid_time: str) -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    with pytest.raises(ValueError, match="freshness"):
+        normalize_heatmap_response(
+            {
+                "features": [
+                    {
+                        "geometry": {"type": "Point", "coordinates": [1, 1]},
+                        "properties": {"value": 35, "unit": "C", "valid_time": valid_time},
+                    }
+                ]
+            },
+            request=request,
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
+def test_normalizer_preserves_complete_activity_metadata() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    activity = ActivityMetadata(
+        "activity-1",
+        datetime(2026, 8, 23, 14, tzinfo=timezone.utc),
+        "/v1/heatmap",
+        ("analytic_type",),
+        ("Processing", "Completed"),
+        {"request_id": "request-1"},
+    )
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {"value": 35, "unit": "C", "valid_time": "2026-08-23T15:00:00Z"},
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+        activity=activity,
+    )
+    assert result.activity == activity
+    assert result.tiles[0].activity_id == "activity-1"
 
 
 def test_heatmap_request_rejects_unknown_analytic_type() -> None:
@@ -345,6 +720,91 @@ def test_live_result_preserves_activity_id_and_malformed_payload_uses_cache() ->
         cache=cache,
     ).run(request, live=True)
     assert replayed.provenance.source == "cache"
+
+
+def test_cache_replay_preserves_complete_activity_metadata() -> None:
+    from app.integrations.fortyguard.live import LiveHeatmapPayload
+    from app.services.cache import CacheService
+    from app.services.execution import HeatmapExecution
+
+    payload = json.loads((Path("fixtures") / "heatmap-historical.json").read_text())
+    activity = ActivityMetadata(
+        "live-1",
+        datetime(2026, 8, 23, tzinfo=timezone.utc),
+        "/v1/heatmap",
+        ("analytic_type",),
+        ("Completed",),
+    )
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    cache = CacheService()
+    execution = HeatmapExecution(
+        fixture_path=Path("fixtures") / "heatmap-historical.json",
+        live_loader=lambda _: LiveHeatmapPayload(payload, activity=activity),
+        cache=cache,
+    )
+    assert execution.run(request, live=True).activity == activity
+    execution.live_loader = lambda _: (_ for _ in ()).throw(ConnectionError("offline"))
+    assert execution.run(request, live=True).activity == activity
+
+
+def test_live_map_data_inferred_unit_survives_cache_replay() -> None:
+    from app.integrations.fortyguard.live import LiveHeatmapPayload
+    from app.services.cache import CacheService
+    from app.services.execution import HeatmapExecution
+
+    payload = {
+        "map_data": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[1, 1], [2, 1], [2, 2], [1, 1]]],
+                    },
+                    "properties": {"temperature": 36.71, "valid_time": "2026-08-23T15:00:00Z"},
+                }
+            ],
+        }
+    }
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    execution = HeatmapExecution(
+        fixture_path=Path("fixtures") / "heatmap-historical.json",
+        live_loader=lambda _: LiveHeatmapPayload(payload, inferred_unit="C"),
+        cache=CacheService(),
+    )
+    assert execution.run(request, live=True).tiles[0].unit_source == "inferred"
+    execution.live_loader = lambda _: (_ for _ in ()).throw(ConnectionError("offline"))
+    assert execution.run(request, live=True).tiles[0].unit_source == "inferred"
+
+
+def test_live_execution_rejects_conflicting_provider_unit_fields() -> None:
+    from app.services.execution import HeatmapExecution, UnavailableError
+
+    payload = {
+        "map_data": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [-98.4936, 29.4241]},
+                    "properties": {
+                        "temperature": 35,
+                        "temperature_unit": "C",
+                        "unit": "F",
+                        "valid_time": "2026-08-23T15:00:00Z",
+                    },
+                }
+            ],
+        }
+    }
+    execution = HeatmapExecution(
+        fixture_path=Path("fixtures") / "missing.json",
+        live_loader=lambda _: payload,
+    )
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date(2026, 8, 23), forecast=False)
+    with pytest.raises(UnavailableError, match="live heatmap request failed"):
+        execution.run(request, live=True)
 
 
 def test_live_provenance_uses_provider_freshness_date() -> None:

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -1,7 +1,22 @@
-import pytest
-from shapely.geometry import Point, Polygon
+import math
+from dataclasses import replace
+from datetime import date, datetime, timezone
 
-from app.domain.analysis import TileGeometry, build_aoi, join_point_to_tiles, join_polygon_to_tiles
+import pytest
+from shapely.geometry import MultiPolygon, Point, Polygon
+
+from app.domain.analysis import (
+    SpatialMetadata,
+    TileGeometry,
+    build_aoi,
+    join_point_to_tiles,
+    join_polygon_to_tiles,
+)
+from app.integrations.fortyguard.contracts import (
+    AnalyticType,
+    HeatmapRequest,
+    normalize_heatmap_response,
+)
 
 
 def test_polygon_join_area_weights_partial_overlap_in_projected_crs() -> None:
@@ -38,15 +53,107 @@ def test_point_join_distinguishes_containing_boundary_and_nearest_fallback() -> 
     tile = TileGeometry(
         "tile", Polygon([(-98.50, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.50, 29.43)]), 35
     )
-    assert join_point_to_tiles(Point(-98.495, 29.425), [tile]).quality == "containing_tile"
-    assert join_point_to_tiles(Point(-98.50, 29.425), [tile]).quality == "boundary"
-    fallback = join_point_to_tiles(Point(-98.4899, 29.425), [tile], nearest_max_distance_m=20)
+    aoi = Polygon([(-98.51, 29.41), (-98.48, 29.41), (-98.48, 29.44), (-98.51, 29.44)])
+    assert join_point_to_tiles(Point(-98.495, 29.425), [tile], aoi=aoi).quality == "containing_tile"
+    assert join_point_to_tiles(Point(-98.50, 29.425), [tile], aoi=aoi).quality == "boundary"
+    fallback = join_point_to_tiles(
+        Point(-98.4899, 29.425), [tile], aoi=aoi, nearest_max_distance_m=20
+    )
     assert fallback.quality == "nearest_fallback"
     assert fallback.distance_m is not None and fallback.distance_m > 0
     assert (
-        join_point_to_tiles(Point(-98.40, 29.425), [tile], nearest_max_distance_m=20).quality
+        join_point_to_tiles(
+            Point(-98.40, 29.425), [tile], aoi=aoi, nearest_max_distance_m=20
+        ).quality
         == "outside_aoi"
     )
+    assert join_point_to_tiles(Point(-98.485, 29.425), [tile], aoi=aoi).quality == "no_match"
+
+
+@pytest.mark.parametrize("distance", [-1, float("nan"), float("inf"), float("-inf")])  # type: ignore[misc]
+def test_point_join_rejects_invalid_nearest_fallback_distance(distance: float) -> None:
+    aoi = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    with pytest.raises(ValueError, match="fallback distance"):
+        join_point_to_tiles(Point(1, 1), [], aoi=aoi, nearest_max_distance_m=distance)
+
+
+def test_point_join_allows_zero_nearest_fallback_distance() -> None:
+    aoi = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    result = join_point_to_tiles(Point(1, 1), [], aoi=aoi, nearest_max_distance_m=0)
+    assert result.quality == "no_match"
+
+
+def test_point_outside_aoi_does_not_match_an_extending_tile() -> None:
+    tile = TileGeometry(
+        "wide", Polygon([(-98.6, 29.3), (-98.3, 29.3), (-98.3, 29.6), (-98.6, 29.6)]), 35
+    )
+    aoi = Polygon([(-98.5, 29.4), (-98.4, 29.4), (-98.4, 29.5), (-98.5, 29.5)])
+    assert join_point_to_tiles(Point(-98.55, 29.45), [tile], aoi=aoi).quality == "outside_aoi"
+
+
+def test_point_join_rejects_invalid_aoi() -> None:
+    invalid = Polygon([(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)])
+    with pytest.raises(ValueError, match="AOI"):
+        join_point_to_tiles(Point(0.5, 0.5), [], aoi=invalid)
+
+
+def test_point_join_rejects_non_point_input() -> None:
+    aoi = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    with pytest.raises(ValueError, match="point"):
+        join_point_to_tiles(Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), [], aoi=aoi)
+
+
+def test_point_on_shared_boundary_reports_boundary_without_hiding_ambiguity() -> None:
+    west = TileGeometry("west", Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), 30)
+    east = TileGeometry("east", Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]), 40)
+    result = join_point_to_tiles(
+        Point(1, 0.5), [west, east], aoi=Polygon([(0, 0), (2, 0), (2, 1), (0, 1)])
+    )
+    assert result.quality == "boundary"
+    assert result.value is None
+
+
+def test_point_in_overlapping_tiles_is_order_independent_and_exposes_ambiguity() -> None:
+    first = TileGeometry("first", Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), 30)
+    second = TileGeometry("second", Polygon([(1, 0), (3, 0), (3, 2), (1, 2)]), 40)
+    aoi = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+    forward = join_point_to_tiles(Point(1.5, 1), [first, second], aoi=aoi)
+    reverse = join_point_to_tiles(Point(1.5, 1), [second, first], aoi=aoi)
+    assert forward == reverse
+    assert forward.quality == "overlapping_tiles"
+    assert forward.value is None
+
+
+def test_point_inside_one_tile_and_on_another_boundary_reports_boundary() -> None:
+    containing = TileGeometry("containing", Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), 30)
+    adjoining = TileGeometry("adjoining", Polygon([(1, 0), (3, 0), (3, 1), (1, 1)]), 40)
+    aoi = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+    result = join_point_to_tiles(Point(1.5, 1), [containing, adjoining], aoi=aoi)
+    assert result.quality == "boundary"
+    assert result.value is None
+
+
+def test_equidistant_nearest_fallback_exposes_conflicting_values() -> None:
+    geometry = Polygon([(0.001, 0), (0.002, 0), (0.002, 0.001), (0.001, 0.001)])
+    west = TileGeometry("first", geometry, 30)
+    east = TileGeometry("second", geometry, 40)
+    aoi = Polygon([(-0.01, -0.01), (0.01, -0.01), (0.01, 0.01), (-0.01, 0.01)])
+    forward = join_point_to_tiles(
+        Point(0, 0.0005), [west, east], aoi=aoi, nearest_max_distance_m=200
+    )
+    reverse = join_point_to_tiles(
+        Point(0, 0.0005), [east, west], aoi=aoi, nearest_max_distance_m=200
+    )
+    assert forward == reverse
+    assert forward.quality == "nearest_fallback_ambiguous"
+    assert forward.value is None
+
+
+def test_point_join_rejects_empty_tile_geometry() -> None:
+    empty = TileGeometry("empty", Polygon(), 35)
+    aoi = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    with pytest.raises(ValueError, match="tile empty"):
+        join_point_to_tiles(Point(0.5, 0.5), [empty], aoi=aoi, nearest_max_distance_m=10)
 
 
 def test_build_aoi_handles_district_points_and_route_corridors() -> None:
@@ -54,3 +161,354 @@ def test_build_aoi_handles_district_points_and_route_corridors() -> None:
     corridor = build_aoi([Point(-98.50, 29.42), Point(-98.49, 29.43)], buffer_m=25, corridor=True)
     assert district.is_valid and corridor.is_valid
     assert district.area > corridor.area
+
+
+def test_build_aoi_buffers_one_landmark_and_rejects_one_point_corridor() -> None:
+    landmark = build_aoi([Point(-98.49, 29.42)], buffer_m=100)
+    assert landmark.is_valid and landmark.area > 0
+    with pytest.raises(ValueError, match="two points"):
+        build_aoi([Point(-98.49, 29.42)], buffer_m=25, corridor=True)
+
+
+def test_normalized_result_provides_point_and_polygon_lookup() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-98.5, 29.42],
+                                [-98.49, 29.42],
+                                [-98.49, 29.43],
+                                [-98.5, 29.43],
+                                [-98.5, 29.42],
+                            ]
+                        ],
+                    },
+                    "properties": {
+                        "value": 35,
+                        "unit": "C",
+                        "valid_time": "2026-08-23T15:00:00+00:00",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+    )
+    aoi = Polygon([(-98.5, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.5, 29.43)])
+    assert result.point_lookup(Point(-98.495, 29.425), aoi=aoi).quality == "containing_tile"
+    joined = result.polygon_lookup(
+        Polygon([(-98.5, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.5, 29.42)])
+    )
+    assert joined.value == pytest.approx(35)
+    assert joined.coverage == pytest.approx(1)
+
+
+def test_point_lookup_carries_tile_metadata_to_result() -> None:
+    request = HeatmapRequest(
+        AnalyticType.TCM,
+        29.4241,
+        -98.4936,
+        date.today(),
+        threshold_celsius=None,
+        direction=None,
+    )
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-98.5, 29.42],
+                                [-98.49, 29.42],
+                                [-98.49, 29.43],
+                                [-98.5, 29.43],
+                                [-98.5, 29.42],
+                            ]
+                        ],
+                    },
+                    "properties": {
+                        "value": 35,
+                        "unit": "C",
+                        "valid_time": "2026-08-23T15:00:00+00:00",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+        activity_id="act-1",
+    )
+    aoi = Polygon([(-98.5, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.5, 29.43)])
+    match = result.point_lookup(Point(-98.495, 29.425), aoi=aoi)
+    assert match.quality == "containing_tile"
+    assert match.value == 35
+    assert match.metadata is not None
+    assert match.metadata.metric == "tcm"
+    assert match.metadata.unit == "C"
+    assert match.metadata.source == "provider"
+    assert match.metadata.valid_time is not None
+    assert match.metadata.forecast is True
+    assert match.metadata.activity_id == "act-1"
+    assert match.metadata.unit_source == "explicit"
+    assert match.metadata.source_value == 35
+    assert match.metadata.source_unit == "C"
+    assert match.metadata.converted is False
+
+
+def test_polygon_lookup_carries_tile_metadata_to_result() -> None:
+    request = HeatmapRequest(
+        AnalyticType.EXCEEDANCE,
+        29.4241,
+        -98.4936,
+        date(2026, 8, 23),
+        forecast=False,
+        threshold_celsius=35,
+        direction="above",
+    )
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-98.5, 29.42],
+                                [-98.49, 29.42],
+                                [-98.49, 29.43],
+                                [-98.5, 29.43],
+                                [-98.5, 29.42],
+                            ]
+                        ],
+                    },
+                    "properties": {
+                        "value": 6,
+                        "unit": "hours",
+                        "valid_time": "2026-08-23T15:00:00+00:00",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+    )
+    target = Polygon([(-98.5, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.5, 29.43)])
+    match = result.polygon_lookup(target)
+    assert match.value == pytest.approx(6)
+    assert match.quality == "complete"
+    assert match.metadata is not None
+    assert match.metadata.metric == "exceedance"
+    assert match.metadata.unit == "hours"
+    assert match.metadata.forecast is False
+    assert match.metadata.threshold_celsius == 35
+    assert match.metadata.direction == "above"
+
+
+def test_lookup_preserves_inferred_and_converted_unit_provenance() -> None:
+    request = HeatmapRequest(AnalyticType.TCM, 29.4241, -98.4936, date.today())
+    result = normalize_heatmap_response(
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-98.5, 29.42],
+                                [-98.49, 29.42],
+                                [-98.49, 29.43],
+                                [-98.5, 29.43],
+                                [-98.5, 29.42],
+                            ]
+                        ],
+                    },
+                    "properties": {
+                        "temperature": 95,
+                        "valid_time": "2026-08-23T15:00:00+00:00",
+                    },
+                }
+            ]
+        },
+        request=request,
+        retrieved_at=datetime.now(timezone.utc),
+        inferred_unit="F",
+    )
+    aoi = Polygon([(-98.5, 29.42), (-98.49, 29.42), (-98.49, 29.43), (-98.5, 29.43)])
+    match = result.point_lookup(Point(-98.495, 29.425), aoi=aoi)
+
+    assert match.metadata is not None
+    assert match.metadata.unit_source == "inferred"
+    assert match.metadata.source_value == 95
+    assert match.metadata.source_unit == "F"
+    assert match.metadata.converted is True
+
+
+def test_polygon_join_rejects_mixed_contributor_provenance_regardless_of_order() -> None:
+    target = Polygon([(0, 0), (2, 0), (2, 1), (0, 1)])
+    earlier = SpatialMetadata(valid_time="2026-08-23T15:00:00+00:00")
+    later = SpatialMetadata(valid_time="2026-08-23T16:00:00+00:00")
+    west = TileGeometry("west", Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), 30, earlier)
+    east = TileGeometry("east", Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]), 30, later)
+
+    forward = join_polygon_to_tiles(target, [west, east])
+    reverse = join_polygon_to_tiles(target, [east, west])
+
+    assert forward == reverse
+    assert forward.quality == "mixed_provenance"
+    assert forward.value is None
+    assert forward.metadata is None
+
+
+def test_polygon_join_aggregates_distinct_source_values_with_shared_provenance() -> None:
+    target = Polygon([(0, 0), (2, 0), (2, 1), (0, 1)])
+    shared = SpatialMetadata(
+        valid_time="2026-08-23T15:00:00+00:00",
+        source_unit="F",
+        converted=True,
+    )
+    west = TileGeometry(
+        "west",
+        Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+        30,
+        replace(shared, source_value=86),
+    )
+    east = TileGeometry(
+        "east",
+        Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+        40,
+        replace(shared, source_value=104),
+    )
+
+    result = join_polygon_to_tiles(target, [west, east])
+
+    assert result.value == pytest.approx(35, rel=0.01)
+    assert result.metadata is not None
+    assert replace(result.metadata, source_value=None) == shared
+    assert result.metadata.source_value == pytest.approx(95, rel=0.01)
+
+
+def test_point_join_rejects_equal_values_with_mixed_provenance() -> None:
+    geometry = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    first = TileGeometry(
+        "first",
+        geometry,
+        30,
+        SpatialMetadata(valid_time="2026-08-23T15:00:00+00:00"),
+    )
+    second = TileGeometry(
+        "second",
+        geometry,
+        30,
+        SpatialMetadata(valid_time="2026-08-23T16:00:00+00:00"),
+    )
+
+    match = join_point_to_tiles(
+        Point(1, 1),
+        [first, second],
+        aoi=geometry,
+    )
+
+    assert match.quality == "mixed_provenance"
+    assert match.value is None
+    assert match.metadata is None
+
+
+def test_polygon_join_does_not_double_count_duplicate_tiles() -> None:
+    target = Polygon([(-98.5, 29.42), (-98.48, 29.42), (-98.48, 29.44), (-98.5, 29.44)])
+    west = Polygon([(-98.5, 29.42), (-98.49, 29.42), (-98.49, 29.44), (-98.5, 29.44)])
+    result = join_polygon_to_tiles(
+        target,
+        [TileGeometry("west-1", west, 30), TileGeometry("west-2", west, 40)],
+    )
+    assert result.coverage == pytest.approx(0.5, rel=0.01)
+    assert result.value is None
+    assert result.quality == "conflicting_overlap"
+    assert result.conflict_coverage == pytest.approx(0.5, rel=0.01)
+    assert 0 <= result.coverage <= 1
+
+
+def test_polygon_join_duplicate_does_not_bias_an_overlapping_pair() -> None:
+    target = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+    first = TileGeometry("first", Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), 30)
+    second = TileGeometry("second", Polygon([(1, 0), (3, 0), (3, 2), (1, 2)]), 40)
+    duplicate = TileGeometry("duplicate", first.geometry, first.value)
+    baseline = join_polygon_to_tiles(target, [first, second])
+    duplicated = join_polygon_to_tiles(target, [first, second, duplicate])
+    assert duplicated.value == pytest.approx(baseline.value)
+    assert duplicated.coverage == pytest.approx(baseline.coverage)
+
+
+def test_polygon_join_exposes_conflicting_overlap_without_synthetic_average() -> None:
+    target = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+    first = TileGeometry("first", Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), 30)
+    second = TileGeometry("second", Polygon([(1, 0), (3, 0), (3, 2), (1, 2)]), 40)
+    result = join_polygon_to_tiles(target, [first, second])
+    assert result.value is None
+    assert result.quality == "conflicting_overlap"
+    assert result.coverage == pytest.approx(1, rel=0.001)
+    assert result.conflict_coverage == pytest.approx(1 / 3, rel=0.01)
+
+
+def test_polygon_join_handles_target_hole_without_counting_uncovered_hole() -> None:
+    target = Polygon(
+        [(0, 0), (4, 0), (4, 4), (0, 4)],
+        holes=[[(1, 1), (3, 1), (3, 3), (1, 3)]],
+    )
+    tile = TileGeometry("donut", target, 35)
+    result = join_polygon_to_tiles(target, [tile])
+    assert result.value == pytest.approx(35)
+    assert result.coverage == pytest.approx(1)
+    assert result.conflict_coverage == 0
+
+
+def test_polygon_join_exposes_conflicting_multipolygon_overlap() -> None:
+    west = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    east = Polygon([(3, 0), (5, 0), (5, 2), (3, 2)])
+    target = MultiPolygon([west, east])
+    base = TileGeometry("base", target, 30)
+    conflicting = TileGeometry(
+        "conflict", MultiPolygon([Polygon([(1, 0), (2, 0), (2, 2), (1, 2)])]), 40
+    )
+    result = join_polygon_to_tiles(target, [base, conflicting])
+    assert result.value is None
+    assert result.quality == "conflicting_overlap"
+    assert result.coverage == pytest.approx(1)
+    assert 0 < result.conflict_coverage < 1
+    assert math.isfinite(result.conflict_coverage)
+
+
+def test_polygon_join_deduplicates_topologically_equivalent_rings() -> None:
+    target = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+    first = TileGeometry("first", Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), 30)
+    reversed_ring = TileGeometry("reversed", Polygon([(2, 2), (2, 0), (0, 0), (0, 2)]), 30)
+    second = TileGeometry("second", Polygon([(1, 0), (3, 0), (3, 2), (1, 2)]), 40)
+    baseline = join_polygon_to_tiles(target, [first, second])
+    duplicated = join_polygon_to_tiles(target, [first, reversed_ring, second])
+    assert duplicated == baseline
+
+
+def test_polygon_join_deduplicates_equivalent_geometry_with_extra_vertex() -> None:
+    target = Polygon([(0, 0), (3, 0), (3, 2), (0, 2)])
+    first = TileGeometry("first", Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), 30)
+    extra_vertex = TileGeometry("extra", Polygon([(0, 0), (1, 0), (2, 0), (2, 2), (0, 2)]), 30)
+    second = TileGeometry("second", Polygon([(1, 0), (3, 0), (3, 2), (1, 2)]), 40)
+    assert join_polygon_to_tiles(target, [first, extra_vertex, second]) == join_polygon_to_tiles(
+        target, [first, second]
+    )
+
+
+def test_polygon_join_rejects_conflicting_duplicate_identity() -> None:
+    target = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    tiles = [
+        TileGeometry("same", target, 30),
+        TileGeometry("same", Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), 40),
+    ]
+    with pytest.raises(ValueError, match="conflicting"):
+        join_polygon_to_tiles(target, tiles)


### PR DESCRIPTION
## Summary

- normalize ordinary temperature and analytic value heatmap responses with explicit unit and conversion provenance
- add AOI-aware point lookup and projected, area-weighted polygon joins with explicit quality and coverage
- preserve activity metadata through live execution and cache replay while rejecting malformed or ambiguous provider data
- add focused offline normalization, conversion, spatial, cache, and API tests

## Verification

- 384 Python non-integration tests passed
- 10 Python integration tests passed
- 16 frontend tests passed
- 1 offline Playwright E2E test passed
- Ruff format and lint passed
- mypy passed
- Prettier, frontend lint, typecheck, and build passed
- dependency audits reported no known vulnerabilities

Closes #12