### PR TITLE
Feature/temporal data prep 44

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,15 +19,18 @@ directly.
   and route decisions for one trip. It is one setup, not separate walk and
   hotel configurations.
 - **Curated trip** — A trip whose places are fixed to the canonical trip while
-  the traveler may choose its date, hour, and guidance preference. An
-  **exploratory trip** permits place selection and is outside the curated flow.
+  the traveler may choose its date, same-day time window, and guidance
+  preference. An **exploratory trip** permits place selection and is outside
+  the curated flow.
 - **Cautious guidance** — An optional traveler preference requesting the
   product's more conservative heat interpretation. The interpretation policy
   belongs to the heat-classification domain; trip setup only captures the
   preference. Synonym to avoid: "cautious mode".
 - **Trip analysis request** — One product-level request containing a complete
-  trip setup and asking for the connected best-time, hotel, and route
-  decisions. It is not a collection of traveler-visible provider requests.
+  trip setup. Its temporal-preparation stage asks the server for one ranged
+  point heatmap followed by one identically ranged env-params series; later
+  issues consume that series for best-time, hotel, and route decisions. It is
+  not a collection of traveler-visible provider requests.
 - **Supported live-data geography** — The United States, the geographic area
   in which the product may request live provider data. This is distinct from
   the canonical trip's San Antonio location and from fixture replay.
@@ -56,13 +59,16 @@ directly.
   (`analytic_type`), `value_celsius` (tcm) or `metric_value` + unit (`hours`),
   source, valid time, forecast flag, threshold/direction, activity id. The
   single internal heatmap shape for fixture and live data.
-- **Temperature anchor** — The caller-supplied °C value required by the
-  environmental-parameters request. The returned series is fixed to this
-  anchor and is never a real 24-hour forecast; results carry the standing
-  warning.
+- **Temperature anchor** — The °C value required by the
+  environmental-parameters request. Direct env-params callers supply it; the
+  temporal trip pipeline derives it conservatively as the maximum TCM value
+  in the traveler's range. The returned series is fixed to this anchor and is
+  never a real 24-hour forecast; results carry the standing warning.
 - **Env-params series** — Environmental parameters normalized as per-hour
   entries (`valid_time`, nullable metric values) aligned with the provider's
-  `metadata.timestamps`. Missing values stay `None`, never zero.
+  `metadata.timestamps`. Missing values stay `None`, never zero. Temporal trip
+  preparation returns this raw series as `series_ready`; it does not classify
+  heat or recommend a visit time.
 - **Submit-once** — The billable-submission rule: one POST per
   `submit_and_poll`; transient failures are retried as status GETs only
   (ADR 0003). Transport retries never resubmit billable work.

--- a/app/api.py
+++ b/app/api.py
@@ -234,7 +234,15 @@ def create_app(
                 allow_live=allow_live,
                 trip_adapter=trip_adapter,
             )
-        except (KeyError, TypeError, ValueError) as error:
+        except (
+            BudgetExceededError,
+            KeyError,
+            TypeError,
+            ValueError,
+            OSError,
+            RuntimeError,
+            ProviderError,
+        ) as error:
             raise _http_error(error) from error
 
     if frontend_dist is not None and frontend_dist.is_dir():

--- a/app/api.py
+++ b/app/api.py
@@ -273,14 +273,16 @@ def _heatmap_request(body: dict[str, object]) -> HeatmapRequest:
     if isinstance(granularity, bool) or not isinstance(granularity, int):
         raise ValueError("granularity must be an integer")
     return HeatmapRequest(
-        AnalyticType(body["analytic_type"]),
-        latitude,
-        longitude,
-        date.fromisoformat(start_date),
-        _required_bool(body, "forecast", default=True),
-        threshold,
-        direction,
-        granularity,
+        analytic_type=AnalyticType(body["analytic_type"]),
+        latitude=latitude,
+        longitude=longitude,
+        start_date=date.fromisoformat(start_date),
+        forecast=_required_bool(body, "forecast", default=True),
+        threshold_celsius=threshold,
+        direction=direction,
+        granularity=granularity,
+        start_hour=_optional_hour(body, "start_hour"),
+        end_hour=_optional_hour(body, "end_hour"),
     )
 
 
@@ -293,21 +295,22 @@ def _env_params_request(body: dict[str, object]) -> EnvParamsRequest:
     anchor = body.get("temperature_anchor_celsius")
     if anchor is not None:
         anchor = _finite_number(anchor, "temperature_anchor_celsius")
-    hour = body.get("hour")
-    if hour is not None:
-        if isinstance(hour, bool) or not isinstance(hour, int):
-            raise ValueError("hour must be an integer")
+    hour = _optional_hour(body, "hour")
     return EnvParamsRequest(
-        latitude,
-        longitude,
-        date.fromisoformat(start_date),
-        anchor,
+        latitude=latitude,
+        longitude=longitude,
+        start_date=date.fromisoformat(start_date),
+        temperature_anchor_celsius=anchor,
         hour=hour,
+        start_hour=_optional_hour(body, "start_hour"),
+        end_hour=_optional_hour(body, "end_hour"),
     )
 
 
 def _parse_trip_request(body: dict[str, object]) -> TripAnalysisRequest:
     """Parse the frontend request into the provider-independent contract."""
+    if "hour" in body:
+        raise ValueError("hour is no longer accepted; provide start_hour and end_hour")
     provider_fields = {
         "heat_metric",
         "heat_value",
@@ -332,7 +335,8 @@ def _parse_trip_request(body: dict[str, object]) -> TripAnalysisRequest:
     landmark = body.get("landmark_name")
     district = body.get("district_name")
     trip_date = body.get("date")
-    hour = body.get("hour")
+    start_hour = _required_hour(body, "start_hour")
+    end_hour = _required_hour(body, "end_hour")
     mode = body.get("mode")
     if not isinstance(landmark, str) or not landmark:
         raise ValueError("landmark_name must be a non-empty string")
@@ -340,8 +344,6 @@ def _parse_trip_request(body: dict[str, object]) -> TripAnalysisRequest:
         raise ValueError("district_name must be a non-empty string")
     if not isinstance(trip_date, str) or not trip_date:
         raise ValueError("date must be a non-empty string")
-    if isinstance(hour, bool) or not isinstance(hour, int):
-        raise ValueError("hour must be an integer between 0 and 23")
     if not isinstance(mode, str):
         raise ValueError("mode must be curated or exploratory")
 
@@ -352,7 +354,8 @@ def _parse_trip_request(body: dict[str, object]) -> TripAnalysisRequest:
         landmark_name=landmark,
         district_name=district,
         date=trip_date,
-        hour=hour,
+        start_hour=start_hour,
+        end_hour=end_hour,
         cautious=_required_bool(body, "cautious", default=False),
     )
 
@@ -385,6 +388,24 @@ def _execution_mode(body: dict[str, object], *, allow_live: bool) -> ExecutionMo
     if mode is ExecutionMode.LIVE and not allow_live:
         raise ValueError("live execution is not enabled for this server")
     return mode
+
+
+def _required_hour(body: dict[str, object], field: str) -> int:
+    if field not in body:
+        raise ValueError(f"{field} is required")
+    value = body[field]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be a whole hour between 0 and 23")
+    return value
+
+
+def _optional_hour(body: dict[str, object], field: str) -> int | None:
+    value = body.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer")
+    return value
 
 
 def _finite_number(value: object, field: str) -> float:

--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -13,6 +13,8 @@ import math
 from datetime import date as calendar_date, datetime
 from typing import Protocol
 
+from app.domain.environment import TimeWindow
+
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -30,6 +32,7 @@ class ExecutionMode(str, Enum):
 
 
 class ResultState(str, Enum):
+    SERIES_READY = "series_ready"
     SUCCESS = "success"
     DEGRADED = "degraded"
     UNAVAILABLE = "unavailable"
@@ -189,7 +192,8 @@ class TripAnalysisRequest:
     landmark_name: str
     district_name: str
     date: str
-    hour: int
+    start_hour: int
+    end_hour: int
     cautious: bool
 
     def __post_init__(self) -> None:
@@ -205,16 +209,15 @@ class TripAnalysisRequest:
             calendar_date.fromisoformat(self.date)
         except ValueError as error:
             raise ValueError("date must be an ISO date") from error
-        if (
-            isinstance(self.hour, bool)
-            or not isinstance(self.hour, int)
-            or not 0 <= self.hour <= 23
-        ):
-            raise ValueError("hour must be between 0 and 23")
+        TimeWindow(self.start_hour, self.end_hour)
         if not isinstance(self.cautious, bool):
             raise ValueError("cautious must be a boolean")
         if self.mode not in (TripMode.CURATED, TripMode.EXPLORATORY):
             raise ValueError("unknown trip mode")
+
+    @property
+    def window(self) -> TimeWindow:
+        return TimeWindow(self.start_hour, self.end_hour)
 
 
 @dataclass(frozen=True)
@@ -283,6 +286,66 @@ class RouteCandidateData:
 # ---------------------------------------------------------------------------
 # Response sub-shapes
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnvironmentSeriesEntry:
+    """One environmental observation; unavailable provider metrics remain None."""
+
+    valid_time: datetime
+    heat_index_celsius: float | None
+    humidity_percent: float | None
+
+    def __post_init__(self) -> None:
+        if self.valid_time.tzinfo is None or self.valid_time.utcoffset() is None:
+            raise ValueError("environment valid_time must include a timezone")
+        for name, value in (
+            ("heat_index_celsius", self.heat_index_celsius),
+            ("humidity_percent", self.humidity_percent),
+        ):
+            if value is not None and (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+            ):
+                raise ValueError(f"{name} must be a finite number or None")
+        if self.humidity_percent is not None and not 0 <= self.humidity_percent <= 100:
+            raise ValueError("humidity_percent must be between 0 and 100")
+
+
+@dataclass(frozen=True)
+class EnvironmentSeriesResult:
+    """Raw fixed-anchor environmental series produced before any recommendation."""
+
+    entries: tuple[EnvironmentSeriesEntry, ...]
+    timezone: str
+    temperature_anchor_celsius: float
+    warning: str
+    provenance: Provenance
+
+    def __post_init__(self) -> None:
+        if not self.entries:
+            raise ValueError("environment entries are required")
+        if any(not isinstance(entry, EnvironmentSeriesEntry) for entry in self.entries):
+            raise ValueError("environment entries must be EnvironmentSeriesEntry values")
+        if not self.timezone:
+            raise ValueError("environment timezone is required")
+        if (
+            isinstance(self.temperature_anchor_celsius, bool)
+            or not isinstance(self.temperature_anchor_celsius, (int, float))
+            or not math.isfinite(self.temperature_anchor_celsius)
+        ):
+            raise ValueError("temperature_anchor_celsius must be finite")
+        if (
+            "fixed temperature anchor" not in self.warning
+            or "not a real 24-hour forecast" not in self.warning
+        ):
+            raise ValueError("environment requires the standing fixed-anchor warning")
+        if not isinstance(self.provenance, Provenance):
+            raise ValueError("environment provenance is required")
+        valid_times = [entry.valid_time for entry in self.entries]
+        if len(set(valid_times)) != len(valid_times):
+            raise ValueError("environment entries must not contain duplicate valid times")
 
 
 @dataclass(frozen=True)
@@ -569,6 +632,7 @@ class TripAnalysisResponse:
     execution_mode: ExecutionMode
     state: ResultState
 
+    environment: EnvironmentSeriesResult | None = None
     best_time: BestTimeResult | None = None
     hotels: HotelRankingResult | None = None
     routes: RouteComparisonResult | None = None
@@ -582,7 +646,16 @@ class TripAnalysisResponse:
             raise ValueError("execution_mode must be an ExecutionMode value")
         if not isinstance(self.state, ResultState):
             raise ValueError("state must be a ResultState value")
-        if self.state is ResultState.SUCCESS:
+        if self.state is ResultState.SERIES_READY:
+            if not isinstance(self.environment, EnvironmentSeriesResult):
+                raise ValueError("series_ready state requires environment")
+            if self.best_time is not None or self.hotels is not None or self.routes is not None:
+                raise ValueError("series_ready state must not include decision sections")
+            if self.unavailable is not None or self.degraded_reasons is not None:
+                raise ValueError("series_ready state must not include failure detail")
+        elif self.state is ResultState.SUCCESS:
+            if self.environment is not None:
+                raise ValueError("success state must not include the preparation environment")
             if not isinstance(self.best_time, BestTimeResult):
                 raise ValueError("success state requires a BestTimeResult")
             if not isinstance(self.hotels, HotelRankingResult):
@@ -602,11 +675,18 @@ class TripAnalysisResponse:
         elif self.state is ResultState.UNAVAILABLE:
             if not isinstance(self.unavailable, UnavailableResult):
                 raise ValueError("unavailable state requires unavailable detail")
-            if self.best_time is not None or self.hotels is not None or self.routes is not None:
+            if (
+                self.environment is not None
+                or self.best_time is not None
+                or self.hotels is not None
+                or self.routes is not None
+            ):
                 raise ValueError("unavailable state must not include result data")
             if self.degraded_reasons is not None:
                 raise ValueError("unavailable state must not include degraded_reasons")
         elif self.state is ResultState.DEGRADED:
+            if self.environment is not None:
+                raise ValueError("degraded state must not include the preparation environment")
             if self.best_time is None and self.hotels is None and self.routes is None:
                 raise ValueError("degraded state requires at least one partial result")
             if not self.degraded_reasons:
@@ -640,7 +720,12 @@ class TripAnalysisResponse:
         elif self.state is ResultState.ERROR:
             if not isinstance(self.unavailable, UnavailableResult):
                 raise ValueError("error state requires unavailable detail")
-            if self.best_time is not None or self.hotels is not None or self.routes is not None:
+            if (
+                self.environment is not None
+                or self.best_time is not None
+                or self.hotels is not None
+                or self.routes is not None
+            ):
                 raise ValueError("error state must not include result data")
             if self.degraded_reasons is not None:
                 raise ValueError("error state must not include degraded_reasons")

--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -7,11 +7,11 @@ defined here.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 import math
 from datetime import date as calendar_date, datetime
-from typing import Protocol
+from typing import Mapping, Protocol
 
 from app.domain.environment import TimeWindow
 
@@ -290,11 +290,12 @@ class RouteCandidateData:
 
 @dataclass(frozen=True)
 class EnvironmentSeriesEntry:
-    """One environmental observation; unavailable provider metrics remain None."""
+    """One environmental observation with every requested provider parameter."""
 
     valid_time: datetime
     heat_index_celsius: float | None
     humidity_percent: float | None
+    parameters: Mapping[str, float | None] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.valid_time.tzinfo is None or self.valid_time.utcoffset() is None:
@@ -309,8 +310,22 @@ class EnvironmentSeriesEntry:
                 or not math.isfinite(value)
             ):
                 raise ValueError(f"{name} must be a finite number or None")
+        for name, value in self.parameters.items():
+            if not isinstance(name, str) or not name:
+                raise ValueError("environment parameter names must be non-empty strings")
+            if value is not None and (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+            ):
+                raise ValueError(f"environment parameter {name} must be finite or None")
         if self.humidity_percent is not None and not 0 <= self.humidity_percent <= 100:
             raise ValueError("humidity_percent must be between 0 and 100")
+        if self.parameters:
+            if self.parameters.get("relative_humidity_percent") != self.humidity_percent:
+                raise ValueError("humidity_percent must mirror relative_humidity_percent")
+            if self.parameters.get("heat_index_celsius") != self.heat_index_celsius:
+                raise ValueError("heat_index_celsius must mirror the parameter map")
 
 
 @dataclass(frozen=True)

--- a/app/domain/environment.py
+++ b/app/domain/environment.py
@@ -1,0 +1,86 @@
+"""Temporal data-prep domain: traveler time window and anchor selection (issue #44).
+
+This module is provider-free. It owns the product rule — one day, whole
+hours, at most twelve of them — and the conservative chaining policy that
+turns a heatmap response into the environmental-parameters temperature
+anchor. Provider adapters translate a validated window into their own
+request payloads; they never redefine the rule.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Protocol
+
+MAX_WINDOW_HOURS = 12
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    """A half-open window of whole hours within one calendar day.
+
+    ``start_hour`` is inclusive, ``end_hour`` exclusive: the traveler visits
+    from 08:00 up to (but not including) 20:00. Because the provider range
+    filter takes a single ``start_date``, a window cannot cross midnight.
+    """
+
+    start_hour: int
+    end_hour: int
+
+    def __post_init__(self) -> None:
+        for name, value in (("start_hour", self.start_hour), ("end_hour", self.end_hour)):
+            if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 23:
+                raise ValueError(f"{name} must be a whole hour between 0 and 23")
+        if self.start_hour >= self.end_hour:
+            raise ValueError("start_hour must be before end_hour within one day")
+        if self.end_hour - self.start_hour > MAX_WINDOW_HOURS:
+            raise ValueError(f"time window spans at most {MAX_WINDOW_HOURS} hours")
+
+    @property
+    def hours(self) -> range:
+        return range(self.start_hour, self.end_hour)
+
+    def contains_hour(self, hour: int) -> bool:
+        return hour in self.hours
+
+    def start_time(self) -> str:
+        return f"{self.start_hour:02d}:00"
+
+    def end_time(self) -> str:
+        return f"{self.end_hour:02d}:00"
+
+
+class CelsiusReading(Protocol):
+    """The minimal structural interface the anchor policy consumes.
+
+    ``Tile`` satisfies it structurally: any reading shape with a valid time
+    and an optional °C value can be chained into the anchor policy. Both
+    members are read-only properties so frozen dataclasses conform.
+    """
+
+    @property
+    def valid_time(self) -> datetime: ...
+
+    @property
+    def value_celsius(self) -> float | None: ...
+
+
+def select_anchor_celsius(readings: Iterable[CelsiusReading], window: TimeWindow) -> float:
+    """Return the maximum °C among readings whose hour falls inside ``window``.
+
+    Conservative by design: the environmental series is anchored to the
+    worst in-window heat so #14's analysis never under-reports exposure.
+    Raises when no in-window reading carries a value — the anchor is never
+    invented.
+    """
+    in_window = [
+        reading.value_celsius
+        for reading in readings
+        if window.contains_hour(reading.valid_time.hour) and reading.value_celsius is not None
+    ]
+    if not in_window:
+        raise ValueError(
+            "no in-window temperature reading is available to anchor the environmental series"
+        )
+    return max(in_window)

--- a/app/domain/environment.py
+++ b/app/domain/environment.py
@@ -41,6 +41,11 @@ class TimeWindow:
     def hours(self) -> range:
         return range(self.start_hour, self.end_hour)
 
+    @property
+    def last_hour(self) -> int:
+        """The final whole hour inside the window (``end_hour`` is exclusive)."""
+        return self.end_hour - 1
+
     def contains_hour(self, hour: int) -> bool:
         return hour in self.hours
 
@@ -48,7 +53,17 @@ class TimeWindow:
         return f"{self.start_hour:02d}:00"
 
     def end_time(self) -> str:
-        return f"{self.end_hour:02d}:00"
+        """The inclusive upper bound for the provider's hour-range filter.
+
+        The provider's range filter is inclusive of ``end_time`` — a live call
+        for 08:00-14:00 returned seven hourly readings, 08:00 through 14:00 —
+        while this window is half-open. Rendering :attr:`last_hour` therefore
+        asks for exactly the hours the traveler is present for. Rendering
+        ``end_hour`` would request one hour beyond the window, up to
+        ``MAX_WINDOW_HOURS + 1`` readings, and leave the trailing reading
+        outside :meth:`contains_hour` for every consumer downstream.
+        """
+        return f"{self.last_hour:02d}:00"
 
 
 class CelsiusReading(Protocol):

--- a/app/integrations/fortyguard/contracts.py
+++ b/app/integrations/fortyguard/contracts.py
@@ -20,6 +20,7 @@ from app.domain.analysis import (
     join_point_to_tiles,
     join_polygon_to_tiles,
 )
+from app.domain.environment import TimeWindow
 from app.domain.provenance import Provenance, Transformation
 from app.domain.security import sanitize_payload
 from app.integrations.fortyguard.client import ActivityMetadata
@@ -44,6 +45,8 @@ class HeatmapRequest:
     threshold_celsius: float | None = None
     direction: str | None = None
     granularity: int = 60
+    start_hour: int | None = None
+    end_hour: int | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.analytic_type, AnalyticType):
@@ -70,6 +73,22 @@ class HeatmapRequest:
             or self.granularity not in (60, 80, 100)
         ):
             raise ValueError("granularity must be 60, 80, or 100 meters")
+        _validate_hour_window(self.start_hour, self.end_hour)
+
+    @property
+    def window(self) -> TimeWindow | None:
+        """The validated traveler window, or ``None`` for a full-day request.
+
+        Re-deriving from the validated hours hands callers the domain type (with
+        its ``start_time``/``end_time`` rendering) instead of raw integers.
+        """
+        return _validate_hour_window(self.start_hour, self.end_hour)
+
+    @property
+    def hours(self) -> range | None:
+        """The hours covered by the window, or ``None`` for a full-day request."""
+        window = self.window
+        return window.hours if window is not None else None
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -84,7 +103,25 @@ class HeatmapRequest:
             payload["threshold_celsius"] = self.threshold_celsius
         if self.direction is not None:
             payload["direction"] = self.direction
+        if self.start_hour is not None and self.end_hour is not None:
+            payload["start_hour"] = self.start_hour
+            payload["end_hour"] = self.end_hour
         return payload
+
+
+def _validate_hour_window(start_hour: int | None, end_hour: int | None) -> TimeWindow | None:
+    """Validate an optional whole-hour window by delegating to the domain rule.
+
+    The one-day / whole-hours / at-most-twelve-hours rule lives in
+    :class:`app.domain.environment.TimeWindow`; this helper only maps the
+    all-or-nothing field contract onto it. Both bounds must be set together or
+    neither — a single bound is a caller mistake, not a full-day request.
+    """
+    if start_hour is None and end_hour is None:
+        return None
+    if (start_hour is None) != (end_hour is None):
+        raise ValueError("start_hour and end_hour must be set together")
+    return TimeWindow(start_hour or 0, end_hour or 0)
 
 
 @dataclass(frozen=True)
@@ -95,6 +132,8 @@ class EnvParamsRequest:
     temperature_anchor_celsius: float | None
     is_real_forecast: bool = False
     hour: int | None = None
+    start_hour: int | None = None
+    end_hour: int | None = None
 
     def __post_init__(self) -> None:
         _validate_us_coordinates(self.latitude, self.longitude)
@@ -114,6 +153,14 @@ class EnvParamsRequest:
                 or not 0 <= self.hour <= 23
             ):
                 raise ValueError("hour must be an integer between 0 and 23")
+        if self.hour is not None and (self.start_hour is not None or self.end_hour is not None):
+            raise ValueError("hour and start_hour/end_hour must not be set together")
+        _validate_hour_window(self.start_hour, self.end_hour)
+
+    @property
+    def window(self) -> TimeWindow | None:
+        """The validated traveler window, or ``None`` for full-day/single-hour requests."""
+        return _validate_hour_window(self.start_hour, self.end_hour)
 
     def to_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -126,6 +173,9 @@ class EnvParamsRequest:
         }
         if self.hour is not None:
             payload["hour"] = self.hour
+        if self.start_hour is not None and self.end_hour is not None:
+            payload["start_hour"] = self.start_hour
+            payload["end_hour"] = self.end_hour
         return payload
 
 

--- a/app/integrations/fortyguard/contracts.py
+++ b/app/integrations/fortyguard/contracts.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from enum import Enum
 import math
@@ -214,13 +214,35 @@ class AreaHeatmapRequest:
         }
 
 
+ENVIRONMENT_PARAMETERS = (
+    "heat_index_celsius",
+    "apparent_temperature_celsius",
+    "wet_bulb_temperature_celsius",
+    "relative_humidity_percent",
+    "precipitation_mm",
+    "cloud_cover_octas",
+    "elevation",
+    "air_quality:idx",
+    "air_quality_pm2p5:idx",
+    "air_quality_pm10:idx",
+    "air_quality_no2:idx",
+    "aqi_us_co",
+    "air_quality_o3:idx",
+    "air_quality_so2:idx",
+    "methane_ppb",
+    "co2_ppm",
+    "solar_irradiance",
+)
+
+
 @dataclass(frozen=True)
 class EnvParamsEntry:
-    """One hour of the environmental series; missing values stay None, never zero."""
+    """One hour of all returned environmental parameters."""
 
     valid_time: datetime
     heat_index_celsius: float | None
     humidity_percent: float | None
+    parameters: Mapping[str, float | None] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -246,6 +268,29 @@ def _series_list(series: object, field: str) -> list[object]:
     return list(series)
 
 
+_FLAT_METADATA_KEYS = frozenset(
+    {"timestamps", "timestamp", "timezone", "count", "forecast", "mode"}
+)
+
+
+def _is_series(value: object) -> bool:
+    """Report whether a flat-shape value is a parameter series rather than metadata.
+
+    The flat shape mixes scalar metadata (``offset``, ``interval``) in among the
+    parameter arrays, so shape decides what is a series instead of a fixed name
+    list. That keeps every real environmental parameter without having to
+    enumerate metadata the provider may add later.
+
+    Known limitation: a genuine parameter that is scalar-shaped is
+    indistinguishable from metadata here and is dropped silently. A live call on
+    2026-08-29 returned 15 of the 17 requested parameters, with ``elevation``
+    and ``solar_irradiance`` absent; whether the provider omitted them or sent
+    them as scalars is undetermined, and ``elevation`` is time-invariant so the
+    scalar case is plausible. Resolving it needs the raw payload.
+    """
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes))
+
+
 def normalize_env_params_response(
     payload: Mapping[str, object], *, request: EnvParamsRequest
 ) -> EnvParamsResult:
@@ -254,13 +299,12 @@ def normalize_env_params_response(
     timestamps, timezone, series = _env_params_series(payload)
     entries = tuple(
         EnvParamsEntry(
-            _parse_datetime(timestamp),
-            _series_value(heat, "heat index"),
-            _series_value(humidity, "humidity"),
+            valid_time=_parse_datetime(timestamp),
+            heat_index_celsius=series["heat_index_celsius"][index],
+            humidity_percent=series["relative_humidity_percent"][index],
+            parameters={name: values[index] for name, values in series.items()},
         )
-        for timestamp, heat, humidity in zip(
-            timestamps, series["heat"], series["humidity"], strict=True
-        )
+        for index, timestamp in enumerate(timestamps)
     )
     if not entries:
         raise ValueError("env params response contains no entries")
@@ -274,7 +318,7 @@ def normalize_env_params_response(
 
 def _env_params_series(
     payload: Mapping[str, object],
-) -> tuple[Sequence[object], str, dict[str, list[object]]]:
+) -> tuple[Sequence[object], str, dict[str, list[float | None]]]:
     """Extract timestamps, timezone, and the consumed series from either provider shape.
 
     Two provider shapes are reality: the documented ``metadata`` + ``locations``
@@ -290,7 +334,7 @@ def _env_params_series(
 
 def _documented_series(
     payload: Mapping[str, object], metadata: Mapping[str, object]
-) -> tuple[Sequence[object], str, dict[str, list[object]]]:
+) -> tuple[Sequence[object], str, dict[str, list[float | None]]]:
     timestamps = metadata.get("timestamps")
     if not isinstance(timestamps, Sequence) or isinstance(timestamps, (str, bytes)):
         raise ValueError("missing freshness metadata")
@@ -311,16 +355,19 @@ def _documented_series(
     if not isinstance(parameters, Mapping):
         raise ValueError("malformed env params parameters")
     series = {
-        "heat": _series_list(parameters.get("heat_index_celsius"), "heat index"),
-        "humidity": _series_list(parameters.get("relative_humidity_percent"), "humidity"),
+        name: [_series_value(value, _series_error_name(name)) for value in _series_list(raw, name)]
+        for name, raw in parameters.items()
     }
-    _require_aligned(series, timestamps)
+    for name in ("heat_index_celsius", "relative_humidity_percent"):
+        if name not in series:
+            raise ValueError(f"missing {_series_error_name(name)} series")
+    _ensure_legacy_series(series, timestamps)
     return timestamps, timezone, series
 
 
 def _flat_series(
     payload: Mapping[str, object],
-) -> tuple[Sequence[object], str, dict[str, list[object]]]:
+) -> tuple[Sequence[object], str, dict[str, list[float | None]]]:
     timezone = payload.get("timezone")
     if not isinstance(timezone, str) or not timezone:
         raise ValueError("missing timezone metadata")
@@ -336,14 +383,36 @@ def _flat_series(
         else:
             raise ValueError("missing freshness metadata")
     series = {
-        "heat": _series_list(payload.get("heat_index_celsius"), "heat index"),
-        "humidity": _series_list(payload.get("relative_humidity_percent"), "humidity"),
+        name: [
+            _series_value(value, _series_error_name(name)) for value in _series_list(values, name)
+        ]
+        for name, values in payload.items()
+        if name not in _FLAT_METADATA_KEYS and _is_series(values)
     }
-    _require_aligned(series, timestamps)
+    for name in ("heat_index_celsius", "relative_humidity_percent"):
+        if name not in series:
+            raise ValueError(f"missing {_series_error_name(name)} series")
+    _ensure_legacy_series(series, timestamps)
     return timestamps, timezone, series
 
 
-def _require_aligned(series: dict[str, list[object]], timestamps: Sequence[object]) -> None:
+def _series_error_name(name: str) -> str:
+    return {
+        "heat_index_celsius": "heat index",
+        "relative_humidity_percent": "humidity",
+    }.get(name, name)
+
+
+def _ensure_legacy_series(
+    series: dict[str, list[float | None]], timestamps: Sequence[object]
+) -> None:
+    length = len(timestamps)
+    for name in ("heat_index_celsius", "relative_humidity_percent"):
+        series.setdefault(name, [None] * length)
+    _require_aligned(series, timestamps)
+
+
+def _require_aligned(series: dict[str, list[float | None]], timestamps: Sequence[object]) -> None:
     if any(len(values) != len(timestamps) for values in series.values()):
         raise ValueError("env params series must be time-aligned with timestamps")
 

--- a/app/integrations/fortyguard/live.py
+++ b/app/integrations/fortyguard/live.py
@@ -21,7 +21,12 @@ from shapely.ops import transform as shapely_ops_transform
 from app.domain.environment import TimeWindow
 from app.domain.provenance import Transformation
 from app.integrations.fortyguard.client import ActivityMetadata, FortyGuardClient
-from app.integrations.fortyguard.contracts import AnalyticType, EnvParamsRequest, HeatmapRequest
+from app.integrations.fortyguard.contracts import (
+    ENVIRONMENT_PARAMETERS,
+    AnalyticType,
+    EnvParamsRequest,
+    HeatmapRequest,
+)
 from app.integrations.fortyguard.errors import ProviderError, ProviderErrorKind
 from app.integrations.fortyguard.transport import HttpFortyGuardTransport
 from app.settings import FortyGuardPollingSettings
@@ -175,6 +180,21 @@ def _point_square_feature_collection(
     }
 
 
+def _tile_valid_time(request: HeatmapRequest) -> str:
+    """Stamp tiles with the hour the readings were actually requested for.
+
+    A windowed request is submitted as the range filter (``filter_type`` 2 with
+    ``start_time``/``end_time``), so the readings that come back describe that
+    window rather than midnight. Stamping the window start keeps the tile inside
+    the traveler window that :func:`app.domain.environment.select_anchor_celsius`
+    tests, which midnight would fall outside of for every daytime window.
+    Full-day requests (``filter_type`` 3) carry no hour and keep midnight.
+    """
+    window = request.window
+    hour = 0 if window is None else window.start_hour
+    return f"{request.start_date.isoformat()}T{hour:02d}:00:00+00:00"
+
+
 def translate_heatmap_response(
     result: Mapping[str, object], *, request: HeatmapRequest
 ) -> dict[str, object]:
@@ -196,7 +216,7 @@ def translate_heatmap_response(
         raise ProviderError(
             ProviderErrorKind.MALFORMED_RESPONSE, detail="map_data contains no features"
         )
-    valid_time = f"{request.start_date.isoformat()}T00:00:00+00:00"
+    valid_time = _tile_valid_time(request)
     unit = "C" if request.analytic_type is AnalyticType.TCM else "hours"
     internal_features: list[dict[str, object]] = []
     for index, feature in enumerate(features):
@@ -259,11 +279,17 @@ def _tile_value(properties: Mapping[str, object], analytic_type: AnalyticType) -
 
 
 def request_transformations(request: HeatmapRequest) -> tuple[Transformation, ...]:
-    """The inference stamps every live heatmap result carries (ADR 0002)."""
+    """The inference stamps every live point heatmap result carries (ADR 0002).
+
+    ``valid_time_from_request`` is version 2: the rule now derives the tile hour
+    from the requested window's start rather than always stamping midnight, so
+    consumers can tell window-derived valid times from the date-only rule (ADR
+    0002 §3). The area path still applies version 1 — it submits no window.
+    """
     stamps = [
         Transformation("live_envelope_unwrapped", 1),
         Transformation("point_to_aoi_expansion", 1),
-        Transformation("valid_time_from_request", 1),
+        Transformation("valid_time_from_request", 2),
     ]
     if request.analytic_type is AnalyticType.TCM:
         stamps.append(Transformation("tcm_unit_celsius", 1))
@@ -473,7 +499,12 @@ def build_documented_area_heatmap_payload(
 
 
 def area_request_transformations(analytic_type: AnalyticType) -> tuple[Transformation, ...]:
-    """The inference stamps every live area heatmap result carries (ADR 0002)."""
+    """The inference stamps every live area heatmap result carries (ADR 0002).
+
+    ``valid_time_from_request`` stays version 1 here: area requests submit no
+    hour window (always ``filter_type`` 3), so the tile valid time is still
+    midnight derived from the request date alone.
+    """
     stamps = [
         Transformation("live_envelope_unwrapped", 1),
         Transformation("route_to_aoi_buffer", 1),
@@ -655,9 +686,9 @@ def map_tiles_to_route_segments(
 def build_documented_env_params_payload(request: EnvParamsRequest) -> dict[str, object]:
     """Build the documented /v1/env_params payload for a single-point series request.
 
-    The caller-supplied Celsius anchor is the documented ``temperature`` input;
-    ``analysis`` explicitly lists only the two consumed parameters so the
-    request stays within the three-parameter plan limit (ADR 0001). An optional
+    The complete documented parameter set is requested by default. The caller-supplied
+    Celsius anchor is the documented ``temperature`` input. Parameters are kept
+    provider-shaped so newly added fields are not silently discarded. An optional
     hour selects the single-hour filter; the default is the full-day series.
     Out-of-contract dates are rejected before any billable submission, matching
     the heatmap path (ADR 0001 §3). Env-params dates are validated as anchored
@@ -684,7 +715,7 @@ def build_documented_env_params_payload(request: EnvParamsRequest) -> dict[str, 
         "longitude": request.longitude,
         "temperature": request.temperature_anchor_celsius,
         "date_time": date_time,
-        "analysis": ["heat_index_celsius", "relative_humidity_percent"],
+        "analysis": list(ENVIRONMENT_PARAMETERS),
     }
 
 

--- a/app/integrations/fortyguard/live.py
+++ b/app/integrations/fortyguard/live.py
@@ -18,6 +18,7 @@ from shapely.geometry import LineString, Polygon, mapping as shapely_mapping
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform as shapely_ops_transform
 
+from app.domain.environment import TimeWindow
 from app.domain.provenance import Transformation
 from app.integrations.fortyguard.client import ActivityMetadata, FortyGuardClient
 from app.integrations.fortyguard.contracts import AnalyticType, EnvParamsRequest, HeatmapRequest
@@ -85,6 +86,11 @@ def build_documented_heatmap_payload(
     semantics are expressed purely by the date window, so full-day forecast
     requests are limited to today (the documented horizon is 12 hours ahead)
     and historical requests must fall between 2019-01-01 and today.
+
+    A request carrying a validated traveler window (``start_hour``/``end_hour``)
+    is submitted as the documented range-of-hours filter (``filter_type`` 2 with
+    ``start_time``/``end_time``); without one it stays a full-day request
+    (``filter_type`` 3), preserving every existing caller.
     """
     current = date.today() if today is None else today
     _validate_documented_window(
@@ -94,7 +100,7 @@ def build_documented_heatmap_payload(
         "polygon_aoi": _point_square_feature_collection(
             request.latitude, request.longitude, side_m=request.granularity
         ),
-        "date_time": {"start_date": request.start_date.isoformat(), "filter_type": 3},
+        "date_time": _date_time_filter(start_date=request.start_date, window=request.window),
         "granularity": request.granularity,
         "analytic_type": request.analytic_type.value,
     }
@@ -103,6 +109,24 @@ def build_documented_heatmap_payload(
     if request.direction is not None:
         payload["direction"] = request.direction
     return payload
+
+
+def _date_time_filter(*, start_date: date, window: TimeWindow | None) -> dict[str, object]:
+    """Render the documented ``date_time`` filter block for a request.
+
+    A traveler window becomes the documented range filter (``filter_type`` 2
+    with ``start_time``/``end_time`` as ``"HH:00"`` strings); without one the
+    request keeps its full-day shape (``filter_type`` 3), which is how
+    full-day heatmap and env-params calls are made today (ADR 0001).
+    """
+    date_time: dict[str, object] = {
+        "start_date": start_date.isoformat(),
+        "filter_type": 2 if window is not None else 3,
+    }
+    if window is not None:
+        date_time["start_time"] = window.start_time()
+        date_time["end_time"] = window.end_time()
+    return date_time
 
 
 def _validate_documented_window(*, start_date: date, forecast: bool, today: date) -> None:
@@ -638,14 +662,23 @@ def build_documented_env_params_payload(request: EnvParamsRequest) -> dict[str, 
     Out-of-contract dates are rejected before any billable submission, matching
     the heatmap path (ADR 0001 §3). Env-params dates are validated as anchored
     observations: between 2019-01-01 and today.
+
+    The filter mirrors the request it was built from: a single ``hour`` stays
+    the single-hour filter (``filter_type`` 1), a traveler window
+    (``start_hour``/``end_hour``) becomes the range filter (``filter_type`` 2
+    with ``start_time``/``end_time``), and neither is the full-day series
+    (``filter_type`` 3). The window and the chained heatmap request therefore
+    always carry an identical ``date_time`` block (issue #44).
     """
     _validate_documented_date(request.start_date, today=date.today())
-    date_time: dict[str, object] = {
-        "start_date": request.start_date.isoformat(),
-        "filter_type": 1 if request.hour is not None else 3,
-    }
     if request.hour is not None:
-        date_time["start_time"] = f"{request.hour:02d}:00"
+        date_time: dict[str, object] = {
+            "start_date": request.start_date.isoformat(),
+            "filter_type": 1,
+            "start_time": f"{request.hour:02d}:00",
+        }
+    else:
+        date_time = _date_time_filter(start_date=request.start_date, window=request.window)
     return {
         "latitude": request.latitude,
         "longitude": request.longitude,

--- a/app/integrations/fortyguard/live.py
+++ b/app/integrations/fortyguard/live.py
@@ -123,6 +123,11 @@ def _date_time_filter(*, start_date: date, window: TimeWindow | None) -> dict[st
     with ``start_time``/``end_time`` as ``"HH:00"`` strings); without one the
     request keeps its full-day shape (``filter_type`` 3), which is how
     full-day heatmap and env-params calls are made today (ADR 0001).
+
+    The provider treats the range as inclusive of ``end_time``, so
+    :meth:`TimeWindow.end_time` renders the window's last in-window hour rather
+    than its exclusive bound. Heatmap and env-params share this helper so a
+    chained trip asks both endpoints for the identical set of hours.
     """
     date_time: dict[str, object] = {
         "start_date": start_date.isoformat(),

--- a/app/services/execution.py
+++ b/app/services/execution.py
@@ -288,7 +288,7 @@ def _request_identity_matches(
 
 def heatmap_request_payload(request: HeatmapRequest) -> dict[str, object]:
     """The complete request identity for heatmap cache keys and fixture matching."""
-    return {
+    payload: dict[str, object] = {
         "analytic_type": request.analytic_type.value,
         "latitude": request.latitude,
         "longitude": request.longitude,
@@ -298,6 +298,10 @@ def heatmap_request_payload(request: HeatmapRequest) -> dict[str, object]:
         "direction": request.direction,
         "granularity": request.granularity,
     }
+    if request.start_hour is not None and request.end_hour is not None:
+        payload["start_hour"] = request.start_hour
+        payload["end_hour"] = request.end_hour
+    return payload
 
 
 def _fixture_data_date(payload: Mapping[str, object]) -> str:
@@ -470,13 +474,17 @@ class EnvParamsExecution:
 
 def env_params_request_payload(request: EnvParamsRequest) -> dict[str, object]:
     """The complete request identity for env-params cache keys and fixture matching."""
-    return {
+    payload: dict[str, object] = {
         "latitude": request.latitude,
         "longitude": request.longitude,
         "start_date": request.start_date.isoformat(),
         "temperature_anchor_celsius": request.temperature_anchor_celsius,
         "hour": request.hour,
     }
+    if request.start_hour is not None and request.end_hour is not None:
+        payload["start_hour"] = request.start_hour
+        payload["end_hour"] = request.end_hour
+    return payload
 
 
 def _env_data_date(payload: Mapping[str, object]) -> str | None:

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from datetime import date
 from pathlib import Path
 from typing import Callable, Mapping
 
@@ -11,6 +12,8 @@ from app.domain.contracts import (
     BestTimeResult,
     Confidence,
     EnrichmentState,
+    EnvironmentSeriesEntry,
+    EnvironmentSeriesResult,
     ExecutionMode,
     HeatMetricName,
     HeatStatus,
@@ -18,15 +21,30 @@ from app.domain.contracts import (
     HourlyEntry,
     Metric,
     MetricLabel,
+    OptionalEnrichment,
     Provenance,
     RankedHotel,
     ResultState,
     RouteComparisonResult,
     RouteOption,
-    OptionalEnrichment,
+    TripAnalysisAdapter,
     TripAnalysisRequest,
     TripAnalysisResponse,
+    TripMode,
     UnavailableResult,
+)
+from app.domain.environment import select_anchor_celsius
+from app.integrations.fortyguard.contracts import (
+    AnalyticType,
+    EnvParamsRequest,
+    HeatmapRequest,
+    HeatmapResult,
+)
+from app.services.execution import (
+    EnvParamsExecution,
+    EnvParamsOutcome,
+    HeatmapExecution,
+    UnavailableError,
 )
 from app.services.sidecars import load_acquisition_record
 
@@ -92,13 +110,133 @@ class LiveTripAnalysisAdapter:
         return normalize_trip_analysis(payload, request, execution_mode)
 
 
+class TemporalTripAnalysisAdapter:
+    """Chain one ranged point heatmap into one ranged environment request."""
+
+    def __init__(
+        self,
+        heatmap_execution: HeatmapExecution,
+        env_params_execution: EnvParamsExecution,
+    ) -> None:
+        self.heatmap_execution = heatmap_execution
+        self.env_params_execution = env_params_execution
+
+    def analyze(
+        self,
+        request: TripAnalysisRequest,
+        execution_mode: ExecutionMode = ExecutionMode.LIVE,
+    ) -> TripAnalysisResponse:
+        if execution_mode is not ExecutionMode.LIVE:
+            raise ValueError("temporal trip adapter only supports live execution")
+        if request.mode is not TripMode.CURATED:
+            return _unavailable_response(
+                request,
+                execution_mode,
+                "temporal data preparation is only available for curated trips",
+            )
+        analysis_date = date.fromisoformat(request.date)
+        heatmap_request = HeatmapRequest(
+            analytic_type=AnalyticType.TCM,
+            latitude=request.destination.latitude,
+            longitude=request.destination.longitude,
+            start_date=analysis_date,
+            forecast=analysis_date >= date.today(),
+            start_hour=request.start_hour,
+            end_hour=request.end_hour,
+        )
+        try:
+            heatmap = self.heatmap_execution.run(heatmap_request, live=True)
+            anchor = select_anchor_celsius(heatmap.tiles, request.window)
+            env_request = EnvParamsRequest(
+                latitude=heatmap_request.latitude,
+                longitude=heatmap_request.longitude,
+                start_date=analysis_date,
+                temperature_anchor_celsius=anchor,
+                start_hour=request.start_hour,
+                end_hour=request.end_hour,
+            )
+            outcome = self.env_params_execution.run(env_request, live=True)
+            environment = _environment_result(request, anchor, heatmap, outcome)
+        except (UnavailableError, ValueError) as error:
+            return _unavailable_response(request, execution_mode, str(error))
+        return TripAnalysisResponse(
+            request_identity=_request_identity(request),
+            mode=request.mode,
+            execution_mode=execution_mode,
+            state=ResultState.SERIES_READY,
+            environment=environment,
+        )
+
+
+def _environment_result(
+    request: TripAnalysisRequest,
+    anchor: float,
+    heatmap: HeatmapResult,
+    outcome: EnvParamsOutcome,
+) -> EnvironmentSeriesResult:
+    if outcome.retrieved_at is None or outcome.data_date is None:
+        raise ValueError("environmental-parameters provenance is incomplete")
+    entries = tuple(
+        EnvironmentSeriesEntry(
+            valid_time=entry.valid_time,
+            heat_index_celsius=entry.heat_index_celsius,
+            humidity_percent=entry.humidity_percent,
+        )
+        for entry in outcome.result.entries
+        if request.window.contains_hour(entry.valid_time.hour)
+    )
+    provenance = Provenance(
+        source=outcome.source,
+        data_date=outcome.data_date,
+        confidence=Confidence.SUFFICIENT,
+        retrieved_at=outcome.retrieved_at.isoformat(),
+        transformation_version="trip-environment-series-v1",
+        provider="fortyguard",
+        response_status="completed",
+        request_configuration={
+            "latitude": request.destination.latitude,
+            "longitude": request.destination.longitude,
+            "start_date": request.date,
+            "start_hour": request.start_hour,
+            "end_hour": request.end_hour,
+            "temperature_anchor_celsius": anchor,
+            "anchor_policy": "maximum_in_window_temperature_celsius",
+            "heatmap_source": heatmap.provenance.source,
+            "heatmap_activity_id": heatmap.provenance.activity_id,
+        },
+        fresh=not heatmap.provenance.stale and not outcome.stale,
+        activity_id=outcome.activity_id,
+    )
+    return EnvironmentSeriesResult(
+        entries=entries,
+        timezone=outcome.result.timezone,
+        temperature_anchor_celsius=anchor,
+        warning="fixed temperature anchor; not a real 24-hour forecast",
+        provenance=provenance,
+    )
+
+
+def _unavailable_response(
+    request: TripAnalysisRequest,
+    execution_mode: ExecutionMode,
+    reason: str,
+) -> TripAnalysisResponse:
+    return TripAnalysisResponse(
+        request_identity=_request_identity(request),
+        mode=request.mode,
+        execution_mode=execution_mode,
+        state=ResultState.UNAVAILABLE,
+        unavailable=UnavailableResult(reason, recoverable=True),
+    )
+
+
 class ModeDispatchTripAnalysisAdapter:
     """Selects the adapter owned by the requested execution mode."""
 
     def __init__(
         self,
         fixture: FixtureTripAnalysisAdapter,
-        live: LiveTripAnalysisAdapter,
+        live: TripAnalysisAdapter,
     ) -> None:
         self.fixture = fixture
         self.live = live

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -409,7 +409,7 @@ def _number_dict(value: object, field: str) -> dict[str, float]:
 
 
 def _request_identity(request: TripAnalysisRequest) -> str:
-    return f"{request.mode.value}:{request.date}:{request.hour}"
+    return f"{request.mode.value}:{request.date}:{request.start_hour}-{request.end_hour}"
 
 
 def _fixture_matches(scenario: Mapping[str, object], request: TripAnalysisRequest) -> bool:
@@ -420,7 +420,8 @@ def _fixture_matches(scenario: Mapping[str, object], request: TripAnalysisReques
         and _string(scenario.get("district_name"), "scenario district_name")
         == request.district_name
         and _string(scenario.get("date"), "scenario date") == request.date
-        and _integer(scenario.get("hour"), "scenario hour") == request.hour
+        and _integer(scenario.get("start_hour"), "scenario start_hour") == request.start_hour
+        and _integer(scenario.get("end_hour"), "scenario end_hour") == request.end_hour
         and math.isclose(
             _number(origin.get("latitude"), "origin latitude"), request.origin.latitude
         )

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -181,6 +181,7 @@ def _environment_result(
             valid_time=entry.valid_time,
             heat_index_celsius=entry.heat_index_celsius,
             humidity_percent=entry.humidity_percent,
+            parameters=dict(entry.parameters),
         )
         for entry in outcome.result.entries
         if request.window.contains_hour(entry.valid_time.hour)

--- a/app/wiring.py
+++ b/app/wiring.py
@@ -33,6 +33,7 @@ from app.services.trip_adapters import (
     FixtureTripAnalysisAdapter,
     LiveTripAnalysisAdapter,
     ModeDispatchTripAnalysisAdapter,
+    TemporalTripAnalysisAdapter,
 )
 from app.settings import AppSettings, SettingsError
 
@@ -170,11 +171,19 @@ def create_production_app(
             additional_fixtures=_fixture_candidates(env_fixture, "env-params*.json"),
         )
     if trip_adapter is None:
-        trip_adapter = ModeDispatchTripAnalysisAdapter(
-            FixtureTripAnalysisAdapter(heatmap_fixture.parent / "trip-analysis.json"),
-            LiveTripAnalysisAdapter(
+        fixture_trip_adapter = FixtureTripAnalysisAdapter(
+            heatmap_fixture.parent / "trip-analysis.json"
+        )
+        live_trip_adapter: TripAnalysisAdapter
+        if execution is not None and env_params_execution is not None:
+            live_trip_adapter = TemporalTripAnalysisAdapter(execution, env_params_execution)
+        else:
+            live_trip_adapter = LiveTripAnalysisAdapter(
                 lambda request: {"unavailable": "live trip adapter is not configured"}
-            ),
+            )
+        trip_adapter = ModeDispatchTripAnalysisAdapter(
+            fixture_trip_adapter,
+            live_trip_adapter,
         )
     return create_app(
         heatmap_fixture,

--- a/docs/adr/0001-live-provider-adapter-boundary.md
+++ b/docs/adr/0001-live-provider-adapter-boundary.md
@@ -40,9 +40,15 @@ properties.
    60/80/100); area requests default internally to 100 m granularity. Full-day
    requests use filter_type 3; validated ranges use filter_type 2 with the
    same `start_date`, `start_time`, and `end_time` carried by the product
-   request. Dates are validated against the documented windows (historical >=
-   2019-01-01, forecast <= 12 h ahead); violations raise a classified
-   VALIDATION error before any billable submission.
+   request. The provider's range filter is **inclusive** of `end_time` (a live
+   call for `08:00`–`14:00` returned seven hourly readings) while the product
+   window is half-open, so the adapter renders `end_time` from the window's
+   last in-window hour (`end_hour - 1`). Sending the exclusive bound would bill
+   for an hour outside the trip and hand consumers a reading that
+   `TimeWindow.contains_hour` rejects. Dates are validated against the
+   documented windows (historical >= 2019-01-01, forecast <= 12 h ahead);
+   violations raise a classified VALIDATION error before any billable
+   submission.
 4. **The auth header is `api-key`** (raw key, no Bearer), per the official
    documentation and the observed live 401 with `X-API-Key`. The salvaged
    usage module already used `api-key`.
@@ -62,8 +68,13 @@ properties.
    full-day hourly series (filter_type 3) by default; an optional `hour`
    selects filter_type 1. A validated traveler window selects filter_type 2
    with matching `start_time` and `end_time` on both heatmap and environment
-   requests. The request explicitly lists the two consumed `analysis`
-   parameters (within the 3-parameter plan limit).
+   requests. The request explicitly lists the full `analysis` parameter set
+   (`ENVIRONMENT_PARAMETERS`, 17 names) rather than only the two the trip stage
+   consumes: a live call on 2026-08-29 accepted the full list and returned 15
+   of them, so there is no 3-parameter plan limit on this key. The two absent
+   names (`elevation`, `solar_irradiance`) are kept in the request — whether
+   the provider omitted them or returned them scalar-shaped (and the flat-shape
+   series filter dropped them) is undetermined without the raw payload.
 8. **Trip temporal preparation is a series-only contract stage.**
    `POST /api/trip/analyze` accepts a same-day half-open `start_hour` /
    `end_hour` window of at most twelve whole hours; it no longer accepts a
@@ -87,9 +98,11 @@ properties.
   documented-payload construction (issue #11 owns cache-key policy).
 - The translation adapter is the only place allowed to know the documented
   live shapes; `contracts.py` and `client.py` remain shape-neutral.
-- `fixtures/env-params.json` is regenerated in the documented series shape
-  (arrays + `metadata.timestamps`), built from the issue-7 recorded live
-  observation; the previous scalar fixture was an invented shape.
+- `fixtures/env-params.json` holds a recorded live series. It is in the
+  provider's *flat* shape (top-level `timestamp`/`timezone`/`offset`/`interval`/
+  `count` beside one array per parameter), not the documented `metadata` +
+  `locations` shape, so the adapter branches on the presence of a `metadata`
+  mapping and supports both. The earlier scalar fixture was an invented shape.
 - One risk accepted: the documented per-tile property name (`properties.temperature`)
   is undocumented; the adapter reads it from live evidence and stamps the
   inference in provenance. If the provider changes it, only the adapter

--- a/docs/adr/0001-live-provider-adapter-boundary.md
+++ b/docs/adr/0001-live-provider-adapter-boundary.md
@@ -99,7 +99,7 @@ properties.
 - The translation adapter is the only place allowed to know the documented
   live shapes; `contracts.py` and `client.py` remain shape-neutral.
 - `fixtures/env-params.json` holds a recorded live series. It is in the
-  provider's *flat* shape (top-level `timestamp`/`timezone`/`offset`/`interval`/
+  provider's _flat_ shape (top-level `timestamp`/`timezone`/`offset`/`interval`/
   `count` beside one array per parameter), not the documented `metadata` +
   `locations` shape, so the adapter branches on the presence of a `metadata`
   mapping and supports both. The earlier scalar fixture was an invented shape.

--- a/docs/adr/0001-live-provider-adapter-boundary.md
+++ b/docs/adr/0001-live-provider-adapter-boundary.md
@@ -37,10 +37,12 @@ properties.
    the internal request into the documented payload: point requests are
    expanded to a square AOI (side = granularity, centered on the point,
    default 60 m; `granularity` is exposed on the public request, allowed
-   60/80/100); area requests default internally to 100 m granularity. Dates are
-   validated against the documented windows (historical ≥ 2019-01-01, forecast
-   ≤ 12 h ahead); violations raise a classified VALIDATION error before any
-   billable submission.
+   60/80/100); area requests default internally to 100 m granularity. Full-day
+   requests use filter_type 3; validated ranges use filter_type 2 with the
+   same `start_date`, `start_time`, and `end_time` carried by the product
+   request. Dates are validated against the documented windows (historical >=
+   2019-01-01, forecast <= 12 h ahead); violations raise a classified
+   VALIDATION error before any billable submission.
 4. **The auth header is `api-key`** (raw key, no Bearer), per the official
    documentation and the observed live 401 with `X-API-Key`. The salvaged
    usage module already used `api-key`.
@@ -67,8 +69,13 @@ properties.
    `end_hour` window of at most twelve whole hours; it no longer accepts a
    selected visit `hour`. The initial `series_ready` response carries only the
    raw nullable environment series, timezone, conservative temperature anchor,
-   provenance, and the fixed-anchor warning. Hotel, route, best-time, and
-   comfort decisions remain outside this preparation stage.
+   provenance, and the fixed-anchor warning. Production wiring runs exactly
+   one ranged TCM heatmap execution at the curated destination, derives the
+   anchor as the maximum in-window Celsius tile value, then runs exactly one
+   env-params execution with identical coordinates and range. Each execution
+   retains its ADR 0004 cache/fixture degradation chain and submit-once ledger
+   behavior. Hotel, route, best-time, and comfort decisions remain outside
+   this preparation stage.
 
 ## Consequences
 

--- a/docs/adr/0001-live-provider-adapter-boundary.md
+++ b/docs/adr/0001-live-provider-adapter-boundary.md
@@ -23,8 +23,8 @@ properties.
 
 ## Decision
 
-1. **The internal domain contract is unchanged and stays the single validated
-   schema.** Live provider shapes never leak into it. A dedicated live adapter
+1. **The internal domain contract stays the single validated schema.** Live
+   provider shapes never leak into it. A dedicated live adapter
    (`app/integrations/fortyguard/live.py`) owns all provider-specific behavior:
    documented payload construction, envelope handling, translation into the
    internal shape, and inference stamping.
@@ -58,8 +58,17 @@ properties.
 7. **Environment parameters are part of the same boundary.** A public
    `POST /api/env-params` route mirrors the heatmap gating. Requests ask for a
    full-day hourly series (filter_type 3) by default; an optional `hour`
-   selects filter_type 1. The request explicitly lists the two consumed
-   `analysis` parameters (within the 3-parameter plan limit).
+   selects filter_type 1. A validated traveler window selects filter_type 2
+   with matching `start_time` and `end_time` on both heatmap and environment
+   requests. The request explicitly lists the two consumed `analysis`
+   parameters (within the 3-parameter plan limit).
+8. **Trip temporal preparation is a series-only contract stage.**
+   `POST /api/trip/analyze` accepts a same-day half-open `start_hour` /
+   `end_hour` window of at most twelve whole hours; it no longer accepts a
+   selected visit `hour`. The initial `series_ready` response carries only the
+   raw nullable environment series, timezone, conservative temperature anchor,
+   provenance, and the fixed-anchor warning. Hotel, route, best-time, and
+   comfort decisions remain outside this preparation stage.
 
 ## Consequences
 

--- a/docs/adr/0002-live-unit-and-freshness-inference.md
+++ b/docs/adr/0002-live-unit-and-freshness-inference.md
@@ -35,6 +35,10 @@ expansion) and responses (envelope unwrap, shape translation).
    - `valid_time_from_request` — the heatmap result carries no freshness, so
      the requested `date_time` is used as the tile valid time. This is
      definitionally true for what we asked, though not provider-attested.
+     Version 2 (point path) derives the hour from the requested window's start
+     when one was submitted (`filter_type` 2), because the returned readings
+     describe that window; full-day requests keep midnight. The area path stays
+     at version 1 — it submits no window.
    - `point_to_aoi_expansion` — a point request was expanded to a square AOI
      before submission.
    - `live_envelope_unwrapped` — the documented `data` envelope was hoisted.

--- a/fixtures/trip-analysis.acquisition.json
+++ b/fixtures/trip-analysis.acquisition.json
@@ -5,7 +5,8 @@
     "landmark_name": "The Alamo",
     "district_name": "Downtown San Antonio",
     "date": "2026-08-23",
-    "hour": 8,
+    "start_hour": 8,
+    "end_hour": 20,
     "origin": {
       "latitude": 29.4245914,
       "longitude": -98.4864288

--- a/fixtures/trip-analysis.json
+++ b/fixtures/trip-analysis.json
@@ -3,7 +3,8 @@
     "landmark_name": "The Alamo",
     "district_name": "Downtown San Antonio",
     "date": "2026-08-23",
-    "hour": 8,
+    "start_hour": 8,
+    "end_hour": 20,
     "origin": { "latitude": 29.4245914, "longitude": -98.4864288 },
     "destination": { "latitude": 29.425833, "longitude": -98.485833 }
   },

--- a/frontend/e2e/fixture-trip.spec.ts
+++ b/frontend/e2e/fixture-trip.spec.ts
@@ -13,7 +13,9 @@ test("analyzes the curated trip entirely from fixtures", async ({ page }) => {
 
   await expect(page.getByText("Fixture replay", { exact: true })).toBeVisible();
   await expect(
-    page.getByLabel("Curated trip places").getByText("The Alamo", { exact: true })
+    page
+      .getByLabel("Curated trip places")
+      .getByText("The Alamo", { exact: true })
   ).toBeVisible();
   const analysisResponse = page.waitForResponse((response) =>
     response.url().endsWith("/api/trip/analyze")

--- a/frontend/e2e/fixture-trip.spec.ts
+++ b/frontend/e2e/fixture-trip.spec.ts
@@ -12,7 +12,9 @@ test("analyzes the curated trip entirely from fixtures", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByText("Fixture replay", { exact: true })).toBeVisible();
-  await expect(page.getByText("The Alamo")).toBeVisible();
+  await expect(
+    page.getByLabel("Curated trip places").getByText("The Alamo", { exact: true })
+  ).toBeVisible();
   const analysisResponse = page.waitForResponse((response) =>
     response.url().endsWith("/api/trip/analyze")
   );

--- a/frontend/src/app/AppState.tsx
+++ b/frontend/src/app/AppState.tsx
@@ -48,7 +48,12 @@ export function AppProvider({ children }: { children: ReactNode }) {
     ranking: null,
     mode: queryMode ?? "success",
     tripAnalysis: null,
-    curatedTripSetup: { date: "2026-08-23", hour: 8, cautious: false },
+    curatedTripSetup: {
+      date: "2026-08-23",
+      startHour: 8,
+      endHour: 20,
+      cautious: false,
+    },
   });
   const value = useMemo<AppContextValue>(
     () => ({

--- a/frontend/src/screens/TripSetupScreen.tsx
+++ b/frontend/src/screens/TripSetupScreen.tsx
@@ -19,6 +19,32 @@ function validDate(value: string) {
   );
 }
 
+function formatMetric(value: number | null, unit?: string) {
+  return value === null
+    ? "Unavailable"
+    : `${value.toFixed(1)}${unit ? ` ${unit}` : ""}`;
+}
+
+function formatHour(validTime: string, timezone: string) {
+  return `${validTime.slice(11, 16)} ${timezone}`;
+}
+
+function formatParameterName(name: string) {
+  return name
+    .replaceAll("_", " ")
+    .replaceAll(":", " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function parameterUnit(name: string) {
+  if (name.includes("humidity") || name.includes("cloud_cover")) return "%";
+  if (name.includes("precipitation")) return "mm";
+  if (name.includes("irradiance")) return "W/m2";
+  if (name.includes("elevation")) return "m";
+  if (name.includes("index") || name.includes("temperature")) return "C";
+  return "";
+}
+
 export function TripSetupScreen() {
   const {
     curatedTripSetup,
@@ -26,11 +52,15 @@ export function TripSetupScreen() {
     tripAnalysis,
     setTripAnalysis,
   } = useAppState();
-  const { date, hour, cautious } = curatedTripSetup;
+  const { date, startHour, endHour, cautious } = curatedTripSetup;
   const [dateError, setDateError] = useState("");
+  const [startError, setStartError] = useState("");
+  const [endError, setEndError] = useState("");
   const [health, setHealth] = useState<HealthState>({ status: "checking" });
   const [requestState, setRequestState] = useState<RequestState>("idle");
   const dateRef = useRef<HTMLInputElement>(null);
+  const startRef = useRef<HTMLSelectElement>(null);
+  const endRef = useRef<HTMLSelectElement>(null);
 
   async function checkHealth(signal?: AbortSignal) {
     setHealth({ status: "checking" });
@@ -67,12 +97,26 @@ export function TripSetupScreen() {
 
   async function submit(event?: FormEvent) {
     event?.preventDefault();
-    if (!validDate(date)) {
-      setDateError("Enter a valid date.");
-      dateRef.current?.focus();
+    const invalidDate = !validDate(date);
+    const invalidOrder = startHour >= endHour;
+    const invalidLength = !invalidOrder && endHour - startHour > 12;
+    setDateError(invalidDate ? "Enter a valid date." : "");
+    setStartError(
+      invalidOrder ? "Start time must be earlier than end time." : ""
+    );
+    setEndError(
+      invalidOrder
+        ? "End time must be later than start time."
+        : invalidLength
+          ? "The time window cannot exceed 12 hours."
+          : ""
+    );
+    if (invalidDate || invalidOrder || invalidLength) {
+      if (invalidDate) dateRef.current?.focus();
+      else if (invalidOrder) startRef.current?.focus();
+      else endRef.current?.focus();
       return;
     }
-    setDateError("");
     if (health.status !== "available" || requestState === "submitting") return;
 
     const request: TripAnalysisRequest = {
@@ -84,7 +128,8 @@ export function TripSetupScreen() {
       landmark_name: "The Alamo",
       district_name: "Downtown San Antonio",
       date,
-      hour,
+      start_hour: startHour,
+      end_hour: endHour,
       cautious,
       execution_mode: health.mode,
     };
@@ -112,8 +157,8 @@ export function TripSetupScreen() {
         <span className="step-label">Curated San Antonio trip</span>
         <h1>Trip Setup</h1>
         <p>
-          Configure one analysis for the best time, nearby hotels, and walking
-          route for this fixed journey.
+          Select a date and time window for environmental conditions at The
+          Alamo.
         </p>
       </header>
 
@@ -166,16 +211,21 @@ export function TripSetupScreen() {
               )}
             </div>
             <div className="field">
-              <label htmlFor="trip-hour">Hour</label>
+              <label htmlFor="trip-start-hour">Start time</label>
               <select
-                id="trip-hour"
-                value={hour}
+                ref={startRef}
+                id="trip-start-hour"
+                value={startHour}
                 disabled={busy}
+                aria-invalid={Boolean(startError)}
+                aria-describedby={startError ? "start-hour-error" : undefined}
                 onChange={(event) => {
                   setCuratedTripSetup({
                     ...curatedTripSetup,
-                    hour: Number(event.target.value),
+                    startHour: Number(event.target.value),
                   });
+                  setStartError("");
+                  setEndError("");
                   setRequestState("idle");
                 }}
               >
@@ -185,6 +235,42 @@ export function TripSetupScreen() {
                   </option>
                 ))}
               </select>
+              {startError && (
+                <span id="start-hour-error" className="field-error">
+                  {startError}
+                </span>
+              )}
+            </div>
+            <div className="field">
+              <label htmlFor="trip-end-hour">End time</label>
+              <select
+                ref={endRef}
+                id="trip-end-hour"
+                value={endHour}
+                disabled={busy}
+                aria-invalid={Boolean(endError)}
+                aria-describedby={endError ? "end-hour-error" : undefined}
+                onChange={(event) => {
+                  setCuratedTripSetup({
+                    ...curatedTripSetup,
+                    endHour: Number(event.target.value),
+                  });
+                  setStartError("");
+                  setEndError("");
+                  setRequestState("idle");
+                }}
+              >
+                {HOURS.map((value) => (
+                  <option key={value} value={value}>
+                    {String(value).padStart(2, "0")}:00
+                  </option>
+                ))}
+              </select>
+              {endError && (
+                <span id="end-hour-error" className="field-error">
+                  {endError}
+                </span>
+              )}
             </div>
           </div>
 
@@ -279,6 +365,76 @@ export function TripSetupScreen() {
         >
           <CheckCircle2 size={24} />
           <div>
+            {tripAnalysis.state === "series_ready" &&
+              tripAnalysis.environment && (
+                <>
+                  <h2>Environmental conditions</h2>
+                  <div className="series-summary">
+                    <div>
+                      <span>Temperature anchor</span>
+                      <strong>
+                        {tripAnalysis.environment.temperature_anchor_celsius.toFixed(
+                          1
+                        )}{" "}
+                        C
+                      </strong>
+                    </div>
+                    <div>
+                      <span>Data source</span>
+                      <strong>
+                        {tripAnalysis.environment.provenance.source}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>Data date</span>
+                      <strong>
+                        {tripAnalysis.environment.provenance.data_date}
+                      </strong>
+                    </div>
+                  </div>
+                  <div className="series-table-wrap">
+                    <table className="series-table">
+                      <caption>Hourly environmental readings</caption>
+                      <thead>
+                        <tr>
+                          <th scope="col">Time</th>
+                          {Object.keys(
+                            tripAnalysis.environment.entries[0].parameters
+                          ).map((parameter) => (
+                            <th scope="col" key={parameter}>
+                              {formatParameterName(parameter)}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {tripAnalysis.environment.entries.map((entry) => (
+                          <tr key={entry.valid_time}>
+                            <th scope="row">
+                              {formatHour(
+                                entry.valid_time,
+                                tripAnalysis.environment!.timezone
+                              )}
+                            </th>
+                            {Object.keys(entry.parameters).map((parameter) => (
+                              <td key={parameter}>
+                                {formatMetric(
+                                  entry.parameters[parameter],
+                                  parameterUnit(parameter)
+                                )}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  <p className="series-warning">
+                    <AlertTriangle size={17} />
+                    {tripAnalysis.environment.warning}
+                  </p>
+                </>
+              )}
             {tripAnalysis.state === "success" && <h2>Trip analysis ready</h2>}
             {tripAnalysis.state === "degraded" && (
               <>

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -15,6 +15,50 @@ function isResultSection(value: unknown) {
   return value === null || isObject(value);
 }
 
+function isNullableFiniteNumber(value: unknown) {
+  return (
+    value === null || (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function validEnvironment(value: unknown) {
+  if (
+    !isObject(value) ||
+    !Array.isArray(value.entries) ||
+    value.entries.length === 0 ||
+    typeof value.timezone !== "string" ||
+    value.timezone.length === 0 ||
+    typeof value.temperature_anchor_celsius !== "number" ||
+    !Number.isFinite(value.temperature_anchor_celsius) ||
+    typeof value.warning !== "string" ||
+    !isObject(value.provenance)
+  ) {
+    return false;
+  }
+  const provenance = value.provenance;
+  return (
+    value.entries.every(
+      (entry) =>
+        isObject(entry) &&
+        typeof entry.valid_time === "string" &&
+        !Number.isNaN(Date.parse(entry.valid_time)) &&
+        isNullableFiniteNumber(entry.heat_index_celsius) &&
+        isNullableFiniteNumber(entry.humidity_percent) &&
+        isObject(entry.parameters) &&
+        Object.values(entry.parameters).every(isNullableFiniteNumber)
+    ) &&
+    typeof provenance.source === "string" &&
+    typeof provenance.data_date === "string" &&
+    typeof provenance.retrieved_at === "string" &&
+    typeof provenance.provider === "string" &&
+    typeof provenance.response_status === "string" &&
+    typeof provenance.fresh === "boolean" &&
+    (provenance.activity_id === null ||
+      typeof provenance.activity_id === "string") &&
+    isObject(provenance.request_configuration)
+  );
+}
+
 function validUnavailable(value: unknown) {
   return (
     isObject(value) &&
@@ -44,12 +88,13 @@ function isTripAnalysisResponse(
   if (
     !isObject(value) ||
     value.request_identity !==
-      `${request.mode}:${request.date}:${request.hour}` ||
+      `${request.mode}:${request.date}:${request.start_hour}-${request.end_hour}` ||
     value.mode !== request.mode ||
     value.execution_mode !== request.execution_mode ||
-    !["success", "degraded", "unavailable", "error"].includes(
+    !["series_ready", "success", "degraded", "unavailable", "error"].includes(
       String(value.state)
     ) ||
+    !(value.environment === null || validEnvironment(value.environment)) ||
     !isResultSection(value.best_time) ||
     !isResultSection(value.hotels) ||
     !isResultSection(value.routes)
@@ -57,6 +102,15 @@ function isTripAnalysisResponse(
     return false;
   }
   const hasResults = Boolean(value.best_time || value.hotels || value.routes);
+  if (value.state === "series_ready") {
+    return Boolean(
+      validEnvironment(value.environment) &&
+      !hasResults &&
+      value.unavailable === null &&
+      value.degraded_reasons === null
+    );
+  }
+  if (value.environment !== null) return false;
   if (value.state === "success") {
     return Boolean(
       value.best_time &&

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -693,7 +693,7 @@ dd {
 }
 .setup-fields {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
 }
 .field {
@@ -786,6 +786,7 @@ dd {
 }
 .setup-outcome > div {
   min-width: 0;
+  width: 100%;
 }
 .setup-outcome h2 {
   margin: 0 0 8px;
@@ -797,6 +798,79 @@ dd {
   margin: 10px 0 18px;
   padding-left: 20px;
   color: var(--muted);
+}
+.series-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 18px 0;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+.series-summary > div {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+  padding: 14px;
+  background: #f8faf7;
+}
+.series-summary span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.series-summary strong {
+  overflow-wrap: anywhere;
+}
+.series-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+}
+.series-table {
+  width: 100%;
+  min-width: 520px;
+  border-collapse: collapse;
+  text-align: left;
+}
+.series-table caption {
+  padding: 14px 16px;
+  color: var(--ink);
+  font-weight: 800;
+  text-align: left;
+}
+.series-table th,
+.series-table td {
+  padding: 11px 16px;
+  border-top: 1px solid var(--line);
+  white-space: nowrap;
+}
+.series-table thead th {
+  background: #edf2eb;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+.series-table tbody th {
+  color: var(--ink);
+}
+.series-table tbody tr:nth-child(even) {
+  background: #faf9f5;
+}
+.setup-outcome .series-warning {
+  display: flex;
+  gap: 9px;
+  align-items: flex-start;
+  margin: 16px 0 18px;
+  padding: 12px 14px;
+  background: #fff3d9;
+  color: #684c1b;
+  font-size: 13px;
+}
+.series-warning svg {
+  flex: none;
+  margin-top: 2px;
 }
 .setup-outcome.degraded {
   border-left-color: #c18320;
@@ -908,6 +982,9 @@ dd {
   }
   .setup-outcome {
     align-items: flex-start;
+  }
+  .series-summary {
+    grid-template-columns: minmax(0, 1fr);
   }
   .setup-card > button,
   .setup-outcome button,

--- a/frontend/src/test/tripSetup.test.tsx
+++ b/frontend/src/test/tripSetup.test.tsx
@@ -10,10 +10,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 
 const successResponse = {
-  request_identity: "curated:2026-08-23:8",
+  request_identity: "curated:2026-08-23:8-20",
   mode: "curated",
   execution_mode: "fixture",
   state: "success",
+  environment: null,
   best_time: { hourly: [] },
   hotels: { ranked: [] },
   routes: { alternatives: [] },
@@ -58,7 +59,8 @@ describe("curated Trip Setup", () => {
       screen.getByText("Downtown San Antonio / Alamo Plaza")
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Date")).toHaveValue("2026-08-23");
-    expect(screen.getByLabelText("Hour")).toHaveValue("8");
+    expect(screen.getByLabelText("Start time")).toHaveValue("8");
+    expect(screen.getByLabelText("End time")).toHaveValue("20");
     expect(screen.getByLabelText(/Cautious guidance/)).not.toBeChecked();
     expect(screen.getByText(/United States/)).toBeInTheDocument();
 
@@ -82,7 +84,8 @@ describe("curated Trip Setup", () => {
           landmark_name: "The Alamo",
           district_name: "Downtown San Antonio",
           date: "2026-08-23",
-          hour: 8,
+          start_hour: 8,
+          end_hour: 20,
           cautious: false,
           execution_mode: "fixture",
         }),
@@ -133,6 +136,107 @@ describe("curated Trip Setup", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("validates time order and the 12-hour maximum without submitting", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    const start = screen.getByLabelText("Start time");
+    const end = screen.getByLabelText("End time");
+
+    await user.selectOptions(start, "20");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+    expect(
+      screen.getByText("Start time must be earlier than end time.")
+    ).toBeInTheDocument();
+    expect(end).toHaveAttribute("aria-invalid", "true");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await user.selectOptions(start, "0");
+    await user.selectOptions(end, "13");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+    expect(
+      screen.getByText("The time window cannot exceed 12 hours.")
+    ).toBeInTheDocument();
+    expect(end).toHaveFocus();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts and displays the raw nullable environmental series", async () => {
+    mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse({
+        ...successResponse,
+        state: "series_ready",
+        environment: {
+          entries: [
+            {
+              valid_time: "2026-08-23T08:00:00-05:00",
+              heat_index_celsius: 31.4,
+              humidity_percent: 72.5,
+              parameters: {
+                heat_index_celsius: 31.4,
+                relative_humidity_percent: 72.5,
+                apparent_temperature_celsius: 35.1,
+              },
+            },
+            {
+              valid_time: "2026-08-23T09:00:00-05:00",
+              heat_index_celsius: null,
+              humidity_percent: 68,
+              parameters: {
+                heat_index_celsius: null,
+                relative_humidity_percent: 68,
+                apparent_temperature_celsius: null,
+              },
+            },
+          ],
+          timezone: "GMT-5",
+          temperature_anchor_celsius: 34.2,
+          warning: "fixed temperature anchor; not a real 24-hour forecast",
+          provenance: {
+            source: "fixture",
+            data_date: "2026-08-23",
+            confidence: "sufficient",
+            retrieved_at: "2026-08-24T00:00:00+00:00",
+            transformation_version: "trip-environment-series-v1",
+            provider: "fortyguard",
+            response_status: "completed",
+            request_configuration: {},
+            fresh: true,
+            coverage: null,
+            note: null,
+            activity_id: null,
+          },
+        },
+        best_time: null,
+        hotels: null,
+        routes: null,
+      })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Environmental conditions" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("08:00 GMT-5")).toBeInTheDocument();
+    expect(screen.getByText("31.4 C")).toBeInTheDocument();
+    expect(screen.getAllByText("Unavailable")).toHaveLength(2);
+    expect(screen.getByText("68.0 %")).toBeInTheDocument();
+    expect(screen.getByText("34.2 C")).toBeInTheDocument();
+    expect(
+      screen.getByText("fixed temperature anchor; not a real 24-hour forecast")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/best time/i)).not.toBeInTheDocument();
+  });
+
   it("announces busy state and disables setup controls", async () => {
     let resolveAnalysis!: (response: Response) => void;
     const pending = new Promise<Response>((resolve) => {
@@ -147,7 +251,8 @@ describe("curated Trip Setup", () => {
 
     expect(screen.getByRole("status")).toHaveTextContent("Analyzing trip...");
     expect(screen.getByLabelText("Date")).toBeDisabled();
-    expect(screen.getByLabelText("Hour")).toBeDisabled();
+    expect(screen.getByLabelText("Start time")).toBeDisabled();
+    expect(screen.getByLabelText("End time")).toBeDisabled();
     expect(screen.getByLabelText(/Cautious guidance/)).toBeDisabled();
     resolveAnalysis(jsonResponse(successResponse));
     expect(await screen.findByText("Trip analysis ready")).toBeInTheDocument();
@@ -181,7 +286,7 @@ describe("curated Trip Setup", () => {
       within(outcome).getByText("Hotel ranking is temporarily unavailable.")
     ).toBeInTheDocument();
 
-    await user.selectOptions(screen.getByLabelText("Hour"), "9");
+    await user.selectOptions(screen.getByLabelText("Start time"), "9");
     expect(screen.queryByText(/Trip analysis ready/)).not.toBeInTheDocument();
   });
 
@@ -221,7 +326,7 @@ describe("curated Trip Setup", () => {
       jsonResponse({ status: "ok", mode: "fixture" }),
       jsonResponse({
         ...successResponse,
-        request_identity: "curated:2026-08-23:9",
+        request_identity: "curated:2026-08-23:9-20",
       }),
       jsonResponse({ status: "ok", mode: "fixture" })
     );
@@ -229,7 +334,7 @@ describe("curated Trip Setup", () => {
 
     render(<App />);
     await screen.findByText("Fixture replay");
-    await user.selectOptions(screen.getByLabelText("Hour"), "9");
+    await user.selectOptions(screen.getByLabelText("Start time"), "9");
     await user.click(screen.getByRole("button", { name: "Analyze trip" }));
     await screen.findByText("Trip analysis ready");
 
@@ -241,7 +346,7 @@ describe("curated Trip Setup", () => {
     );
 
     expect(await screen.findByText("Trip analysis ready")).toBeInTheDocument();
-    expect(screen.getByLabelText("Hour")).toHaveValue("9");
+    expect(screen.getByLabelText("Start time")).toHaveValue("9");
   });
 
   it("clears a retained result when application mode changes", async () => {
@@ -277,7 +382,7 @@ describe("curated Trip Setup", () => {
       "mismatched request identity",
       jsonResponse({
         ...successResponse,
-        request_identity: "curated:2026-08-23:9",
+        request_identity: "curated:2026-08-23:9-20",
       }),
     ],
     [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -72,6 +72,36 @@ export type RequestOptions = {
 
 export type ExecutionMode = "fixture" | "live";
 
+export type ApiProvenance = {
+  source: string;
+  data_date: string;
+  confidence: "sufficient" | "insufficient";
+  retrieved_at: string;
+  transformation_version: string;
+  provider: string;
+  response_status: string;
+  request_configuration: Record<string, unknown>;
+  fresh: boolean;
+  coverage: number | null;
+  note: string | null;
+  activity_id: string | null;
+};
+
+export type EnvironmentSeriesEntry = {
+  valid_time: string;
+  heat_index_celsius: number | null;
+  humidity_percent: number | null;
+  parameters: Record<string, number | null>;
+};
+
+export type EnvironmentSeriesResult = {
+  entries: EnvironmentSeriesEntry[];
+  timezone: string;
+  temperature_anchor_celsius: number;
+  warning: string;
+  provenance: ApiProvenance;
+};
+
 export type TripAnalysisRequest = {
   mode: "curated";
   origin_latitude: number;
@@ -81,7 +111,8 @@ export type TripAnalysisRequest = {
   landmark_name: "The Alamo";
   district_name: "Downtown San Antonio";
   date: string;
-  hour: number;
+  start_hour: number;
+  end_hour: number;
   cautious: boolean;
   execution_mode: ExecutionMode;
 };
@@ -90,7 +121,8 @@ export type TripAnalysisResponse = {
   request_identity: string;
   mode: "curated";
   execution_mode: ExecutionMode;
-  state: "success" | "degraded" | "unavailable" | "error";
+  state: "series_ready" | "success" | "degraded" | "unavailable" | "error";
+  environment: EnvironmentSeriesResult | null;
   best_time: Record<string, unknown> | null;
   hotels: Record<string, unknown> | null;
   routes: Record<string, unknown> | null;
@@ -100,6 +132,7 @@ export type TripAnalysisResponse = {
 
 export type CuratedTripSetup = {
   date: string;
-  hour: number;
+  startHour: number;
+  endHour: number;
   cautious: boolean;
 };

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -115,7 +115,7 @@ def test_heatmap_acquisition_writes_raw_fixture_and_sidecar(tmp_path: Path) -> N
     assert stamps == (
         ("live_envelope_unwrapped", 1),
         ("point_to_aoi_expansion", 1),
-        ("valid_time_from_request", 1),
+        ("valid_time_from_request", 2),
         ("tcm_unit_celsius", 1),
     )
 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -117,7 +117,8 @@ def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> No
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown San Antonio",
                 "date": "2026-08-23",
-                "hour": 8,
+                "start_hour": 8,
+                "end_hour": 20,
             }
         ).encode()
         response = urlopen(
@@ -146,7 +147,7 @@ def test_trip_analysis_endpoint_returns_ranked_hotels_and_route_decision() -> No
         thread.join(timeout=2)
 
 
-def test_trip_analysis_endpoint_returns_unavailable_for_unmatched_hour() -> None:
+def test_trip_analysis_endpoint_returns_unavailable_for_unmatched_window() -> None:
     server = create_fixture_server(
         Path("fixtures/heatmap-historical.json"),
         trip_adapter=FixtureTripAnalysisAdapter(Path("fixtures/trip-analysis.json")),
@@ -164,7 +165,8 @@ def test_trip_analysis_endpoint_returns_unavailable_for_unmatched_hour() -> None
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown San Antonio",
                 "date": "2026-08-23",
-                "hour": 9,
+                "start_hour": 9,
+                "end_hour": 20,
             }
         ).encode()
         response = urlopen(
@@ -204,7 +206,8 @@ def test_trip_analysis_returns_explicit_unavailable_contract() -> None:
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown San Antonio",
                 "date": "2026-08-23",
-                "hour": 14,
+                "start_hour": 8,
+                "end_hour": 20,
             }
         ).encode()
         response = urlopen(
@@ -247,7 +250,8 @@ def test_trip_analysis_rejects_untrusted_metric_and_provenance_fields() -> None:
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown San Antonio",
                 "date": "2026-08-23",
-                "hour": 14,
+                "start_hour": 8,
+                "end_hour": 20,
                 "heat_metric": "heat_index_celsius",
                 "heat_value": 38,
                 "heat_threshold": 35,
@@ -298,7 +302,8 @@ def test_trip_analysis_rejects_malformed_adapter_response() -> None:
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown San Antonio",
                 "date": "2026-08-23",
-                "hour": 14,
+                "start_hour": 8,
+                "end_hour": 20,
             }
         ).encode()
         with pytest.raises(HTTPError) as caught:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -76,7 +76,8 @@ def _valid_request(**overrides: object) -> TripAnalysisRequest:
         "landmark_name": "The Alamo",
         "district_name": "Downtown San Antonio",
         "date": "2026-08-23",
-        "hour": 14,
+        "start_hour": 8,
+        "end_hour": 20,
         "cautious": False,
     }
     defaults.update(overrides)
@@ -281,7 +282,7 @@ class TestIncompleteFields:
 
     def test_request_hour_out_of_range(self) -> None:
         with pytest.raises(ValueError, match="hour"):
-            _valid_request(hour=24)
+            _valid_request(end_hour=24)
 
     def test_response_success_missing_best_time(self) -> None:
         with pytest.raises(ValueError, match="BestTimeResult"):
@@ -768,7 +769,8 @@ class TestApiContractValidation:
                     "landmark_name": "The Alamo",
                     "district_name": "Downtown",
                     "date": "2026-08-23",
-                    "hour": 14,
+                    "start_hour": 8,
+                    "end_hour": 20,
                 }
             )
 
@@ -784,12 +786,13 @@ class TestApiContractValidation:
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown",
                 "date": "2026-08-23",
-                "hour": 12,
+                "start_hour": 8,
+                "end_hour": 20,
                 "mode": "curated",
             }
         )
         assert request.cautious is False
-        assert request.hour == 12
+        assert request.window.hours == range(8, 20)
 
     def test_full_contract_body_accepted(self) -> None:
         from app.api import _parse_trip_request
@@ -804,14 +807,16 @@ class TestApiContractValidation:
                 "landmark_name": "The Alamo",
                 "district_name": "Downtown San Antonio",
                 "date": "2026-08-23",
-                "hour": 14,
+                "start_hour": 8,
+                "end_hour": 20,
                 "cautious": True,
             }
         )
         assert request.mode is TripMode.EXPLORATORY
         assert request.landmark_name == "The Alamo"
         assert request.cautious is True
-        assert request.hour == 14
+        assert request.start_hour == 8
+        assert request.end_hour == 20
 
     def test_string_cautious_value_rejected(self) -> None:
         from app.api import _parse_trip_request
@@ -827,7 +832,8 @@ class TestApiContractValidation:
                     "landmark_name": "The Alamo",
                     "district_name": "Downtown",
                     "date": "2026-08-23",
-                    "hour": 14,
+                    "start_hour": 8,
+                    "end_hour": 20,
                     "cautious": "false",
                 }
             )

--- a/tests/test_environment_window.py
+++ b/tests/test_environment_window.py
@@ -1,0 +1,88 @@
+"""Offline tests for the temporal data-prep domain (issue #44).
+
+Covers the traveler time window (one day, whole hours, at most 12 hours) and
+the conservative anchor-selection policy that chains the heatmap result into
+the environmental-parameters request.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+
+from app.domain.environment import TimeWindow, select_anchor_celsius
+
+
+@dataclass(frozen=True)
+class Reading:
+    """Structural stand-in for a provider tile: only what the policy consumes."""
+
+    valid_time: datetime
+    value_celsius: float | None
+
+
+def _reading(hour: int, value: float | None) -> Reading:
+    return Reading(datetime(2026, 8, 23, hour, 0), value)
+
+
+class TestTimeWindow:
+    def test_accepts_a_valid_window(self) -> None:
+        window = TimeWindow(8, 20)
+        assert window.hours == range(8, 20)
+        assert window.start_time() == "08:00"
+        assert window.end_time() == "20:00"
+
+    def test_accepts_exactly_twelve_hours(self) -> None:
+        assert TimeWindow(0, 12).hours == range(0, 12)
+        assert TimeWindow(11, 23).hours == range(11, 23)
+
+    def test_rejects_a_window_longer_than_twelve_hours(self) -> None:
+        with pytest.raises(ValueError, match="at most 12 hours"):
+            TimeWindow(0, 13)
+
+    def test_rejects_start_not_before_end(self) -> None:
+        with pytest.raises(ValueError, match="before end_hour"):
+            TimeWindow(9, 9)
+        with pytest.raises(ValueError, match="before end_hour"):
+            TimeWindow(10, 9)
+
+    @pytest.mark.parametrize("bound", [-1, 24, 8.0, True, "8"])  # type: ignore[misc]
+    def test_rejects_non_whole_hour_bounds(self, bound: object) -> None:
+        with pytest.raises(ValueError, match="between 0 and 23"):
+            TimeWindow(bound, 20)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="between 0 and 23"):
+            TimeWindow(8, bound)  # type: ignore[arg-type]
+
+    def test_window_is_half_open(self) -> None:
+        window = TimeWindow(8, 9)
+        assert window.contains_hour(8)
+        assert not window.contains_hour(9)
+
+
+class TestSelectAnchorCelsius:
+    def test_returns_the_maximum_in_window_reading(self) -> None:
+        readings = [_reading(7, 30.0), _reading(9, 35.5), _reading(15, 41.0), _reading(19, 38.2)]
+        assert select_anchor_celsius(readings, TimeWindow(8, 20)) == 41.0
+
+    def test_ignores_readings_outside_the_window(self) -> None:
+        readings = [_reading(7, 50.0), _reading(20, 45.0), _reading(10, 33.0)]
+        assert select_anchor_celsius(readings, TimeWindow(8, 20)) == 33.0
+
+    def test_ignores_readings_without_a_celsius_value(self) -> None:
+        # Non-tcm tiles carry value_celsius=None; the policy skips them.
+        readings = [_reading(9, None), _reading(12, 36.0)]
+        assert select_anchor_celsius(readings, TimeWindow(8, 20)) == 36.0
+
+    def test_tied_maxima_resolve_to_the_same_anchor(self) -> None:
+        readings = [_reading(9, 40.0), _reading(15, 40.0)]
+        assert select_anchor_celsius(readings, TimeWindow(8, 20)) == 40.0
+
+    def test_raises_when_no_reading_falls_inside_the_window(self) -> None:
+        with pytest.raises(ValueError, match="no in-window temperature"):
+            select_anchor_celsius([_reading(7, 30.0)], TimeWindow(8, 20))
+
+    def test_raises_when_every_in_window_reading_lacks_a_value(self) -> None:
+        with pytest.raises(ValueError, match="no in-window temperature"):
+            select_anchor_celsius([_reading(9, None), _reading(10, None)], TimeWindow(8, 20))

--- a/tests/test_environment_window.py
+++ b/tests/test_environment_window.py
@@ -32,7 +32,23 @@ class TestTimeWindow:
         window = TimeWindow(8, 20)
         assert window.hours == range(8, 20)
         assert window.start_time() == "08:00"
-        assert window.end_time() == "20:00"
+        assert window.end_time() == "19:00"
+
+    def test_end_time_is_the_last_in_window_hour(self) -> None:
+        """The provider's range filter is inclusive; this window is half-open.
+
+        A live call for 08:00-14:00 returned seven readings, so ``end_time``
+        must render the last hour the traveler is actually present for.
+        """
+        window = TimeWindow(8, 14)
+        assert window.last_hour == 13
+        assert window.end_time() == "13:00"
+        assert window.contains_hour(13)
+        assert not window.contains_hour(14)
+
+    def test_single_hour_window_asks_for_exactly_that_hour(self) -> None:
+        window = TimeWindow(8, 9)
+        assert window.start_time() == window.end_time() == "08:00"
 
     def test_accepts_exactly_twelve_hours(self) -> None:
         assert TimeWindow(0, 12).hours == range(0, 12)

--- a/tests/test_execution_degradation.py
+++ b/tests/test_execution_degradation.py
@@ -46,7 +46,7 @@ RAW_TCM_RESULT: dict[str, Any] = {
 TCM_STAMPS = (
     ("live_envelope_unwrapped", 1),
     ("point_to_aoi_expansion", 1),
-    ("valid_time_from_request", 1),
+    ("valid_time_from_request", 2),
     ("tcm_unit_celsius", 1),
 )
 

--- a/tests/test_fortyguard_live.py
+++ b/tests/test_fortyguard_live.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.integrations.fortyguard.client import FortyGuardClient, poll_activity
 from app.integrations.fortyguard.contracts import (
+    ENVIRONMENT_PARAMETERS,
     AnalyticType,
     EnvParamsRequest,
     HeatmapRequest,
@@ -381,7 +382,7 @@ def test_adapter_load_translates_and_stamps_transformations() -> None:
     assert stamps == {
         "live_envelope_unwrapped": 1,
         "point_to_aoi_expansion": 1,
-        "valid_time_from_request": 1,
+        "valid_time_from_request": 2,
         "tcm_unit_celsius": 1,
     }
     result = normalize_heatmap_response(
@@ -556,7 +557,7 @@ def test_env_params_documented_payload_full_day_and_hourly() -> None:
     payload = build_documented_env_params_payload(_env_request())
     assert payload["date_time"] == {"start_date": "2026-08-24", "filter_type": 3}
     assert payload["temperature"] == 35.0
-    assert payload["analysis"] == ["heat_index_celsius", "relative_humidity_percent"]
+    assert payload["analysis"] == list(ENVIRONMENT_PARAMETERS)
     hourly = build_documented_env_params_payload(_env_request(hour=13))
     assert hourly["date_time"] == {
         "start_date": "2026-08-24",

--- a/tests/test_range_payloads.py
+++ b/tests/test_range_payloads.py
@@ -167,7 +167,7 @@ class TestHeatmapRangePayload:
             "start_date": date.today().isoformat(),
             "filter_type": 2,
             "start_time": "08:00",
-            "end_time": "20:00",
+            "end_time": "19:00",
         }
 
     def test_full_day_request_still_emits_filter_type_three(self) -> None:
@@ -213,8 +213,27 @@ class TestEnvParamsRangePayload:
             "start_date": "2026-08-24",
             "filter_type": 2,
             "start_time": "08:00",
-            "end_time": "20:00",
+            "end_time": "19:00",
         }
+
+    def test_inclusive_range_asks_for_exactly_the_in_window_hours(self) -> None:
+        """The provider range is inclusive, so the bounds must be in-window hours.
+
+        A live call for 08:00-14:00 returned seven hourly readings. Sending the
+        exclusive ``end_hour`` would bill for one hour the traveler is not
+        present for and hand the series an entry ``contains_hour`` rejects.
+        """
+        request = _env_request(start_hour=8, end_hour=20)
+        window = request.window
+        assert window is not None
+        date_time = cast(
+            "dict[str, str]", build_documented_env_params_payload(request)["date_time"]
+        )
+
+        first = int(date_time["start_time"][:2])
+        last = int(date_time["end_time"][:2])
+        assert [*range(first, last + 1)] == [*window.hours]
+        assert last - first + 1 <= MAX_WINDOW_HOURS
 
     def test_full_day_request_still_emits_filter_type_three(self) -> None:
         payload = build_documented_env_params_payload(_env_request())

--- a/tests/test_range_payloads.py
+++ b/tests/test_range_payloads.py
@@ -11,23 +11,57 @@ behaviour is preserved.
 
 from __future__ import annotations
 
-from datetime import date, timedelta
-from typing import cast
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, cast
 
 import pytest
 
-from app.domain.environment import MAX_WINDOW_HOURS
+from app.domain.environment import MAX_WINDOW_HOURS, select_anchor_celsius
 from app.integrations.fortyguard.contracts import (
     AnalyticType,
     EnvParamsRequest,
     HeatmapRequest,
+    normalize_heatmap_response,
 )
 from app.integrations.fortyguard.errors import ProviderError, ProviderErrorKind
 from app.integrations.fortyguard.live import (
     build_documented_env_params_payload,
     build_documented_heatmap_payload,
+    translate_heatmap_response,
 )
 from app.services.execution import env_params_request_payload, heatmap_request_payload
+
+
+def _raw_tcm_map_data() -> dict[str, object]:
+    """A completed live tcm result: the provider stamps no per-feature time."""
+    return {
+        "map_data": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [-98.5, 29.4],
+                                [-98.4, 29.4],
+                                [-98.4, 29.5],
+                                [-98.5, 29.5],
+                                [-98.5, 29.4],
+                            ]
+                        ],
+                    },
+                    "properties": {
+                        "average_temperature": 36.5,
+                        "min_temperature": 28.1,
+                        "max_temperature": 41.2,
+                    },
+                }
+            ],
+        },
+        "stats_data": {"units": "celsius", "analytic_type": "tcm"},
+    }
 
 
 def _tcm_request(**overrides: object) -> HeatmapRequest:
@@ -222,3 +256,51 @@ class TestRequestIdentityPayloads:
         identity = env_params_request_payload(_env_request())
         assert "start_hour" not in identity
         assert "end_hour" not in identity
+
+
+# --- Translated tile timestamps: the anchor contract --- #
+
+
+class TestWindowedTileValidTime:
+    """A windowed request must produce tiles the anchor policy accepts.
+
+    The provider echoes no per-feature timestamp, so the translator stamps one
+    from the request. Stamping midnight put every tile outside the traveler
+    window, which made ``select_anchor_celsius`` reject live readings for any
+    daytime window and reported the trip as ``unavailable``.
+    """
+
+    def test_range_request_stamps_tiles_with_the_window_start_hour(self) -> None:
+        request = _tcm_request(start_hour=8, end_hour=14)
+        translated = translate_heatmap_response(_raw_tcm_map_data(), request=request)
+        feature = cast(list[dict[str, Any]], translated["features"])[0]
+        properties = cast(dict[str, Any], feature["properties"])
+        assert properties["valid_time"] == f"{date.today().isoformat()}T08:00:00+00:00"
+
+    def test_full_day_request_still_stamps_midnight(self) -> None:
+        translated = translate_heatmap_response(_raw_tcm_map_data(), request=_tcm_request())
+        feature = cast(list[dict[str, Any]], translated["features"])[0]
+        properties = cast(dict[str, Any], feature["properties"])
+        assert properties["valid_time"] == f"{date.today().isoformat()}T00:00:00+00:00"
+
+    def test_windowed_tiles_anchor_inside_the_traveler_window(self) -> None:
+        request = _tcm_request(start_hour=8, end_hour=14)
+        window = request.window
+        assert window is not None
+        result = normalize_heatmap_response(
+            translate_heatmap_response(_raw_tcm_map_data(), request=request),
+            request=request,
+            retrieved_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+        )
+        assert select_anchor_celsius(result.tiles, window) == 36.5
+
+    def test_late_window_also_anchors(self) -> None:
+        request = _tcm_request(start_hour=15, end_hour=21)
+        window = request.window
+        assert window is not None
+        result = normalize_heatmap_response(
+            translate_heatmap_response(_raw_tcm_map_data(), request=request),
+            request=request,
+            retrieved_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+        )
+        assert select_anchor_celsius(result.tiles, window) == 36.5

--- a/tests/test_range_payloads.py
+++ b/tests/test_range_payloads.py
@@ -1,0 +1,224 @@
+"""Offline tests for the hour-range (filter_type 2) provider payloads (issue #44).
+
+Both the heatmap and env-params requests grow an optional ``start_hour`` /
+``end_hour`` window. When set, the documented provider payloads must carry
+``filter_type: 2`` with identical ``start_date``, ``start_time``, and
+``end_time`` for both requests, so the chained trip flow issues one billable
+heatmap call and one billable env-params call over the exact window the
+traveler selected. Existing full-day (filter 3) and single-hour (filter 1)
+behaviour is preserved.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import cast
+
+import pytest
+
+from app.domain.environment import MAX_WINDOW_HOURS
+from app.integrations.fortyguard.contracts import (
+    AnalyticType,
+    EnvParamsRequest,
+    HeatmapRequest,
+)
+from app.integrations.fortyguard.errors import ProviderError, ProviderErrorKind
+from app.integrations.fortyguard.live import (
+    build_documented_env_params_payload,
+    build_documented_heatmap_payload,
+)
+from app.services.execution import env_params_request_payload, heatmap_request_payload
+
+
+def _tcm_request(**overrides: object) -> HeatmapRequest:
+    defaults: dict[str, object] = {
+        "analytic_type": AnalyticType.TCM,
+        "latitude": 29.4241,
+        "longitude": -98.4936,
+        "start_date": date.today(),
+        "forecast": True,
+    }
+    defaults.update(overrides)
+    return HeatmapRequest(**defaults)  # type: ignore[arg-type]
+
+
+def _env_request(**overrides: object) -> EnvParamsRequest:
+    defaults: dict[str, object] = {
+        "latitude": 29.4241,
+        "longitude": -98.4936,
+        "start_date": date(2026, 8, 24),
+        "temperature_anchor_celsius": 35.0,
+    }
+    defaults.update(overrides)
+    return EnvParamsRequest(**defaults)  # type: ignore[arg-type]
+
+
+# --- HeatmapRequest window fields --- #
+
+
+class TestHeatmapRequestWindow:
+    def test_accepts_a_valid_window(self) -> None:
+        request = _tcm_request(start_hour=8, end_hour=20)
+        assert request.start_hour == 8
+        assert request.end_hour == 20
+
+    def test_window_may_span_exactly_twelve_hours(self) -> None:
+        request = _tcm_request(start_hour=10, end_hour=10 + MAX_WINDOW_HOURS)
+        assert request.hours is not None
+
+    def test_rejects_only_one_bound_set(self) -> None:
+        with pytest.raises(ValueError, match="together"):
+            _tcm_request(start_hour=8)
+        with pytest.raises(ValueError, match="together"):
+            _tcm_request(end_hour=20)
+
+    def test_rejects_window_longer_than_twelve_hours(self) -> None:
+        with pytest.raises(ValueError, match="at most 12 hours"):
+            _tcm_request(start_hour=0, end_hour=13)
+
+    def test_rejects_start_not_before_end(self) -> None:
+        with pytest.raises(ValueError, match="before end_hour"):
+            _tcm_request(start_hour=9, end_hour=9)
+        with pytest.raises(ValueError, match="before end_hour"):
+            _tcm_request(start_hour=10, end_hour=9)
+
+    def test_rejects_non_whole_hour_bounds(self) -> None:
+        with pytest.raises(ValueError, match="between 0 and 23"):
+            _tcm_request(start_hour=-1, end_hour=20)
+        with pytest.raises(ValueError, match="between 0 and 23"):
+            _tcm_request(start_hour=8, end_hour=24)
+        with pytest.raises(ValueError, match="between 0 and 23"):
+            _tcm_request(start_hour=8.0, end_hour=20)
+        with pytest.raises(ValueError, match="between 0 and 23"):
+            _tcm_request(start_hour=True, end_hour=20)
+
+
+# --- EnvParamsRequest window fields --- #
+
+
+class TestEnvParamsRequestWindow:
+    def test_accepts_a_valid_window(self) -> None:
+        request = _env_request(start_hour=8, end_hour=20)
+        assert request.start_hour == 8
+        assert request.end_hour == 20
+
+    def test_rejects_only_one_bound_set(self) -> None:
+        with pytest.raises(ValueError, match="together"):
+            _env_request(start_hour=8)
+        with pytest.raises(ValueError, match="together"):
+            _env_request(end_hour=20)
+
+    def test_rejects_window_longer_than_twelve_hours(self) -> None:
+        with pytest.raises(ValueError, match="at most 12 hours"):
+            _env_request(start_hour=0, end_hour=13)
+
+    def test_rejects_start_not_before_end(self) -> None:
+        with pytest.raises(ValueError, match="before end_hour"):
+            _env_request(start_hour=9, end_hour=9)
+
+    def test_rejects_non_whole_hour_bounds(self) -> None:
+        with pytest.raises(ValueError, match="between 0 and 23"):
+            _env_request(start_hour=8, end_hour="20")
+
+
+# --- Documented heatmap payload: filter_type 2 --- #
+
+
+class TestHeatmapRangePayload:
+    def test_range_request_emits_filter_type_two_with_window(self) -> None:
+        payload = build_documented_heatmap_payload(
+            _tcm_request(start_hour=8, end_hour=20), today=date.today()
+        )
+        assert payload["date_time"] == {
+            "start_date": date.today().isoformat(),
+            "filter_type": 2,
+            "start_time": "08:00",
+            "end_time": "20:00",
+        }
+
+    def test_full_day_request_still_emits_filter_type_three(self) -> None:
+        payload = build_documented_heatmap_payload(_tcm_request(), today=date.today())
+        assert payload["date_time"] == {"start_date": date.today().isoformat(), "filter_type": 3}
+
+    def test_historical_range_request_is_valid(self) -> None:
+        request = _historical_tcm_request(start_hour=8, end_hour=20)
+        payload = build_documented_heatmap_payload(request, today=date.today())
+        date_time = cast("dict[str, object]", payload["date_time"])
+        assert date_time["filter_type"] == 2
+
+    def test_range_forecast_beyond_documented_window_rejected(self) -> None:
+        request = _tcm_request(
+            start_date=date.today() + timedelta(days=1), start_hour=8, end_hour=20
+        )
+        with pytest.raises(ProviderError) as error:
+            build_documented_heatmap_payload(request, today=date.today())
+        assert error.value.kind is ProviderErrorKind.VALIDATION
+
+
+def _historical_tcm_request(**overrides: object) -> HeatmapRequest:
+    defaults: dict[str, object] = {
+        "analytic_type": AnalyticType.TCM,
+        "latitude": 29.4241,
+        "longitude": -98.4936,
+        "start_date": date(2026, 8, 20),
+        "forecast": False,
+        "start_hour": 8,
+        "end_hour": 20,
+    }
+    defaults.update(overrides)
+    return HeatmapRequest(**defaults)  # type: ignore[arg-type]
+
+
+# --- Documented env-params payload: filter_type 2 --- #
+
+
+class TestEnvParamsRangePayload:
+    def test_range_request_emits_filter_type_two_with_window(self) -> None:
+        payload = build_documented_env_params_payload(_env_request(start_hour=8, end_hour=20))
+        assert payload["date_time"] == {
+            "start_date": "2026-08-24",
+            "filter_type": 2,
+            "start_time": "08:00",
+            "end_time": "20:00",
+        }
+
+    def test_full_day_request_still_emits_filter_type_three(self) -> None:
+        payload = build_documented_env_params_payload(_env_request())
+        assert payload["date_time"] == {"start_date": "2026-08-24", "filter_type": 3}
+
+    def test_single_hour_request_still_emits_filter_type_one(self) -> None:
+        payload = build_documented_env_params_payload(_env_request(hour=13))
+        assert payload["date_time"] == {
+            "start_date": "2026-08-24",
+            "filter_type": 1,
+            "start_time": "13:00",
+        }
+
+    def test_range_and_hour_are_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError, match="together"):
+            _env_request(start_hour=8, end_hour=20, hour=13)
+
+
+# --- Request identity for cache keys and fixture matching --- #
+
+
+class TestRequestIdentityPayloads:
+    def test_heatmap_identity_includes_the_window(self) -> None:
+        identity = heatmap_request_payload(_tcm_request(start_hour=8, end_hour=20))
+        assert identity["start_hour"] == 8
+        assert identity["end_hour"] == 20
+
+    def test_heatmap_identity_without_window_omits_window_fields(self) -> None:
+        identity = heatmap_request_payload(_tcm_request())
+        assert "start_hour" not in identity
+        assert "end_hour" not in identity
+
+    def test_env_params_identity_includes_the_window(self) -> None:
+        identity = env_params_request_payload(_env_request(start_hour=8, end_hour=20))
+        assert identity["start_hour"] == 8
+        assert identity["end_hour"] == 20
+
+    def test_env_params_identity_without_window_omits_window_fields(self) -> None:
+        identity = env_params_request_payload(_env_request())
+        assert "start_hour" not in identity
+        assert "end_hour" not in identity

--- a/tests/test_temporal_trip_contract.py
+++ b/tests/test_temporal_trip_contract.py
@@ -166,6 +166,16 @@ class TestSeriesReadyResponse:
                 provenance=_provenance(),
             )
 
+    @pytest.mark.parametrize("humidity", [-0.1, 100.1, 999.0])
+    def test_entry_rejects_out_of_range_humidity(self, humidity: float) -> None:
+        """Widening the entry to carry every parameter must not drop this bound."""
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            EnvironmentSeriesEntry(
+                valid_time=datetime.fromisoformat("2026-08-23T08:00:00-05:00"),
+                heat_index_celsius=33.2,
+                humidity_percent=humidity,
+            )
+
 
 class TestTemporalTripApi:
     def test_endpoint_accepts_a_valid_window(self) -> None:

--- a/tests/test_temporal_trip_contract.py
+++ b/tests/test_temporal_trip_contract.py
@@ -236,7 +236,7 @@ class TestTemporalTripApi:
         )
 
         assert request.window.start_time() == "08:00"
-        assert request.window.end_time() == "20:00"
+        assert request.window.end_time() == "19:00"
 
     def test_api_rejects_a_missing_window_bound(self) -> None:
         with pytest.raises(ValueError, match="end_hour"):

--- a/tests/test_temporal_trip_contract.py
+++ b/tests/test_temporal_trip_contract.py
@@ -100,7 +100,7 @@ class TestTemporalTripRequest:
         assert list(request.window.hours) == list(range(8, 20))
         assert not hasattr(request, "hour")
 
-    @pytest.mark.parametrize(
+    @pytest.mark.parametrize(  # type: ignore[misc]
         ("overrides", "message"),
         [
             ({"start_hour": 8, "end_hour": 21}, "at most 12 hours"),
@@ -166,7 +166,7 @@ class TestSeriesReadyResponse:
                 provenance=_provenance(),
             )
 
-    @pytest.mark.parametrize("humidity", [-0.1, 100.1, 999.0])
+    @pytest.mark.parametrize("humidity", [-0.1, 100.1, 999.0])  # type: ignore[misc]
     def test_entry_rejects_out_of_range_humidity(self, humidity: float) -> None:
         """Widening the entry to carry every parameter must not drop this bound."""
         with pytest.raises(ValueError, match="between 0 and 100"):
@@ -191,7 +191,7 @@ class TestTemporalTripApi:
         assert response.status_code == 200
         assert response.json()["request_identity"] == "curated:2026-08-23:8-20"
 
-    @pytest.mark.parametrize(
+    @pytest.mark.parametrize(  # type: ignore[misc]
         "overrides",
         [
             {"end_hour": None},

--- a/tests/test_temporal_trip_contract.py
+++ b/tests/test_temporal_trip_contract.py
@@ -1,0 +1,245 @@
+"""Temporal trip request and series-only response contracts for issue #44."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api import _parse_trip_request, create_app
+from app.domain.contracts import (
+    Confidence,
+    Coordinates,
+    EnvironmentSeriesEntry,
+    EnvironmentSeriesResult,
+    ExecutionMode,
+    Provenance,
+    ResultState,
+    TripAnalysisRequest,
+    TripAnalysisResponse,
+    TripMode,
+)
+from app.services.trip_adapters import FixtureTripAnalysisAdapter
+
+
+def _trip_body(**overrides: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "origin_latitude": 29.4245914,
+        "origin_longitude": -98.4864288,
+        "destination_latitude": 29.425833,
+        "destination_longitude": -98.485833,
+        "mode": "curated",
+        "landmark_name": "The Alamo",
+        "district_name": "Downtown San Antonio",
+        "date": "2026-08-23",
+        "start_hour": 8,
+        "end_hour": 20,
+    }
+    body.update(overrides)
+    return body
+
+
+def _request(**overrides: object) -> TripAnalysisRequest:
+    values: dict[str, object] = {
+        "mode": TripMode.CURATED,
+        "origin": Coordinates(29.4245914, -98.4864288),
+        "destination": Coordinates(29.425833, -98.485833),
+        "landmark_name": "The Alamo",
+        "district_name": "Downtown San Antonio",
+        "date": "2026-08-23",
+        "start_hour": 8,
+        "end_hour": 20,
+        "cautious": False,
+    }
+    values.update(overrides)
+    return TripAnalysisRequest(**values)  # type: ignore[arg-type]
+
+
+def _provenance() -> Provenance:
+    return Provenance(
+        source="fixture",
+        data_date="2026-08-23",
+        confidence=Confidence.SUFFICIENT,
+        retrieved_at="2026-08-24T00:00:00+00:00",
+        transformation_version="trip-environment-series-v1",
+        provider="fortyguard",
+        response_status="completed",
+        request_configuration={"start_hour": 8, "end_hour": 20},
+        fresh=True,
+        coverage=1.0,
+    )
+
+
+def _environment() -> EnvironmentSeriesResult:
+    return EnvironmentSeriesResult(
+        entries=(
+            EnvironmentSeriesEntry(
+                valid_time=datetime.fromisoformat("2026-08-23T08:00:00-05:00"),
+                heat_index_celsius=None,
+                humidity_percent=54.0,
+            ),
+            EnvironmentSeriesEntry(
+                valid_time=datetime.fromisoformat("2026-08-23T09:00:00-05:00"),
+                heat_index_celsius=33.2,
+                humidity_percent=None,
+            ),
+        ),
+        timezone="America/Chicago",
+        temperature_anchor_celsius=36.4,
+        warning="fixed temperature anchor; not a real 24-hour forecast",
+        provenance=_provenance(),
+    )
+
+
+class TestTemporalTripRequest:
+    def test_request_carries_the_traveler_window_without_a_visit_hour(self) -> None:
+        request = _request()
+
+        assert request.window.start_hour == 8
+        assert request.window.end_hour == 20
+        assert list(request.window.hours) == list(range(8, 20))
+        assert not hasattr(request, "hour")
+
+    @pytest.mark.parametrize(
+        ("overrides", "message"),
+        [
+            ({"start_hour": 8, "end_hour": 21}, "at most 12 hours"),
+            ({"start_hour": 8, "end_hour": 8}, "before end_hour"),
+            ({"start_hour": 20, "end_hour": 8}, "before end_hour"),
+            ({"start_hour": 8.5, "end_hour": 20}, "whole hour"),
+            ({"start_hour": 8, "end_hour": 24}, "whole hour"),
+        ],
+    )
+    def test_request_reuses_time_window_validation(
+        self, overrides: dict[str, object], message: str
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            _request(**overrides)
+
+
+class TestSeriesReadyResponse:
+    def test_series_ready_contains_raw_nullable_series_and_no_decisions(self) -> None:
+        response = TripAnalysisResponse(
+            request_identity="curated:2026-08-23:8-20",
+            mode=TripMode.CURATED,
+            execution_mode=ExecutionMode.FIXTURE,
+            state=ResultState.SERIES_READY,
+            environment=_environment(),
+        )
+
+        assert response.environment is not None
+        assert response.environment.entries[0].heat_index_celsius is None
+        assert response.environment.entries[1].humidity_percent is None
+        assert response.best_time is None
+        assert response.hotels is None
+        assert response.routes is None
+
+    def test_series_ready_requires_environment(self) -> None:
+        with pytest.raises(ValueError, match="environment"):
+            TripAnalysisResponse(
+                request_identity="curated:2026-08-23:8-20",
+                mode=TripMode.CURATED,
+                execution_mode=ExecutionMode.FIXTURE,
+                state=ResultState.SERIES_READY,
+            )
+
+    def test_series_ready_rejects_decision_sections(self) -> None:
+        from tests.test_contracts import _valid_best_time
+
+        with pytest.raises(ValueError, match="decision"):
+            TripAnalysisResponse(
+                request_identity="curated:2026-08-23:8-20",
+                mode=TripMode.CURATED,
+                execution_mode=ExecutionMode.FIXTURE,
+                state=ResultState.SERIES_READY,
+                environment=_environment(),
+                best_time=_valid_best_time(),
+            )
+
+    def test_environment_rejects_empty_series(self) -> None:
+        with pytest.raises(ValueError, match="entries"):
+            EnvironmentSeriesResult(
+                entries=(),
+                timezone="America/Chicago",
+                temperature_anchor_celsius=36.4,
+                warning="fixed temperature anchor; not a real 24-hour forecast",
+                provenance=_provenance(),
+            )
+
+
+class TestTemporalTripApi:
+    def test_endpoint_accepts_a_valid_window(self) -> None:
+        client = TestClient(
+            create_app(
+                Path("fixtures/heatmap-historical.json"),
+                trip_adapter=FixtureTripAnalysisAdapter(Path("fixtures/trip-analysis.json")),
+            )
+        )
+
+        response = client.post("/api/trip/analyze", json=_trip_body())
+
+        assert response.status_code == 200
+        assert response.json()["request_identity"] == "curated:2026-08-23:8-20"
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"end_hour": None},
+            {"start_hour": 8, "end_hour": 8},
+            {"start_hour": 9, "end_hour": 8},
+            {"start_hour": 0, "end_hour": 13},
+            {"start_hour": 8.5, "end_hour": 20},
+            {"start_hour": -1, "end_hour": 8},
+            {"start_hour": 8, "end_hour": 24},
+        ],
+    )
+    def test_endpoint_rejects_invalid_windows(self, overrides: dict[str, object]) -> None:
+        client = TestClient(create_app(Path("fixtures/heatmap-historical.json")))
+
+        response = client.post("/api/trip/analyze", json=_trip_body(**overrides))
+
+        assert response.status_code == 400
+
+    def test_endpoint_rejects_the_removed_selected_hour(self) -> None:
+        client = TestClient(create_app(Path("fixtures/heatmap-historical.json")))
+        body = _trip_body(hour=8)
+
+        response = client.post("/api/trip/analyze", json=body)
+
+        assert response.status_code == 400
+        assert "no longer accepted" in response.json()["detail"]["error"]
+
+    def test_api_parses_the_window_without_requiring_a_visit_hour(self) -> None:
+        request = _parse_trip_request(
+            {
+                "origin_latitude": 29.4245914,
+                "origin_longitude": -98.4864288,
+                "destination_latitude": 29.425833,
+                "destination_longitude": -98.485833,
+                "mode": "curated",
+                "landmark_name": "The Alamo",
+                "district_name": "Downtown San Antonio",
+                "date": "2026-08-23",
+                "start_hour": 8,
+                "end_hour": 20,
+            }
+        )
+
+        assert request.window.start_time() == "08:00"
+        assert request.window.end_time() == "20:00"
+
+    def test_api_rejects_a_missing_window_bound(self) -> None:
+        with pytest.raises(ValueError, match="end_hour"):
+            _parse_trip_request(
+                {
+                    "origin_latitude": 29.4245914,
+                    "origin_longitude": -98.4864288,
+                    "destination_latitude": 29.425833,
+                    "destination_longitude": -98.485833,
+                    "mode": "curated",
+                    "landmark_name": "The Alamo",
+                    "district_name": "Downtown San Antonio",
+                    "date": "2026-08-23",
+                    "start_hour": 8,
+                }
+            )

--- a/tests/test_temporal_trip_orchestration.py
+++ b/tests/test_temporal_trip_orchestration.py
@@ -1,0 +1,286 @@
+"""Temporal trip orchestration tests for issue #44 phase 4."""
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.wiring as wiring
+from app.api import create_app
+from app.domain.contracts import (
+    Coordinates,
+    ExecutionMode,
+    ResultState,
+    TripAnalysisRequest,
+    TripMode,
+)
+from app.domain.ledger import BudgetExceededError
+from app.integrations.fortyguard.contracts import EnvParamsRequest, HeatmapRequest
+from app.services.execution import EnvParamsExecution, HeatmapExecution
+from app.services.trip_adapters import TemporalTripAnalysisAdapter
+from app.settings import AppSettings
+
+
+def _request() -> TripAnalysisRequest:
+    return TripAnalysisRequest(
+        mode=TripMode.CURATED,
+        origin=Coordinates(29.4245914, -98.4864288),
+        destination=Coordinates(29.425833, -98.485833),
+        landmark_name="The Alamo",
+        district_name="Downtown San Antonio",
+        date="2026-08-23",
+        start_hour=8,
+        end_hour=20,
+        cautious=False,
+    )
+
+
+def _heatmap_payload() -> dict[str, object]:
+    return {
+        "mode": "historical",
+        "features": [
+            {
+                "geometry": {"type": "Point", "coordinates": [-98.485833, 29.425833]},
+                "properties": {
+                    "id": "morning",
+                    "value": 32.1,
+                    "unit": "C",
+                    "valid_time": "2026-08-23T09:00:00-05:00",
+                },
+            },
+            {
+                "geometry": {"type": "Point", "coordinates": [-98.485833, 29.425833]},
+                "properties": {
+                    "id": "afternoon",
+                    "value": 39.4,
+                    "unit": "C",
+                    "valid_time": "2026-08-23T15:00:00-05:00",
+                },
+            },
+        ],
+    }
+
+
+def _env_payload() -> dict[str, object]:
+    return {
+        "metadata": {
+            "timestamps": [
+                "2026-08-23T08:00:00-05:00",
+                "2026-08-23T09:00:00-05:00",
+            ],
+            "timezone": "America/Chicago",
+        },
+        "locations": [
+            {
+                "parameters": {
+                    "heat_index_celsius": [None, 36.8],
+                    "relative_humidity_percent": [58.0, None],
+                }
+            }
+        ],
+    }
+
+
+def test_temporal_adapter_chains_one_heatmap_call_into_one_env_params_call(
+    tmp_path: Path,
+) -> None:
+    heatmap_requests: list[HeatmapRequest] = []
+    env_requests: list[EnvParamsRequest] = []
+
+    def load_heatmap(request: HeatmapRequest) -> Mapping[str, object]:
+        heatmap_requests.append(request)
+        return _heatmap_payload()
+
+    def load_environment(request: EnvParamsRequest) -> Mapping[str, object]:
+        env_requests.append(request)
+        return _env_payload()
+
+    adapter = TemporalTripAnalysisAdapter(
+        HeatmapExecution(fixture_path=tmp_path / "heatmap.json", live_loader=load_heatmap),
+        EnvParamsExecution(fixture_path=tmp_path / "env.json", live_loader=load_environment),
+    )
+
+    response = adapter.analyze(_request(), ExecutionMode.LIVE)
+
+    assert len(heatmap_requests) == 1
+    assert len(env_requests) == 1
+    heatmap_request = heatmap_requests[0]
+    env_request = env_requests[0]
+    assert (heatmap_request.latitude, heatmap_request.longitude) == (
+        _request().destination.latitude,
+        _request().destination.longitude,
+    )
+    assert (env_request.latitude, env_request.longitude) == (
+        heatmap_request.latitude,
+        heatmap_request.longitude,
+    )
+    assert (heatmap_request.start_date, heatmap_request.start_hour, heatmap_request.end_hour) == (
+        env_request.start_date,
+        env_request.start_hour,
+        env_request.end_hour,
+    )
+    assert env_request.temperature_anchor_celsius == 39.4
+    assert response.state is ResultState.SERIES_READY
+    assert response.environment is not None
+    assert response.environment.temperature_anchor_celsius == 39.4
+    assert response.environment.entries[0].heat_index_celsius is None
+    assert response.environment.entries[1].humidity_percent is None
+    assert response.best_time is None
+    assert response.hotels is None
+    assert response.routes is None
+    assert response.environment.provenance.request_configuration["anchor_policy"] == (
+        "maximum_in_window_temperature_celsius"
+    )
+
+
+def test_heatmap_unavailable_stops_before_env_params_call(tmp_path: Path) -> None:
+    env_calls = 0
+
+    def fail_heatmap(request: HeatmapRequest) -> Mapping[str, object]:
+        raise ConnectionError("heatmap unavailable")
+
+    def load_environment(request: EnvParamsRequest) -> Mapping[str, object]:
+        nonlocal env_calls
+        env_calls += 1
+        return _env_payload()
+
+    adapter = TemporalTripAnalysisAdapter(
+        HeatmapExecution(fixture_path=tmp_path / "heatmap.json", live_loader=fail_heatmap),
+        EnvParamsExecution(fixture_path=tmp_path / "env.json", live_loader=load_environment),
+    )
+
+    response = adapter.analyze(_request(), ExecutionMode.LIVE)
+
+    assert response.state is ResultState.UNAVAILABLE
+    assert response.unavailable is not None
+    assert "heatmap" in response.unavailable.reason
+    assert env_calls == 0
+
+
+def test_env_params_unavailable_returns_explicit_unavailable_after_one_call(
+    tmp_path: Path,
+) -> None:
+    heatmap_calls = 0
+    env_calls = 0
+
+    def load_heatmap(request: HeatmapRequest) -> Mapping[str, object]:
+        nonlocal heatmap_calls
+        heatmap_calls += 1
+        return _heatmap_payload()
+
+    def fail_environment(request: EnvParamsRequest) -> Mapping[str, object]:
+        nonlocal env_calls
+        env_calls += 1
+        raise ConnectionError("environment unavailable")
+
+    adapter = TemporalTripAnalysisAdapter(
+        HeatmapExecution(fixture_path=tmp_path / "heatmap.json", live_loader=load_heatmap),
+        EnvParamsExecution(fixture_path=tmp_path / "env.json", live_loader=fail_environment),
+    )
+
+    response = adapter.analyze(_request(), ExecutionMode.LIVE)
+
+    assert heatmap_calls == 1
+    assert env_calls == 1
+    assert response.state is ResultState.UNAVAILABLE
+    assert response.unavailable is not None
+    assert "environmental-parameters" in response.unavailable.reason
+
+
+def test_production_wiring_uses_temporal_adapter_for_live_trip_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    heatmap_execution = HeatmapExecution(
+        fixture_path=tmp_path / "heatmap.json",
+        live_loader=lambda request: _heatmap_payload(),
+    )
+    env_execution = EnvParamsExecution(
+        fixture_path=tmp_path / "env.json",
+        live_loader=lambda request: _env_payload(),
+    )
+    monkeypatch.setattr(wiring, "build_live_client", lambda settings, ledger=None: object())
+    monkeypatch.setattr(
+        wiring,
+        "build_live_heatmap_execution",
+        lambda *args, **kwargs: heatmap_execution,
+    )
+    monkeypatch.setattr(
+        wiring,
+        "build_live_env_params_execution",
+        lambda *args, **kwargs: env_execution,
+    )
+    app = wiring.create_production_app(
+        AppSettings(
+            allow_live=True,
+            fortyguard_api_key="test-key",
+            fortyguard_base_url="https://api.example.test",
+        ),
+        fixture_path=tmp_path / "heatmap.json",
+        env_params_fixture_path=tmp_path / "env.json",
+        frontend_dist=tmp_path / "dist",
+    )
+
+    response = TestClient(app).post(
+        "/api/trip/analyze",
+        json={
+            "origin_latitude": 29.4245914,
+            "origin_longitude": -98.4864288,
+            "destination_latitude": 29.425833,
+            "destination_longitude": -98.485833,
+            "mode": "curated",
+            "landmark_name": "The Alamo",
+            "district_name": "Downtown San Antonio",
+            "date": "2026-08-23",
+            "start_hour": 8,
+            "end_hour": 20,
+            "execution_mode": "live",
+        },
+    )
+
+    assert response.status_code == 200
+    body: dict[str, Any] = response.json()
+    assert body["state"] == "series_ready"
+    assert body["environment"]["temperature_anchor_celsius"] == 39.4
+    assert body["best_time"] is None
+
+
+def test_trip_endpoint_maps_orchestration_budget_failure_to_503(tmp_path: Path) -> None:
+    def exceed_budget(request: HeatmapRequest) -> Mapping[str, object]:
+        raise BudgetExceededError("credit budget exceeded")
+
+    adapter = TemporalTripAnalysisAdapter(
+        HeatmapExecution(fixture_path=tmp_path / "heatmap.json", live_loader=exceed_budget),
+        EnvParamsExecution(
+            fixture_path=tmp_path / "env.json",
+            live_loader=lambda request: _env_payload(),
+        ),
+    )
+    client = TestClient(
+        create_app(
+            tmp_path / "heatmap.json",
+            allow_live=True,
+            trip_adapter=adapter,
+        )
+    )
+
+    response = client.post(
+        "/api/trip/analyze",
+        json={
+            "origin_latitude": 29.4245914,
+            "origin_longitude": -98.4864288,
+            "destination_latitude": 29.425833,
+            "destination_longitude": -98.485833,
+            "mode": "curated",
+            "landmark_name": "The Alamo",
+            "district_name": "Downtown San Antonio",
+            "date": "2026-08-23",
+            "start_hour": 8,
+            "end_hour": 20,
+            "execution_mode": "live",
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error_kind"] == "budget_exceeded"

--- a/tests/test_trip_adapters.py
+++ b/tests/test_trip_adapters.py
@@ -28,7 +28,8 @@ def _request() -> TripAnalysisRequest:
         landmark_name="The Alamo",
         district_name="Downtown San Antonio",
         date="2026-08-23",
-        hour=8,
+        start_hour=8,
+        end_hour=20,
         cautious=False,
     )
 
@@ -89,9 +90,9 @@ def test_route_distances_reflect_observed_canonical_osrm_response() -> None:
     assert by_identity["shady"].duration_s == 196.0
 
 
-def test_fixture_adapter_returns_unavailable_for_unmatched_hour() -> None:
+def test_fixture_adapter_returns_unavailable_for_unmatched_window() -> None:
     response = FixtureTripAnalysisAdapter(Path("fixtures/trip-analysis.json")).analyze(
-        replace(_request(), hour=9), ExecutionMode.FIXTURE
+        replace(_request(), start_hour=9), ExecutionMode.FIXTURE
     )
 
     assert response.state is ResultState.UNAVAILABLE

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -8,7 +8,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api import create_app
-from app.integrations.fortyguard.contracts import EnvParamsRequest, HeatmapRequest
+from app.integrations.fortyguard.contracts import (
+    ENVIRONMENT_PARAMETERS,
+    EnvParamsRequest,
+    HeatmapRequest,
+)
 from app.integrations.fortyguard.errors import ProviderError, ProviderErrorKind
 from app.integrations.fortyguard.live import LiveEnvParamsPayload
 from app.services.execution import EnvParamsExecution, HeatmapExecution
@@ -292,7 +296,7 @@ def test_env_params_live_loader_receives_documented_date_windows() -> None:
     date_time = cast(dict[str, Any], payload["date_time"])
     assert date_time["filter_type"] == 3
     assert payload["temperature"] == 35.0
-    assert payload["analysis"] == ["heat_index_celsius", "relative_humidity_percent"]
+    assert payload["analysis"] == list(ENVIRONMENT_PARAMETERS)
     hourly = build_documented_env_params_payload(
         EnvParamsRequest(29.4241, -98.4936, date(2026, 8, 24), 35.0, hour=13)
     )


### PR DESCRIPTION
This pull request introduces several important changes to the trip analysis API and its domain contracts, primarily to support specifying a time window (start and end hour) for trip analysis and to add a new environment series result type for the temporal preparation stage. It also improves error handling and updates documentation to clarify the new flow.

**API and Domain Model Changes:**

* The trip analysis request now requires a `start_hour` and `end_hour` instead of a single `hour`, enforcing this throughout the API and domain contracts. (`app/api.py` [[1]](diffhunk://#diff-2106c49169c769b7be0fb5630a434a947d7d70c2080ad092b28a499eb49bde85L296-R321) [[2]](diffhunk://#diff-2106c49169c769b7be0fb5630a434a947d7d70c2080ad092b28a499eb49bde85L335-L344) [[3]](diffhunk://#diff-2106c49169c769b7be0fb5630a434a947d7d70c2080ad092b28a499eb49bde85L355-R366) [[4]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L192-R196) [[5]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L208-R221)
* Added helper methods `_required_hour` and `_optional_hour` to standardize hour field validation. (`app/api.py` [app/api.pyR401-R418](diffhunk://#diff-2106c49169c769b7be0fb5630a434a947d7d70c2080ad092b28a499eb49bde85R401-R418))
* The `TripAnalysisRequest` class now validates the time window using the `TimeWindow` class and exposes it as a property. (`app/domain/contracts.py` [app/domain/contracts.pyL208-R221](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L208-R221))

**Environment Series Support:**

* Introduced `EnvironmentSeriesEntry` and `EnvironmentSeriesResult` dataclasses to represent the raw, fixed-anchor environmental parameter series before any recommendations. (`app/domain/contracts.py` [app/domain/contracts.pyR291-R365](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R291-R365))
* The `TripAnalysisResponse` now supports a new `SERIES_READY` state, which includes the environment series and enforces state-specific validation logic. (`app/domain/contracts.py` [[1]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R35) [[2]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R650) [[3]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L585-R673) [[4]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L605-R704) [[5]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L643-R743)

**Error Handling Improvements:**

* The API now catches additional error types (`BudgetExceededError`, `ProviderError`, `OSError`, `RuntimeError`) and returns appropriate HTTP errors. (`app/api.py` [app/api.pyL237-R245](diffhunk://#diff-2106c49169c769b7be0fb5630a434a947d7d70c2080ad092b28a499eb49bde85L237-R245))

**Documentation Updates:**

* Updated `CONTEXT.md` to clarify the new temporal-preparation flow, the meaning of a trip analysis request, and the role of the temperature anchor and environment series. (`CONTEXT.md` [[1]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L22-R33) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L59-R71)

**Other API Changes:**

* The heatmap and environment parameter request builders now accept and validate optional `start_hour` and `end_hour` fields, and the legacy `hour` field is rejected. (`app/api.py` [[1]](diffhunk://#diff-2106c49169c769b7be0fb5630a434a947d7d70c2080ad092b28a499eb49bde85L276-R293) [[2]](diffhunk://#diff-2106c49169c769b7be0fb5630a434a947d7d70c2080ad092b28a499eb49bde85L296-R321)

These changes collectively improve the flexibility and clarity of the trip analysis API, making it ready for more advanced temporal and environmental analysis workflows.