### PR TITLE
Implement heat classification and cautious guidance policy

### DIFF
--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -295,6 +295,7 @@ class BestTimeResult:
     metric_label: MetricLabel
     provenance: Provenance
     hourly_coverage: float = 1.0
+    heat_interpretation: dict[str, object] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.metric_label, MetricLabel):
@@ -442,6 +443,7 @@ class RouteOption:
     recommended: bool
     recommendation_reason: str | None
     shade_model_label: str | None
+    heat_interpretation: dict[str, object] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.heat_metric, HeatMetricName):
@@ -498,6 +500,7 @@ class RouteComparisonResult:
     comparison_scope: str
     provenance: Provenance
     fallback_reason: str | None = None
+    heat_interpretation: dict[str, object] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.heat_metric, HeatMetricName):

--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -56,6 +56,36 @@ class HeatMetricName(str, Enum):
     HEAT_INDEX_CELSIUS = "heat_index_celsius"
 
 
+class HeatBand(str, Enum):
+    BELOW_CAUTION = "below_caution"
+    CAUTION = "caution"
+    EXTREME_CAUTION = "extreme_caution"
+    DANGER = "danger"
+    EXTREME_DANGER = "extreme_danger"
+    PROVIDER_LOWER = "provider_lower"
+    PROVIDER_MODERATE = "provider_moderate"
+    PROVIDER_HIGHER = "provider_higher"
+    PROVIDER_VERY_HIGH = "provider_very_high"
+
+
+class GuidancePolicy(str, Enum):
+    STANDARD = "standard"
+    CAUTIOUS = "cautious"
+
+
+HEAT_BAND_LABELS = {
+    HeatBand.BELOW_CAUTION: "Below NOAA caution",
+    HeatBand.CAUTION: "Caution",
+    HeatBand.EXTREME_CAUTION: "Extreme caution",
+    HeatBand.DANGER: "Danger",
+    HeatBand.EXTREME_DANGER: "Extreme danger",
+    HeatBand.PROVIDER_LOWER: "Lower provider temperature",
+    HeatBand.PROVIDER_MODERATE: "Moderate provider temperature",
+    HeatBand.PROVIDER_HIGHER: "Higher provider temperature",
+    HeatBand.PROVIDER_VERY_HIGH: "Very high provider temperature",
+}
+
+
 class EnrichmentState(str, Enum):
     AVAILABLE = "available"
     UNAVAILABLE = "unavailable"
@@ -158,6 +188,134 @@ class Metric:
             raise ValueError("NOAA Heat Index label requires an actual heat index")
         if self.label is MetricLabel.PROVIDER_TCM and self.is_actual_heat_index:
             raise ValueError("provider TCM must not be marked as actual heat index")
+
+
+@dataclass(frozen=True)
+class HeatInterpretation:
+    """Typed, product-facing interpretation of one Celsius heat metric."""
+
+    metric: HeatMetricName
+    value_celsius: float | None
+    band: HeatBand | None
+    band_label: str
+    action_threshold_band: HeatBand | None
+    guidance_policy: GuidancePolicy
+    is_actual_heat_index: bool
+    noaa_heat_index_available: bool
+    action_required: bool
+    policy_applied: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.metric, HeatMetricName):
+            raise ValueError("interpretation metric must be a HeatMetricName value")
+        if self.value_celsius is not None and not math.isfinite(self.value_celsius):
+            raise ValueError("interpretation value must be finite or None")
+        if not self.band_label:
+            raise ValueError("interpretation band_label is required")
+        if not isinstance(self.guidance_policy, GuidancePolicy):
+            raise ValueError("interpretation guidance_policy must be a GuidancePolicy value")
+        if not isinstance(self.is_actual_heat_index, bool):
+            raise ValueError("interpretation actual heat-index flag must be boolean")
+        if not isinstance(self.noaa_heat_index_available, bool):
+            raise ValueError("interpretation NOAA availability must be boolean")
+        if not isinstance(self.action_required, bool):
+            raise ValueError("interpretation action_required must be boolean")
+        if not self.policy_applied:
+            raise ValueError("interpretation policy_applied is required")
+        if self.is_actual_heat_index and not self.noaa_heat_index_available:
+            raise ValueError("actual heat index must be available")
+        if self.metric is HeatMetricName.TCM and self.is_actual_heat_index:
+            raise ValueError("provider TCM must not be marked as actual heat index")
+        if self.metric is HeatMetricName.TCM and self.noaa_heat_index_available:
+            raise ValueError("provider TCM must not claim NOAA Heat Index availability")
+        expected_actual = (
+            self.metric is HeatMetricName.HEAT_INDEX_CELSIUS and self.value_celsius is not None
+        )
+        if self.is_actual_heat_index is not expected_actual:
+            raise ValueError("actual heat-index flag must match the metric and value")
+        if self.noaa_heat_index_available is not expected_actual:
+            raise ValueError("NOAA availability must match actual Heat Index data")
+        if self.value_celsius is None and (
+            self.band is not None or self.action_threshold_band is not None or self.action_required
+        ):
+            raise ValueError("missing metric values cannot have heat bands or an action")
+        if self.value_celsius is None:
+            expected_unavailable_label = (
+                "NOAA Heat Index unavailable"
+                if self.metric is HeatMetricName.HEAT_INDEX_CELSIUS
+                else "Provider temperature unavailable"
+            )
+            expected_unavailable_policy = (
+                "no_heat_index_available"
+                if self.metric is HeatMetricName.HEAT_INDEX_CELSIUS
+                else "metric_unavailable"
+            )
+            if (
+                self.band_label != expected_unavailable_label
+                or self.policy_applied != expected_unavailable_policy
+            ):
+                raise ValueError("missing metric copy and policy marker must match its metric")
+        noaa_bands = {
+            HeatBand.BELOW_CAUTION,
+            HeatBand.CAUTION,
+            HeatBand.EXTREME_CAUTION,
+            HeatBand.DANGER,
+            HeatBand.EXTREME_DANGER,
+        }
+        provider_bands = {
+            HeatBand.PROVIDER_LOWER,
+            HeatBand.PROVIDER_MODERATE,
+            HeatBand.PROVIDER_HIGHER,
+            HeatBand.PROVIDER_VERY_HIGH,
+        }
+        expected_bands = (
+            noaa_bands if self.metric is HeatMetricName.HEAT_INDEX_CELSIUS else provider_bands
+        )
+        if self.value_celsius is not None and (
+            self.band is None or self.action_threshold_band is None
+        ):
+            raise ValueError("available metric values require a band and action threshold")
+        if self.band is not None and self.band not in expected_bands:
+            raise ValueError("interpretation band must match its metric")
+        if self.band is not None and self.band_label != HEAT_BAND_LABELS[self.band]:
+            raise ValueError("interpretation band label must match its band")
+        if (
+            self.action_threshold_band is not None
+            and self.action_threshold_band not in expected_bands
+        ):
+            raise ValueError("action threshold band must match its metric")
+        ordered_bands = (
+            (
+                HeatBand.BELOW_CAUTION,
+                HeatBand.CAUTION,
+                HeatBand.EXTREME_CAUTION,
+                HeatBand.DANGER,
+                HeatBand.EXTREME_DANGER,
+            )
+            if self.metric is HeatMetricName.HEAT_INDEX_CELSIUS
+            else (
+                HeatBand.PROVIDER_LOWER,
+                HeatBand.PROVIDER_MODERATE,
+                HeatBand.PROVIDER_HIGHER,
+                HeatBand.PROVIDER_VERY_HIGH,
+            )
+        )
+        expected_threshold = ordered_bands[
+            1 if self.guidance_policy is GuidancePolicy.CAUTIOUS else 2
+        ]
+        if self.value_celsius is not None and self.action_threshold_band is not expected_threshold:
+            raise ValueError("action threshold must match the guidance policy")
+        if self.band is not None and self.action_required is not (
+            ordered_bands.index(self.band) >= ordered_bands.index(expected_threshold)
+        ):
+            raise ValueError("action state must match the observation and threshold bands")
+        expected_policy = (
+            "cautious_guidance_one_band_earlier"
+            if self.guidance_policy is GuidancePolicy.CAUTIOUS
+            else "standard_heat_guidance"
+        )
+        if self.value_celsius is not None and self.policy_applied != expected_policy:
+            raise ValueError("policy marker must match the guidance policy")
 
 
 @dataclass(frozen=True)
@@ -295,7 +453,7 @@ class BestTimeResult:
     metric_label: MetricLabel
     provenance: Provenance
     hourly_coverage: float = 1.0
-    heat_interpretation: dict[str, object] | None = None
+    heat_interpretation: HeatInterpretation | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.metric_label, MetricLabel):
@@ -320,7 +478,13 @@ class BestTimeResult:
         recommendation = next(
             entry.metric.value for entry in self.hourly if entry.hour == self.recommendation_hour
         )
-        if recommendation != min(entry.metric.value for entry in self.hourly):
+        policy_selected = (
+            self.heat_interpretation is not None
+            and self.heat_interpretation.guidance_policy is GuidancePolicy.CAUTIOUS
+        )
+        if not policy_selected and recommendation != min(
+            entry.metric.value for entry in self.hourly
+        ):
             raise ValueError("recommendation_hour must be a coolest available hour")
 
 
@@ -443,7 +607,7 @@ class RouteOption:
     recommended: bool
     recommendation_reason: str | None
     shade_model_label: str | None
-    heat_interpretation: dict[str, object] | None = None
+    heat_interpretation: HeatInterpretation | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.heat_metric, HeatMetricName):
@@ -482,6 +646,11 @@ class RouteOption:
             raise ValueError("shade metadata requires a modeled shade value")
         if self.modeled_shade_percent is not None and not self.shade_model_label:
             raise ValueError("modeled shade requires a model label")
+        if self.heat_interpretation is not None and (
+            self.heat_interpretation.metric is not self.heat_metric
+            or self.heat_interpretation.value_celsius != self.heat_value
+        ):
+            raise ValueError("route option heat interpretation must match its metric and value")
 
 
 @dataclass(frozen=True)
@@ -500,7 +669,7 @@ class RouteComparisonResult:
     comparison_scope: str
     provenance: Provenance
     fallback_reason: str | None = None
-    heat_interpretation: dict[str, object] | None = None
+    heat_interpretation: HeatInterpretation | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.heat_metric, HeatMetricName):
@@ -544,6 +713,11 @@ class RouteComparisonResult:
             shortest = min(self.alternatives, key=lambda route: route.distance_m)
             if recommended[0].identity != shortest.identity:
                 raise ValueError("insufficient confidence must recommend the shortest route")
+        if self.heat_interpretation is not None and (
+            self.heat_interpretation.metric is not self.heat_metric
+            or self.heat_interpretation.value_celsius != self.corridor_heat_value
+        ):
+            raise ValueError("route comparison heat interpretation must match its metric and value")
 
 
 @dataclass(frozen=True)

--- a/app/domain/heat_policy.py
+++ b/app/domain/heat_policy.py
@@ -1,0 +1,161 @@
+"""Metric-specific heat interpretation and cautious-guidance policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import math
+
+from app.domain.contracts import HeatMetricName
+
+
+class HeatBand(str, Enum):
+    BELOW_CAUTION = "below_caution"
+    CAUTION = "caution"
+    EXTREME_CAUTION = "extreme_caution"
+    DANGER = "danger"
+    EXTREME_DANGER = "extreme_danger"
+    PROVIDER_LOWER = "provider_lower"
+    PROVIDER_MODERATE = "provider_moderate"
+    PROVIDER_HIGHER = "provider_higher"
+    PROVIDER_DANGER = "provider_danger"
+
+
+class GuidancePolicy(str, Enum):
+    STANDARD = "standard"
+    CAUTIOUS = "cautious"
+
+
+@dataclass(frozen=True)
+class HeatClassification:
+    metric: HeatMetricName
+    value_celsius: float | None
+    band: HeatBand | None
+    band_label: str
+    action_band: HeatBand | None
+    guidance_policy: GuidancePolicy
+    is_actual_heat_index: bool
+    policy_applied: str
+
+
+_NOAA_BANDS = (
+    (26.7, HeatBand.CAUTION),
+    (32.2, HeatBand.EXTREME_CAUTION),
+    (40.6, HeatBand.DANGER),
+    (54.4, HeatBand.EXTREME_DANGER),
+)
+_NOAA_LABELS = {
+    HeatBand.BELOW_CAUTION: "Below NOAA caution",
+    HeatBand.CAUTION: "Caution",
+    HeatBand.EXTREME_CAUTION: "Extreme caution",
+    HeatBand.DANGER: "Danger",
+    HeatBand.EXTREME_DANGER: "Extreme danger",
+}
+_PROVIDER_LABELS = {
+    HeatBand.PROVIDER_LOWER: "Lower provider temperature",
+    HeatBand.PROVIDER_MODERATE: "Moderate provider temperature",
+    HeatBand.PROVIDER_HIGHER: "Higher provider temperature",
+    HeatBand.PROVIDER_DANGER: "Very high provider temperature",
+}
+
+
+def classify_heat(
+    value_celsius: float | None,
+    *,
+    metric: HeatMetricName,
+    cautious: bool = False,
+) -> HeatClassification:
+    """Classify a Celsius value without conflating provider data with NOAA data."""
+    if not isinstance(metric, HeatMetricName):
+        raise ValueError("metric must be a HeatMetricName value")
+    if value_celsius is not None and (
+        isinstance(value_celsius, bool)
+        or not isinstance(value_celsius, (int, float))
+        or not math.isfinite(value_celsius)
+    ):
+        raise ValueError("heat value must be finite or None")
+    policy = GuidancePolicy.CAUTIOUS if cautious else GuidancePolicy.STANDARD
+    if value_celsius is None:
+        return HeatClassification(
+            metric,
+            None,
+            None,
+            "NOAA Heat Index unavailable"
+            if metric is HeatMetricName.HEAT_INDEX_CELSIUS
+            else "Provider temperature unavailable",
+            None,
+            policy,
+            metric is HeatMetricName.HEAT_INDEX_CELSIUS,
+            "no_heat_index_available"
+            if metric is HeatMetricName.HEAT_INDEX_CELSIUS
+            else "metric_unavailable",
+        )
+
+    if metric is HeatMetricName.HEAT_INDEX_CELSIUS:
+        band = _noaa_band(value_celsius)
+        action_band = _shift_band(band) if cautious else band
+        return HeatClassification(
+            metric,
+            float(value_celsius),
+            band,
+            _NOAA_LABELS[band],
+            action_band,
+            policy,
+            True,
+            "cautious_guidance_one_band_earlier" if cautious else "standard_noaa_guidance",
+        )
+
+    band = _provider_band(value_celsius)
+    return HeatClassification(
+        metric,
+        float(value_celsius),
+        band,
+        _PROVIDER_LABELS[band],
+        _shift_provider_band(band) if cautious else band,
+        policy,
+        False,
+        "cautious_guidance_one_band_earlier" if cautious else "standard_provider_guidance",
+    )
+
+
+def _noaa_band(value: float) -> HeatBand:
+    if value < _NOAA_BANDS[0][0]:
+        return HeatBand.BELOW_CAUTION
+    if value < 32.2:
+        return HeatBand.CAUTION
+    if value < 40.6:
+        return HeatBand.EXTREME_CAUTION
+    if value <= 54.4:
+        return HeatBand.DANGER
+    return HeatBand.EXTREME_DANGER
+
+
+def _shift_band(band: HeatBand) -> HeatBand:
+    order = (
+        HeatBand.BELOW_CAUTION,
+        HeatBand.CAUTION,
+        HeatBand.EXTREME_CAUTION,
+        HeatBand.DANGER,
+        HeatBand.EXTREME_DANGER,
+    )
+    return order[max(order.index(band) - 1, 0)]
+
+
+def _provider_band(value: float) -> HeatBand:
+    if value < 26.7:
+        return HeatBand.PROVIDER_LOWER
+    if value < 32.2:
+        return HeatBand.PROVIDER_MODERATE
+    if value < 40.6:
+        return HeatBand.PROVIDER_HIGHER
+    return HeatBand.PROVIDER_DANGER
+
+
+def _shift_provider_band(band: HeatBand) -> HeatBand:
+    order = (
+        HeatBand.PROVIDER_LOWER,
+        HeatBand.PROVIDER_MODERATE,
+        HeatBand.PROVIDER_HIGHER,
+        HeatBand.PROVIDER_DANGER,
+    )
+    return order[max(order.index(band) - 1, 0)]

--- a/app/domain/heat_policy.py
+++ b/app/domain/heat_policy.py
@@ -2,61 +2,42 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
 import math
 
-from app.domain.contracts import HeatMetricName
-
-
-class HeatBand(str, Enum):
-    BELOW_CAUTION = "below_caution"
-    CAUTION = "caution"
-    EXTREME_CAUTION = "extreme_caution"
-    DANGER = "danger"
-    EXTREME_DANGER = "extreme_danger"
-    PROVIDER_LOWER = "provider_lower"
-    PROVIDER_MODERATE = "provider_moderate"
-    PROVIDER_HIGHER = "provider_higher"
-    PROVIDER_DANGER = "provider_danger"
-
-
-class GuidancePolicy(str, Enum):
-    STANDARD = "standard"
-    CAUTIOUS = "cautious"
-
-
-@dataclass(frozen=True)
-class HeatClassification:
-    metric: HeatMetricName
-    value_celsius: float | None
-    band: HeatBand | None
-    band_label: str
-    action_band: HeatBand | None
-    guidance_policy: GuidancePolicy
-    is_actual_heat_index: bool
-    policy_applied: str
-
-
-_NOAA_BANDS = (
-    (26.7, HeatBand.CAUTION),
-    (32.2, HeatBand.EXTREME_CAUTION),
-    (40.6, HeatBand.DANGER),
-    (54.4, HeatBand.EXTREME_DANGER),
+from app.conversion import fahrenheit_to_celsius
+from app.domain.contracts import (
+    GuidancePolicy,
+    HEAT_BAND_LABELS,
+    HeatBand,
+    HeatInterpretation,
+    HeatMetricName,
 )
-_NOAA_LABELS = {
-    HeatBand.BELOW_CAUTION: "Below NOAA caution",
-    HeatBand.CAUTION: "Caution",
-    HeatBand.EXTREME_CAUTION: "Extreme caution",
-    HeatBand.DANGER: "Danger",
-    HeatBand.EXTREME_DANGER: "Extreme danger",
-}
-_PROVIDER_LABELS = {
-    HeatBand.PROVIDER_LOWER: "Lower provider temperature",
-    HeatBand.PROVIDER_MODERATE: "Moderate provider temperature",
-    HeatBand.PROVIDER_HIGHER: "Higher provider temperature",
-    HeatBand.PROVIDER_DANGER: "Very high provider temperature",
-}
+
+HeatBand = HeatBand
+GuidancePolicy = GuidancePolicy
+HeatInterpretation = HeatInterpretation
+
+
+NOAA_BOUNDARIES_FAHRENHEIT = (80.0, 90.0, 105.0, 130.0)
+NOAA_BOUNDARIES_CELSIUS = tuple(
+    fahrenheit_to_celsius(value) for value in NOAA_BOUNDARIES_FAHRENHEIT
+)
+# Product TCM bands are deliberately separate from NOAA Heat Index boundaries.
+PROVIDER_TCM_BOUNDARIES_CELSIUS = (30.0, 35.0, 40.0)
+
+_NOAA_ORDER = (
+    HeatBand.BELOW_CAUTION,
+    HeatBand.CAUTION,
+    HeatBand.EXTREME_CAUTION,
+    HeatBand.DANGER,
+    HeatBand.EXTREME_DANGER,
+)
+_PROVIDER_ORDER = (
+    HeatBand.PROVIDER_LOWER,
+    HeatBand.PROVIDER_MODERATE,
+    HeatBand.PROVIDER_HIGHER,
+    HeatBand.PROVIDER_VERY_HIGH,
+)
 
 
 def classify_heat(
@@ -64,7 +45,8 @@ def classify_heat(
     *,
     metric: HeatMetricName,
     cautious: bool = False,
-) -> HeatClassification:
+    noaa_heat_index_available: bool | None = None,
+) -> HeatInterpretation:
     """Classify a Celsius value without conflating provider data with NOAA data."""
     if not isinstance(metric, HeatMetricName):
         raise ValueError("metric must be a HeatMetricName value")
@@ -75,87 +57,82 @@ def classify_heat(
     ):
         raise ValueError("heat value must be finite or None")
     policy = GuidancePolicy.CAUTIOUS if cautious else GuidancePolicy.STANDARD
+    noaa_available = (
+        metric is HeatMetricName.HEAT_INDEX_CELSIUS and value_celsius is not None
+        if noaa_heat_index_available is None
+        else noaa_heat_index_available
+    )
+    if not isinstance(noaa_available, bool):
+        raise ValueError("NOAA Heat Index availability must be a boolean")
+    if metric is HeatMetricName.HEAT_INDEX_CELSIUS and noaa_available and value_celsius is None:
+        raise ValueError("available NOAA Heat Index requires a value")
+    actual_heat_index = (
+        metric is HeatMetricName.HEAT_INDEX_CELSIUS and value_celsius is not None and noaa_available
+    )
     if value_celsius is None:
-        return HeatClassification(
-            metric,
-            None,
-            None,
-            "NOAA Heat Index unavailable"
+        return HeatInterpretation(
+            metric=metric,
+            value_celsius=None,
+            band=None,
+            band_label="NOAA Heat Index unavailable"
             if metric is HeatMetricName.HEAT_INDEX_CELSIUS
             else "Provider temperature unavailable",
-            None,
-            policy,
-            metric is HeatMetricName.HEAT_INDEX_CELSIUS,
-            "no_heat_index_available"
+            action_threshold_band=None,
+            guidance_policy=policy,
+            is_actual_heat_index=False,
+            noaa_heat_index_available=noaa_available,
+            action_required=False,
+            policy_applied="no_heat_index_available"
             if metric is HeatMetricName.HEAT_INDEX_CELSIUS
             else "metric_unavailable",
         )
 
-    if metric is HeatMetricName.HEAT_INDEX_CELSIUS:
+    if actual_heat_index:
         band = _noaa_band(value_celsius)
-        action_band = _shift_band(band) if cautious else band
-        return HeatClassification(
-            metric,
-            float(value_celsius),
-            band,
-            _NOAA_LABELS[band],
-            action_band,
-            policy,
-            True,
-            "cautious_guidance_one_band_earlier" if cautious else "standard_noaa_guidance",
-        )
-
-    band = _provider_band(value_celsius)
-    return HeatClassification(
-        metric,
-        float(value_celsius),
-        band,
-        _PROVIDER_LABELS[band],
-        _shift_provider_band(band) if cautious else band,
-        policy,
-        False,
-        "cautious_guidance_one_band_earlier" if cautious else "standard_provider_guidance",
+        order: tuple[HeatBand, ...] = _NOAA_ORDER
+    else:
+        band = _provider_band(value_celsius)
+        order = _PROVIDER_ORDER
+    index = order.index(band)
+    default_threshold = 2
+    threshold_index = max(default_threshold - 1, 0) if cautious else default_threshold
+    action_threshold_band = order[threshold_index]
+    action_required = index >= threshold_index
+    return HeatInterpretation(
+        metric=metric,
+        value_celsius=float(value_celsius),
+        band=band,
+        band_label=HEAT_BAND_LABELS[band],
+        action_threshold_band=action_threshold_band,
+        guidance_policy=policy,
+        is_actual_heat_index=actual_heat_index,
+        noaa_heat_index_available=noaa_available,
+        action_required=action_required,
+        policy_applied=(
+            "cautious_guidance_one_band_earlier" if cautious else "standard_heat_guidance"
+        ),
     )
 
 
 def _noaa_band(value: float) -> HeatBand:
-    if value < _NOAA_BANDS[0][0]:
+    first, second, third, fourth = NOAA_BOUNDARIES_CELSIUS
+    if value < first:
         return HeatBand.BELOW_CAUTION
-    if value < 32.2:
+    if value < second:
         return HeatBand.CAUTION
-    if value < 40.6:
+    if value < third:
         return HeatBand.EXTREME_CAUTION
-    if value <= 54.4:
+    if value < fourth:
         return HeatBand.DANGER
     return HeatBand.EXTREME_DANGER
 
 
-def _shift_band(band: HeatBand) -> HeatBand:
-    order = (
-        HeatBand.BELOW_CAUTION,
-        HeatBand.CAUTION,
-        HeatBand.EXTREME_CAUTION,
-        HeatBand.DANGER,
-        HeatBand.EXTREME_DANGER,
-    )
-    return order[max(order.index(band) - 1, 0)]
-
-
 def _provider_band(value: float) -> HeatBand:
-    if value < 26.7:
+    first, second, third = PROVIDER_TCM_BOUNDARIES_CELSIUS
+    if value < first:
         return HeatBand.PROVIDER_LOWER
-    if value < 32.2:
+    if value < second:
         return HeatBand.PROVIDER_MODERATE
-    if value < 40.6:
+    if value < third:
         return HeatBand.PROVIDER_HIGHER
-    return HeatBand.PROVIDER_DANGER
-
-
-def _shift_provider_band(band: HeatBand) -> HeatBand:
-    order = (
-        HeatBand.PROVIDER_LOWER,
-        HeatBand.PROVIDER_MODERATE,
-        HeatBand.PROVIDER_HIGHER,
-        HeatBand.PROVIDER_DANGER,
-    )
-    return order[max(order.index(band) - 1, 0)]
+    return HeatBand.PROVIDER_VERY_HIGH

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -28,7 +28,7 @@ from app.domain.contracts import (
     TripAnalysisResponse,
     UnavailableResult,
 )
-from app.domain.heat_policy import HeatClassification, classify_heat
+from app.domain.heat_policy import classify_heat
 from app.services.sidecars import load_acquisition_record
 
 
@@ -207,39 +207,65 @@ def _best_time(
     hourly_payload = best_payload.get("hourly")
     if not isinstance(hourly_payload, list):
         raise ValueError("best_time.hourly must be a list")
+    hourly_items = tuple(_mapping(entry, "hourly entry") for entry in hourly_payload)
     hourly = tuple(
         HourlyEntry(
-            hour=_integer(_mapping(entry, "hourly entry")["hour"], "hour"),
+            hour=_integer(entry["hour"], "hour"),
             metric=Metric(
-                value=_number(_mapping(entry, "hourly entry")["value"], "hourly value"),
+                value=_number(entry["value"], "hourly value"),
                 unit=_string(best_payload["unit"], "unit"),
                 label=metric_label,
                 is_actual_heat_index=metric_name is HeatMetricName.HEAT_INDEX_CELSIUS,
             ),
         )
-        for entry in hourly_payload
+        for entry in hourly_items
     )
+    heat_index_by_hour = {
+        _integer(entry["hour"], "hour"): (
+            _number(entry["value"], "hourly value")
+            if metric_name is HeatMetricName.HEAT_INDEX_CELSIUS
+            else _optional_number(entry.get("heat_index_celsius"), "heat_index_celsius")
+        )
+        for entry in hourly_items
+    }
     recommendation_hour = _integer(best_payload["recommendation_hour"], "recommendation_hour")
     recommendation_value = next(
         (entry.metric.value for entry in hourly if entry.hour == recommendation_hour), None
     )
+    if cautious:
+        recommendation_hour = _cautious_hour(hourly, metric_name, heat_index_by_hour)
+        recommendation_value = next(
+            entry.metric.value for entry in hourly if entry.hour == recommendation_hour
+        )
+    selected_heat_index = heat_index_by_hour[recommendation_hour]
+    interpretation_metric = (
+        HeatMetricName.HEAT_INDEX_CELSIUS if selected_heat_index is not None else metric_name
+    )
+    interpretation_value = (
+        selected_heat_index if selected_heat_index is not None else recommendation_value
+    )
+    interpretation = classify_heat(
+        interpretation_value,
+        metric=interpretation_metric,
+        cautious=cautious,
+        noaa_heat_index_available=selected_heat_index is not None,
+    )
+    recommendation_reason = _string(best_payload["recommendation_reason"], "recommendation_reason")
+    if cautious:
+        recommendation_reason = (
+            "more cautious guidance selected the coolest period below the earlier action threshold"
+            if not interpretation.action_required
+            else "more cautious guidance selected the lowest available metric value; all periods meet the earlier action threshold"
+        )
 
     return BestTimeResult(
         hourly=hourly,
         recommendation_hour=recommendation_hour,
-        recommendation_reason=_string(
-            best_payload["recommendation_reason"], "recommendation_reason"
-        ),
+        recommendation_reason=recommendation_reason,
         metric_label=metric_label,
         provenance=best_provenance,
         hourly_coverage=_number(best_payload["hourly_coverage"], "hourly_coverage"),
-        heat_interpretation=_interpretation(
-            classify_heat(
-                recommendation_value,
-                metric=metric_name,
-                cautious=cautious,
-            )
-        ),
+        heat_interpretation=interpretation,
     )
 
 
@@ -299,9 +325,29 @@ def _routes(
     heat_status = HeatStatus(_string(route_payload["heat_status"], "heat_status"))
     route_metric = HeatMetricName(_string(route_payload["heat_metric"], "heat_metric"))
     route_unit = _string(route_payload["heat_unit"], "heat_unit")
+    route_values = tuple(
+        _number(_mapping(item, "route alternative")["heat_value"], "heat_value")
+        for item in alternatives_payload
+    )
+    original_recommended_id = recommended_id
+    if cautious and confidence is Confidence.SUFFICIENT:
+        recommended_id = _cautious_route_id(
+            alternatives_payload, route_metric, route_values, recommended_id
+        )
+    recommendation_reason = _string(route_payload["reason"], "reason")
+    cautious_selected_route = cautious and recommended_id != original_recommended_id
+    if cautious_selected_route:
+        recommendation_reason = "cautious guidance selected the least-hot returned route"
     alternatives = tuple(
         _route_option(
-            item, recommended_id, route_metric, route_unit, heat_status, confidence, cautious
+            item,
+            recommended_id,
+            route_metric,
+            route_unit,
+            heat_status,
+            confidence,
+            cautious,
+            cautious_selected_route,
         )
         for item in alternatives_payload
     )
@@ -309,7 +355,7 @@ def _routes(
     return RouteComparisonResult(
         alternatives=alternatives,
         recommended_id=recommended_id,
-        reason=_string(route_payload["reason"], "reason"),
+        reason=recommendation_reason,
         heat_status=heat_status,
         corridor_heat_value=_number(route_payload["corridor_heat_value"], "corridor_heat_value"),
         heat_metric=route_metric,
@@ -321,12 +367,10 @@ def _routes(
         fallback_reason=_string(fallback_reason, "fallback_reason")
         if fallback_reason is not None
         else None,
-        heat_interpretation=_interpretation(
-            classify_heat(
-                _number(route_payload["corridor_heat_value"], "corridor_heat_value"),
-                metric=route_metric,
-                cautious=cautious,
-            )
+        heat_interpretation=classify_heat(
+            _number(route_payload["corridor_heat_value"], "corridor_heat_value"),
+            metric=route_metric,
+            cautious=cautious,
         ),
     )
 
@@ -339,6 +383,7 @@ def _route_option(
     status: HeatStatus,
     confidence: Confidence,
     cautious: bool,
+    cautious_selected_route: bool,
 ) -> RouteOption:
     item = _mapping(value, "route alternative")
     identity = _string(item["identity"], "route identity")
@@ -357,26 +402,82 @@ def _route_option(
         shade_confidence=confidence if shade is not None else None,
         building_coverage=_number(item["building_coverage"], "building_coverage"),
         recommended=identity == recommended_id,
-        recommendation_reason=_string(item["recommendation_reason"], "recommendation_reason")
-        if item.get("recommendation_reason") is not None
-        else None,
+        recommendation_reason=_route_recommendation_reason(
+            item,
+            recommended=identity == recommended_id,
+            confidence=confidence,
+            cautious_selected_route=cautious_selected_route,
+        ),
         shade_model_label="modeled shade estimate based on OSM building data"
         if shade is not None
         else None,
-        heat_interpretation=_interpretation(
-            classify_heat(
-                _number(item["heat_value"], "heat_value"),
-                metric=metric,
-                cautious=cautious,
-            )
+        heat_interpretation=classify_heat(
+            _number(item["heat_value"], "heat_value"),
+            metric=metric,
+            cautious=cautious,
         ),
     )
 
 
-def _interpretation(value: HeatClassification) -> dict[str, object]:
-    from dataclasses import asdict
+def _route_recommendation_reason(
+    item: Mapping[str, object],
+    *,
+    recommended: bool,
+    confidence: Confidence,
+    cautious_selected_route: bool,
+) -> str | None:
+    if recommended and confidence is Confidence.INSUFFICIENT:
+        return "shortest-route fallback because route comparison confidence is insufficient"
+    if recommended and cautious_selected_route:
+        return "cautious guidance selected this returned route"
+    reason = item.get("recommendation_reason")
+    return _string(reason, "recommendation_reason") if reason is not None else None
 
-    return dict(asdict(value))
+
+def _cautious_route_id(
+    alternatives: list[object],
+    metric: HeatMetricName,
+    values: tuple[float, ...],
+    original_recommended_id: str,
+) -> str:
+    """Choose the least-hot returned route when cautious guidance is requested."""
+    if not alternatives:
+        raise ValueError("routes.alternatives must not be empty")
+    ranked = min(
+        enumerate(alternatives),
+        key=lambda candidate: (
+            classify_heat(values[candidate[0]], metric=metric, cautious=True).action_required,
+            values[candidate[0]],
+            _string(_mapping(candidate[1], "route alternative")["identity"], "route identity")
+            != original_recommended_id,
+            _number(_mapping(candidate[1], "route alternative")["distance_m"], "distance_m"),
+        ),
+    )
+    return _string(_mapping(ranked[1], "route alternative")["identity"], "route identity")
+
+
+def _cautious_hour(
+    hourly: tuple[HourlyEntry, ...],
+    metric: HeatMetricName,
+    heat_index_by_hour: dict[int, float | None],
+) -> int:
+    """Prefer a period below the cautious action threshold, then the coolest one."""
+    return min(
+        hourly,
+        key=lambda entry: _hour_policy_sort_key(entry, metric, heat_index_by_hour),
+    ).hour
+
+
+def _hour_policy_sort_key(
+    entry: HourlyEntry,
+    metric: HeatMetricName,
+    heat_index_by_hour: dict[int, float | None],
+) -> tuple[bool, float, int]:
+    heat_index = heat_index_by_hour[entry.hour]
+    selected_value = heat_index if heat_index is not None else entry.metric.value
+    selected_metric = HeatMetricName.HEAT_INDEX_CELSIUS if heat_index is not None else metric
+    interpretation = classify_heat(selected_value, metric=selected_metric, cautious=True)
+    return interpretation.action_required, selected_value, entry.hour
 
 
 def _provenance(section: Mapping[str, object], execution_mode: ExecutionMode) -> Provenance:
@@ -426,6 +527,12 @@ def _number(value: object, field: str) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
         raise ValueError(f"{field} must be a finite number")
     return float(value)
+
+
+def _optional_number(value: object, field: str) -> float | None:
+    if value is None:
+        return None
+    return _number(value, field)
 
 
 def _string(value: object, field: str) -> str:

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -28,6 +28,7 @@ from app.domain.contracts import (
     TripAnalysisResponse,
     UnavailableResult,
 )
+from app.domain.heat_policy import HeatClassification, classify_heat
 from app.services.sidecars import load_acquisition_record
 
 
@@ -145,7 +146,9 @@ def normalize_trip_analysis(
     _require_section_reason("routes", route_value, degraded_reasons)
 
     best_time = (
-        _best_time(_mapping(best_value, "best_time"), execution_mode, request.date)
+        _best_time(
+            _mapping(best_value, "best_time"), execution_mode, request.date, request.cautious
+        )
         if best_value is not None
         else None
     )
@@ -155,7 +158,7 @@ def normalize_trip_analysis(
         else None
     )
     routes = (
-        _routes(_mapping(route_value, "routes"), execution_mode, request.date)
+        _routes(_mapping(route_value, "routes"), execution_mode, request.date, request.cautious)
         if route_value is not None
         else None
     )
@@ -186,7 +189,10 @@ def normalize_trip_analysis(
 
 
 def _best_time(
-    best_payload: Mapping[str, object], execution_mode: ExecutionMode, request_date: str
+    best_payload: Mapping[str, object],
+    execution_mode: ExecutionMode,
+    request_date: str,
+    cautious: bool,
 ) -> BestTimeResult:
     best_provenance = _provenance(best_payload, execution_mode)
     if best_provenance.data_date != request_date:
@@ -213,16 +219,27 @@ def _best_time(
         )
         for entry in hourly_payload
     )
+    recommendation_hour = _integer(best_payload["recommendation_hour"], "recommendation_hour")
+    recommendation_value = next(
+        (entry.metric.value for entry in hourly if entry.hour == recommendation_hour), None
+    )
 
     return BestTimeResult(
         hourly=hourly,
-        recommendation_hour=_integer(best_payload["recommendation_hour"], "recommendation_hour"),
+        recommendation_hour=recommendation_hour,
         recommendation_reason=_string(
             best_payload["recommendation_reason"], "recommendation_reason"
         ),
         metric_label=metric_label,
         provenance=best_provenance,
         hourly_coverage=_number(best_payload["hourly_coverage"], "hourly_coverage"),
+        heat_interpretation=_interpretation(
+            classify_heat(
+                recommendation_value,
+                metric=metric_name,
+                cautious=cautious,
+            )
+        ),
     )
 
 
@@ -266,7 +283,10 @@ def _hotels(
 
 
 def _routes(
-    route_payload: Mapping[str, object], execution_mode: ExecutionMode, request_date: str
+    route_payload: Mapping[str, object],
+    execution_mode: ExecutionMode,
+    request_date: str,
+    cautious: bool,
 ) -> RouteComparisonResult:
     route_provenance = _provenance(route_payload, execution_mode)
     if route_provenance.data_date != request_date:
@@ -280,7 +300,9 @@ def _routes(
     route_metric = HeatMetricName(_string(route_payload["heat_metric"], "heat_metric"))
     route_unit = _string(route_payload["heat_unit"], "heat_unit")
     alternatives = tuple(
-        _route_option(item, recommended_id, route_metric, route_unit, heat_status, confidence)
+        _route_option(
+            item, recommended_id, route_metric, route_unit, heat_status, confidence, cautious
+        )
         for item in alternatives_payload
     )
     fallback_reason = route_payload.get("fallback_reason")
@@ -299,6 +321,13 @@ def _routes(
         fallback_reason=_string(fallback_reason, "fallback_reason")
         if fallback_reason is not None
         else None,
+        heat_interpretation=_interpretation(
+            classify_heat(
+                _number(route_payload["corridor_heat_value"], "corridor_heat_value"),
+                metric=route_metric,
+                cautious=cautious,
+            )
+        ),
     )
 
 
@@ -309,6 +338,7 @@ def _route_option(
     unit: str,
     status: HeatStatus,
     confidence: Confidence,
+    cautious: bool,
 ) -> RouteOption:
     item = _mapping(value, "route alternative")
     identity = _string(item["identity"], "route identity")
@@ -333,7 +363,20 @@ def _route_option(
         shade_model_label="modeled shade estimate based on OSM building data"
         if shade is not None
         else None,
+        heat_interpretation=_interpretation(
+            classify_heat(
+                _number(item["heat_value"], "heat_value"),
+                metric=metric,
+                cautious=cautious,
+            )
+        ),
     )
+
+
+def _interpretation(value: HeatClassification) -> dict[str, object]:
+    from dataclasses import asdict
+
+    return dict(asdict(value))
 
 
 def _provenance(section: Mapping[str, object], execution_mode: ExecutionMode) -> Provenance:

--- a/docs/design/design-doc.md
+++ b/docs/design/design-doc.md
@@ -157,7 +157,10 @@ The core uses:
 
 `tcm` must never be silently treated as NOAA Heat Index. If actual heat index
 is unavailable, the UI displays the Celsius metric and a separately named
-product band or no categorical band.
+product band. The initial product-only `tcm` bands are lower (below 30 C),
+moderate (30 to below 35 C), higher (35 to below 40 C), and very high (40 C
+and above). These labels and thresholds are product policy, not NOAA/NWS
+categories or clinical guidance.
 
 ### OSRM
 
@@ -211,7 +214,13 @@ phrasing is “no elevated heat concern detected by the selected metric” and
 The optional cautious setting shifts the product action threshold one band
 earlier. This is an explicit team safety policy supported by general public
 health guidance, not an official medical transformation. It does not collect a
-diagnosis, medication, or clinical profile.
+diagnosis, medication, or clinical profile. Standard guidance takes action from
+the third band; cautious guidance takes action from the second band. The
+measured value and displayed observation band do not change. Recommendations
+prefer returned hours or routes below the applicable action threshold, then the
+lowest selected-metric value. Route confidence remains the higher-priority
+guardrail: when route comparison confidence is insufficient, the existing
+shortest-route fallback applies instead of cautious optimization.
 
 ## Best-Time Decision
 

--- a/docs/research/proposal-fact-check.md
+++ b/docs/research/proposal-fact-check.md
@@ -110,6 +110,7 @@ Project policies and heuristics, not published standards:
 - A 35 C exceedance/persistence threshold.
 - Hotel weights of 35/25/20/20 percent.
 - Shifting the action threshold one band earlier for cautious guidance.
+- Product-only `tcm` bands at 30, 35, and 40 C; these are not NOAA boundaries.
 - Maximum corridor heat aggregation.
 - A building-height coverage threshold for trusting modeled shade.
 

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -38,7 +38,7 @@ const makeTrip = (
   location,
   date,
   metric: {
-    label: limited ? "Provider thermal comfort metric" : "NOAA Heat Index",
+    label: limited ? "Provider temperature metric" : "NOAA Heat Index",
     unit: "C",
     actualHeatIndex: !limited,
   },

--- a/frontend/src/screens/TripSetupScreen.tsx
+++ b/frontend/src/screens/TripSetupScreen.tsx
@@ -300,14 +300,16 @@ export function TripSetupScreen() {
                 <p>{tripAnalysis.unavailable?.reason}</p>
               </>
             )}
-            {tripAnalysis.state === "success" && tripAnalysis.best_time && (
-              <HeatPolicySummary
-                value={
-                  tripAnalysis.best_time.heat_interpretation as
-                    HeatInterpretation | undefined
-                }
-              />
-            )}
+            {(tripAnalysis.state === "success" ||
+              tripAnalysis.state === "degraded") &&
+              tripAnalysis.best_time && (
+                <HeatPolicySummary
+                  value={
+                    tripAnalysis.best_time.heat_interpretation as
+                      HeatInterpretation | undefined
+                  }
+                />
+              )}
             <button
               type="button"
               className="secondary-button"
@@ -344,9 +346,9 @@ function HeatPolicySummary({ value }: { value?: HeatInterpretation }) {
     <div className="heat-policy-summary">
       <strong>{value.band_label}</strong>
       <p>
-        {value.value_celsius === null
-          ? "The selected Celsius metric is shown separately because NOAA Heat Index is unavailable."
-          : `${value.value_celsius.toFixed(1)} °C · ${value.is_actual_heat_index ? "NOAA Heat Index" : "provider temperature metric"}.`}
+        {!value.noaa_heat_index_available
+          ? `${value.value_celsius === null ? "Selected Celsius metric unavailable" : `${value.value_celsius.toFixed(1)} °C provider temperature metric`} · NOAA Heat Index unavailable.`
+          : `${value.value_celsius?.toFixed(1)} °C · NOAA Heat Index.`}
       </p>
       {value.guidance_policy === "cautious" && (
         <small>

--- a/frontend/src/screens/TripSetupScreen.tsx
+++ b/frontend/src/screens/TripSetupScreen.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useAppState } from "../app/AppState";
 import { dataClient } from "../services/dataClient";
 import type { ExecutionMode, TripAnalysisRequest } from "../types";
+import type { HeatInterpretation } from "../types";
 
 const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
 
@@ -299,6 +300,14 @@ export function TripSetupScreen() {
                 <p>{tripAnalysis.unavailable?.reason}</p>
               </>
             )}
+            {tripAnalysis.state === "success" && tripAnalysis.best_time && (
+              <HeatPolicySummary
+                value={
+                  tripAnalysis.best_time.heat_interpretation as
+                    HeatInterpretation | undefined
+                }
+              />
+            )}
             <button
               type="button"
               className="secondary-button"
@@ -326,5 +335,25 @@ export function TripSetupScreen() {
         </section>
       )}
     </section>
+  );
+}
+
+function HeatPolicySummary({ value }: { value?: HeatInterpretation }) {
+  if (!value) return null;
+  return (
+    <div className="heat-policy-summary">
+      <strong>{value.band_label}</strong>
+      <p>
+        {value.value_celsius === null
+          ? "The selected Celsius metric is shown separately because NOAA Heat Index is unavailable."
+          : `${value.value_celsius.toFixed(1)} °C · ${value.is_actual_heat_index ? "NOAA Heat Index" : "provider temperature metric"}.`}
+      </p>
+      {value.guidance_policy === "cautious" && (
+        <small>
+          More cautious guidance selected; the action threshold is shifted one
+          band earlier.
+        </small>
+      )}
+    </div>
   );
 }

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -37,6 +37,112 @@ function validReasons(value: unknown): value is Record<string, string> {
   );
 }
 
+function validHeatInterpretation(value: unknown) {
+  const noaaBands = [
+    "below_caution",
+    "caution",
+    "extreme_caution",
+    "danger",
+    "extreme_danger",
+  ];
+  const providerBands = [
+    "provider_lower",
+    "provider_moderate",
+    "provider_higher",
+    "provider_very_high",
+  ];
+  const bandLabels: Record<string, string> = {
+    below_caution: "Below NOAA caution",
+    caution: "Caution",
+    extreme_caution: "Extreme caution",
+    danger: "Danger",
+    extreme_danger: "Extreme danger",
+    provider_lower: "Lower provider temperature",
+    provider_moderate: "Moderate provider temperature",
+    provider_higher: "Higher provider temperature",
+    provider_very_high: "Very high provider temperature",
+  };
+  if (!isObject(value)) return false;
+  const expectedBands =
+    value.metric === "heat_index_celsius" ? noaaBands : providerBands;
+  const actualHeatIndex =
+    value.metric === "heat_index_celsius" &&
+    typeof value.value_celsius === "number";
+  const hasValue = typeof value.value_celsius === "number";
+  const expectedThreshold =
+    expectedBands[value.guidance_policy === "cautious" ? 1 : 2];
+  const expectedAction =
+    typeof value.band === "string" &&
+    expectedBands.indexOf(value.band) >=
+      expectedBands.indexOf(expectedThreshold);
+  const expectedPolicy =
+    value.guidance_policy === "cautious"
+      ? "cautious_guidance_one_band_earlier"
+      : "standard_heat_guidance";
+  const expectedUnavailableLabel =
+    value.metric === "heat_index_celsius"
+      ? "NOAA Heat Index unavailable"
+      : "Provider temperature unavailable";
+  const expectedUnavailablePolicy =
+    value.metric === "heat_index_celsius"
+      ? "no_heat_index_available"
+      : "metric_unavailable";
+  return (
+    (value.metric === "tcm" || value.metric === "heat_index_celsius") &&
+    (value.value_celsius === null || typeof value.value_celsius === "number") &&
+    (value.band === null || expectedBands.includes(String(value.band))) &&
+    ((value.band === null && typeof value.band_label === "string") ||
+      value.band_label === bandLabels[String(value.band)]) &&
+    (value.action_threshold_band === null ||
+      expectedBands.includes(String(value.action_threshold_band))) &&
+    (value.guidance_policy === "standard" ||
+      value.guidance_policy === "cautious") &&
+    value.is_actual_heat_index === actualHeatIndex &&
+    value.noaa_heat_index_available === actualHeatIndex &&
+    (hasValue
+      ? value.band !== null &&
+        value.action_threshold_band === expectedThreshold &&
+        value.action_required === expectedAction &&
+        value.policy_applied === expectedPolicy
+      : value.band === null &&
+        value.action_threshold_band === null &&
+        value.action_required === false &&
+        value.band_label === expectedUnavailableLabel &&
+        value.policy_applied === expectedUnavailablePolicy) &&
+    typeof value.policy_applied === "string" &&
+    value.policy_applied.length > 0
+  );
+}
+
+function validRoutes(value: unknown) {
+  if (value === null) return true;
+  if (
+    !isObject(value) ||
+    !validHeatInterpretation(value.heat_interpretation) ||
+    !isObject(value.heat_interpretation) ||
+    value.heat_interpretation.metric !== value.heat_metric ||
+    value.heat_interpretation.value_celsius !== value.corridor_heat_value ||
+    !Array.isArray(value.alternatives)
+  ) {
+    return false;
+  }
+  return value.alternatives.every(
+    (route) =>
+      isObject(route) &&
+      validHeatInterpretation(route.heat_interpretation) &&
+      isObject(route.heat_interpretation) &&
+      route.heat_interpretation.metric === route.heat_metric &&
+      route.heat_interpretation.value_celsius === route.heat_value
+  );
+}
+
+function validBestTime(value: unknown) {
+  return (
+    value === null ||
+    (isObject(value) && validHeatInterpretation(value.heat_interpretation))
+  );
+}
+
 function isTripAnalysisResponse(
   value: unknown,
   request: TripAnalysisRequest
@@ -50,9 +156,9 @@ function isTripAnalysisResponse(
     !["success", "degraded", "unavailable", "error"].includes(
       String(value.state)
     ) ||
-    !isResultSection(value.best_time) ||
+    !validBestTime(value.best_time) ||
     !isResultSection(value.hotels) ||
-    !isResultSection(value.routes)
+    !validRoutes(value.routes)
   ) {
     return false;
   }

--- a/frontend/src/test/tripSetup.test.tsx
+++ b/frontend/src/test/tripSetup.test.tsx
@@ -14,9 +14,39 @@ const successResponse = {
   mode: "curated",
   execution_mode: "fixture",
   state: "success",
-  best_time: { hourly: [] },
+  best_time: {
+    hourly: [],
+    heat_interpretation: {
+      metric: "tcm",
+      value_celsius: 29,
+      band: "provider_lower",
+      band_label: "Lower provider temperature",
+      action_threshold_band: "provider_higher",
+      guidance_policy: "standard",
+      is_actual_heat_index: false,
+      noaa_heat_index_available: false,
+      action_required: false,
+      policy_applied: "standard_heat_guidance",
+    },
+  },
   hotels: { ranked: [] },
-  routes: { alternatives: [] },
+  routes: {
+    alternatives: [],
+    heat_metric: "tcm",
+    corridor_heat_value: 38,
+    heat_interpretation: {
+      metric: "tcm",
+      value_celsius: 38,
+      band: "provider_higher",
+      band_label: "Higher provider temperature",
+      action_threshold_band: "provider_higher",
+      guidance_policy: "standard",
+      is_actual_heat_index: false,
+      noaa_heat_index_available: false,
+      action_required: true,
+      policy_applied: "standard_heat_guidance",
+    },
+  },
   unavailable: null,
   degraded_reasons: null,
 };
@@ -65,6 +95,11 @@ describe("curated Trip Setup", () => {
     await user.click(screen.getByRole("button", { name: "Analyze trip" }));
 
     expect(await screen.findByText("Trip analysis ready")).toBeInTheDocument();
+    expect(screen.getByText("Lower provider temperature")).toBeInTheDocument();
+    expect(
+      screen.getByText(/29.0 °C provider temperature metric/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/NOAA Heat Index unavailable/)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(1, "/health", expect.any(Object));
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -179,6 +214,9 @@ describe("curated Trip Setup", () => {
     ).toBeInTheDocument();
     expect(
       within(outcome).getByText("Hotel ranking is temporarily unavailable.")
+    ).toBeInTheDocument();
+    expect(
+      within(outcome).getByText("Lower provider temperature")
     ).toBeInTheDocument();
 
     await user.selectOptions(screen.getByLabelText("Hour"), "9");

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -103,13 +103,26 @@ export type TripAnalysisResponse = {
 export type HeatInterpretation = {
   metric: "tcm" | "heat_index_celsius";
   value_celsius: number | null;
-  band: string | null;
+  band: HeatBand | null;
   band_label: string;
-  action_band: string | null;
+  action_threshold_band: HeatBand | null;
   guidance_policy: "standard" | "cautious";
   is_actual_heat_index: boolean;
+  noaa_heat_index_available: boolean;
+  action_required: boolean;
   policy_applied: string;
 };
+
+export type HeatBand =
+  | "below_caution"
+  | "caution"
+  | "extreme_caution"
+  | "danger"
+  | "extreme_danger"
+  | "provider_lower"
+  | "provider_moderate"
+  | "provider_higher"
+  | "provider_very_high";
 
 export type CuratedTripSetup = {
   date: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -91,11 +91,24 @@ export type TripAnalysisResponse = {
   mode: "curated";
   execution_mode: ExecutionMode;
   state: "success" | "degraded" | "unavailable" | "error";
-  best_time: Record<string, unknown> | null;
+  best_time:
+    | ({ heat_interpretation?: HeatInterpretation } & Record<string, unknown>)
+    | null;
   hotels: Record<string, unknown> | null;
   routes: Record<string, unknown> | null;
   unavailable: { reason: string; recoverable: boolean } | null;
   degraded_reasons: Record<string, string> | null;
+};
+
+export type HeatInterpretation = {
+  metric: "tcm" | "heat_index_celsius";
+  value_celsius: number | null;
+  band: string | null;
+  band_label: string;
+  action_band: string | null;
+  guidance_policy: "standard" | "cautious";
+  is_actual_heat_index: boolean;
+  policy_applied: string;
 };
 
 export type CuratedTripSetup = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ include = ["app*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = [
     "integration: fixture-backed tests that cross application boundaries",
 ]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance and research scripts."""

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -12,6 +12,9 @@ from app.domain.contracts import (
     ExecutionMode,
     HeatStatus,
     HeatMetricName,
+    GuidancePolicy,
+    HeatBand,
+    HeatInterpretation,
     HourlyEntry,
     Metric,
     MetricLabel,
@@ -391,6 +394,36 @@ class TestMalformedPayloads:
     def test_metric_empty_unit(self) -> None:
         with pytest.raises(ValueError, match="unit"):
             Metric(value=35.0, unit="", label=MetricLabel.PROVIDER_TCM, is_actual_heat_index=False)
+
+    def test_heat_interpretation_rejects_noaa_claims_for_provider_tcm(self) -> None:
+        with pytest.raises(ValueError, match="NOAA Heat Index availability"):
+            HeatInterpretation(
+                metric=HeatMetricName.TCM,
+                value_celsius=35,
+                band=HeatBand.PROVIDER_HIGHER,
+                band_label="Higher provider temperature",
+                action_threshold_band=HeatBand.PROVIDER_HIGHER,
+                guidance_policy=GuidancePolicy.STANDARD,
+                is_actual_heat_index=False,
+                noaa_heat_index_available=True,
+                action_required=True,
+                policy_applied="standard_heat_guidance",
+            )
+
+    def test_heat_interpretation_rejects_bands_for_missing_values(self) -> None:
+        with pytest.raises(ValueError, match="missing metric values"):
+            HeatInterpretation(
+                metric=HeatMetricName.HEAT_INDEX_CELSIUS,
+                value_celsius=None,
+                band=HeatBand.CAUTION,
+                band_label="NOAA Heat Index unavailable",
+                action_threshold_band=None,
+                guidance_policy=GuidancePolicy.STANDARD,
+                is_actual_heat_index=False,
+                noaa_heat_index_available=False,
+                action_required=False,
+                policy_applied="no_heat_index_available",
+            )
 
     def test_hourly_entry_invalid_hour(self) -> None:
         with pytest.raises(ValueError, match="hour"):

--- a/tests/test_heat_policy.py
+++ b/tests/test_heat_policy.py
@@ -1,7 +1,7 @@
 import pytest
 
-from app.domain.contracts import HeatMetricName
-from app.domain.heat_policy import HeatBand, GuidancePolicy, classify_heat
+from app.domain.contracts import GuidancePolicy, HeatBand, HeatMetricName
+from app.domain.heat_policy import classify_heat
 from app.conversion import fahrenheit_to_celsius
 
 
@@ -14,11 +14,29 @@ def test_noaa_boundaries_convert_to_celsius(fahrenheit: float, celsius: float) -
 
 
 @pytest.mark.parametrize(  # type: ignore[misc]
+    ("fahrenheit", "band"),
+    [
+        (80, HeatBand.CAUTION),
+        (90, HeatBand.EXTREME_CAUTION),
+        (105, HeatBand.DANGER),
+        (130, HeatBand.EXTREME_DANGER),
+    ],
+)
+def test_converted_noaa_boundaries_classify_at_the_declared_boundary(
+    fahrenheit: float, band: HeatBand
+) -> None:
+    result = classify_heat(
+        fahrenheit_to_celsius(fahrenheit), metric=HeatMetricName.HEAT_INDEX_CELSIUS
+    )
+    assert result.band is band
+
+
+@pytest.mark.parametrize(  # type: ignore[misc]
     ("value", "band"),
     [
         (26.6, HeatBand.BELOW_CAUTION),
         (26.7, HeatBand.CAUTION),
-        (32.2, HeatBand.EXTREME_CAUTION),
+        (32.2, HeatBand.CAUTION),
         (40.6, HeatBand.DANGER),
         (54.4, HeatBand.DANGER),
         (54.5, HeatBand.EXTREME_DANGER),
@@ -37,16 +55,33 @@ def test_provider_tcm_never_uses_noaa_category() -> None:
     assert result.band_label == "Higher provider temperature"
 
 
+@pytest.mark.parametrize(  # type: ignore[misc]
+    ("value", "band"),
+    [
+        (29.9, HeatBand.PROVIDER_LOWER),
+        (30.0, HeatBand.PROVIDER_MODERATE),
+        (35.0, HeatBand.PROVIDER_HIGHER),
+        (40.0, HeatBand.PROVIDER_VERY_HIGH),
+    ],
+)
+def test_provider_tcm_uses_separately_declared_product_boundaries(
+    value: float, band: HeatBand
+) -> None:
+    assert classify_heat(value, metric=HeatMetricName.TCM).band is band
+
+
 def test_missing_heat_index_is_explicit() -> None:
     result = classify_heat(None, metric=HeatMetricName.HEAT_INDEX_CELSIUS)
     assert result.band is None
     assert result.band_label == "NOAA Heat Index unavailable"
+    assert result.is_actual_heat_index is False
+    assert result.noaa_heat_index_available is False
 
 
 def test_cautious_guidance_moves_action_band_one_band_earlier() -> None:
     result = classify_heat(38, metric=HeatMetricName.HEAT_INDEX_CELSIUS, cautious=True)
     assert result.band is HeatBand.EXTREME_CAUTION
-    assert result.action_band is HeatBand.CAUTION
+    assert result.action_threshold_band is HeatBand.CAUTION
     assert result.guidance_policy is GuidancePolicy.CAUTIOUS
     assert result.policy_applied == "cautious_guidance_one_band_earlier"
 
@@ -54,4 +89,4 @@ def test_cautious_guidance_moves_action_band_one_band_earlier() -> None:
 def test_cautious_guidance_does_not_change_provider_value() -> None:
     result = classify_heat(38, metric=HeatMetricName.TCM, cautious=True)
     assert result.value_celsius == 38
-    assert result.action_band is HeatBand.PROVIDER_MODERATE
+    assert result.action_threshold_band is HeatBand.PROVIDER_MODERATE

--- a/tests/test_heat_policy.py
+++ b/tests/test_heat_policy.py
@@ -1,0 +1,57 @@
+import pytest
+
+from app.domain.contracts import HeatMetricName
+from app.domain.heat_policy import HeatBand, GuidancePolicy, classify_heat
+from app.conversion import fahrenheit_to_celsius
+
+
+@pytest.mark.parametrize(  # type: ignore[misc]
+    ("fahrenheit", "celsius"),
+    [(80, 26.6666666667), (90, 32.2222222222), (105, 40.5555555556), (130, 54.4444444444)],
+)
+def test_noaa_boundaries_convert_to_celsius(fahrenheit: float, celsius: float) -> None:
+    assert fahrenheit_to_celsius(fahrenheit) == pytest.approx(celsius)
+
+
+@pytest.mark.parametrize(  # type: ignore[misc]
+    ("value", "band"),
+    [
+        (26.6, HeatBand.BELOW_CAUTION),
+        (26.7, HeatBand.CAUTION),
+        (32.2, HeatBand.EXTREME_CAUTION),
+        (40.6, HeatBand.DANGER),
+        (54.4, HeatBand.DANGER),
+        (54.5, HeatBand.EXTREME_DANGER),
+    ],
+)
+def test_actual_heat_index_uses_noaa_bands(value: float, band: HeatBand) -> None:
+    result = classify_heat(value, metric=HeatMetricName.HEAT_INDEX_CELSIUS)
+    assert result.band is band
+    assert result.is_actual_heat_index is True
+
+
+def test_provider_tcm_never_uses_noaa_category() -> None:
+    result = classify_heat(38, metric=HeatMetricName.TCM)
+    assert result.band is HeatBand.PROVIDER_HIGHER
+    assert result.is_actual_heat_index is False
+    assert result.band_label == "Higher provider temperature"
+
+
+def test_missing_heat_index_is_explicit() -> None:
+    result = classify_heat(None, metric=HeatMetricName.HEAT_INDEX_CELSIUS)
+    assert result.band is None
+    assert result.band_label == "NOAA Heat Index unavailable"
+
+
+def test_cautious_guidance_moves_action_band_one_band_earlier() -> None:
+    result = classify_heat(38, metric=HeatMetricName.HEAT_INDEX_CELSIUS, cautious=True)
+    assert result.band is HeatBand.EXTREME_CAUTION
+    assert result.action_band is HeatBand.CAUTION
+    assert result.guidance_policy is GuidancePolicy.CAUTIOUS
+    assert result.policy_applied == "cautious_guidance_one_band_earlier"
+
+
+def test_cautious_guidance_does_not_change_provider_value() -> None:
+    result = classify_heat(38, metric=HeatMetricName.TCM, cautious=True)
+    assert result.value_celsius == 38
+    assert result.action_band is HeatBand.PROVIDER_MODERATE

--- a/tests/test_trip_adapters.py
+++ b/tests/test_trip_adapters.py
@@ -9,11 +9,12 @@ from app.domain.contracts import (
     Confidence,
     Coordinates,
     ExecutionMode,
+    GuidancePolicy,
+    HeatBand,
     ResultState,
     TripAnalysisRequest,
     TripMode,
 )
-from app.domain.heat_policy import HeatBand, GuidancePolicy
 from app.services.trip_adapters import (
     FixtureTripAnalysisAdapter,
     LiveTripAnalysisAdapter,
@@ -216,10 +217,164 @@ def test_cautious_request_records_one_band_earlier_policy_for_each_heat_section(
     route_policy = response.routes.heat_interpretation
     assert best_policy is not None
     assert route_policy is not None
-    assert best_policy["guidance_policy"] is GuidancePolicy.CAUTIOUS
-    assert best_policy["policy_applied"] == "cautious_guidance_one_band_earlier"
-    assert best_policy["band"] is HeatBand.PROVIDER_MODERATE
-    assert route_policy["band"] is HeatBand.PROVIDER_HIGHER
+    assert best_policy.guidance_policy is GuidancePolicy.CAUTIOUS
+    assert best_policy.policy_applied == "cautious_guidance_one_band_earlier"
+    assert best_policy.band is HeatBand.PROVIDER_LOWER
+    assert route_policy.band is HeatBand.PROVIDER_HIGHER
+    assert response.routes.recommended_id == "shady"
+
+
+def test_cautious_request_changes_route_action_to_the_least_hot_returned_route() -> None:
+    payload = _payload()
+    routes = payload["routes"]
+    assert isinstance(routes, dict)
+    routes["recommended_id"] = "short"
+    routes["reason"] = "shortest returned route"
+    short = routes["alternatives"][0]
+    shady = routes["alternatives"][1]
+    assert isinstance(short, dict) and isinstance(shady, dict)
+    short["heat_value"] = 42
+    shady["heat_value"] = 36
+    shady["recommendation_reason"] = None
+
+    response = normalize_trip_analysis(
+        payload,
+        replace(_request(), cautious=True),
+        ExecutionMode.FIXTURE,
+    )
+
+    assert response.routes is not None
+    assert response.routes.recommended_id == "shady"
+    assert response.routes.reason == "cautious guidance selected the least-hot returned route"
+    assert [route.identity for route in response.routes.alternatives if route.recommended] == [
+        "shady"
+    ]
+
+
+def test_provider_metric_response_records_noaa_heat_index_as_unavailable() -> None:
+    response = normalize_trip_analysis(_payload(), _request(), ExecutionMode.FIXTURE)
+
+    assert response.best_time is not None
+    interpretation = response.best_time.heat_interpretation
+    assert interpretation is not None
+    assert interpretation.metric.value == "tcm"
+    assert interpretation.value_celsius == 29
+    assert interpretation.is_actual_heat_index is False
+    assert interpretation.noaa_heat_index_available is False
+    assert interpretation.band_label == "Lower provider temperature"
+
+
+def test_actual_heat_index_is_classified_with_noaa_names_without_relabeling_tcm() -> None:
+    payload = _payload()
+    best_time = payload["best_time"]
+    assert isinstance(best_time, dict)
+    hourly = best_time["hourly"]
+    assert isinstance(hourly, list)
+    for entry in hourly:
+        assert isinstance(entry, dict)
+        entry["heat_index_celsius"] = 38
+
+    response = normalize_trip_analysis(payload, _request(), ExecutionMode.FIXTURE)
+
+    assert response.best_time is not None
+    interpretation = response.best_time.heat_interpretation
+    assert interpretation is not None
+    assert response.best_time.metric_label.value == "provider_tcm"
+    assert interpretation.metric.value == "heat_index_celsius"
+    assert interpretation.is_actual_heat_index is True
+    assert interpretation.noaa_heat_index_available is True
+    assert interpretation.band is HeatBand.EXTREME_CAUTION
+
+
+def test_cautious_best_time_uses_each_hours_actual_heat_index() -> None:
+    payload = _payload()
+    best_time = payload["best_time"]
+    assert isinstance(best_time, dict)
+    best_time["hourly"] = [
+        {"hour": 8, "value": 28.0, "heat_index_celsius": 34.0},
+        {"hour": 14, "value": 27.0, "heat_index_celsius": 25.0},
+        {"hour": 19, "value": 31.0, "heat_index_celsius": 24.0},
+    ]
+    best_time["recommendation_hour"] = 8
+
+    response = normalize_trip_analysis(
+        payload,
+        replace(_request(), cautious=True),
+        ExecutionMode.FIXTURE,
+    )
+
+    assert response.best_time is not None
+    assert response.best_time.recommendation_hour == 19
+    assert response.best_time.heat_interpretation is not None
+    assert response.best_time.heat_interpretation.value_celsius == 24
+    assert response.best_time.heat_interpretation.is_actual_heat_index is True
+
+
+def test_cautious_best_time_prefers_an_hour_below_the_earlier_action_threshold() -> None:
+    payload = _payload()
+    best_time = payload["best_time"]
+    assert isinstance(best_time, dict)
+    best_time["hourly"] = [
+        {"hour": 8, "value": 33.0},
+        {"hour": 14, "value": 38.0},
+        {"hour": 19, "value": 29.0},
+    ]
+    best_time["recommendation_hour"] = 8
+
+    response = normalize_trip_analysis(
+        payload,
+        replace(_request(), cautious=True),
+        ExecutionMode.FIXTURE,
+    )
+
+    assert response.best_time is not None
+    assert response.best_time.recommendation_hour == 19
+    assert response.best_time.heat_interpretation is not None
+    assert response.best_time.heat_interpretation.action_required is False
+
+
+def test_cautious_best_time_explains_lowest_value_fallback_when_all_hours_trigger_action() -> None:
+    payload = _payload()
+    best_time = payload["best_time"]
+    assert isinstance(best_time, dict)
+    best_time["hourly"] = [
+        {"hour": 8, "value": 34.0},
+        {"hour": 14, "value": 38.0},
+        {"hour": 19, "value": 32.0},
+    ]
+    best_time["recommendation_hour"] = 19
+
+    response = normalize_trip_analysis(
+        payload,
+        replace(_request(), cautious=True),
+        ExecutionMode.FIXTURE,
+    )
+
+    assert response.best_time is not None
+    assert response.best_time.recommendation_hour == 19
+    assert (
+        "all periods meet the earlier action threshold" in response.best_time.recommendation_reason
+    )
+
+
+def test_insufficient_confidence_shortest_route_fallback_overrides_cautious_optimization() -> None:
+    payload = _payload()
+    routes = payload["routes"]
+    assert isinstance(routes, dict)
+    routes["recommended_id"] = "short"
+    routes["confidence"] = Confidence.INSUFFICIENT.value
+    routes["fallback_reason"] = "insufficient route comparison confidence"
+    payload["degraded_reasons"] = {"routes": "insufficient route comparison confidence"}
+
+    response = normalize_trip_analysis(
+        payload,
+        replace(_request(), cautious=True),
+        ExecutionMode.FIXTURE,
+    )
+
+    assert response.routes is not None
+    assert response.routes.recommended_id == "short"
+    assert response.routes.fallback_reason == "insufficient route comparison confidence"
 
 
 def test_duplicate_hourly_evidence_is_rejected() -> None:

--- a/tests/test_trip_adapters.py
+++ b/tests/test_trip_adapters.py
@@ -13,6 +13,7 @@ from app.domain.contracts import (
     TripAnalysisRequest,
     TripMode,
 )
+from app.domain.heat_policy import HeatBand, GuidancePolicy
 from app.services.trip_adapters import (
     FixtureTripAnalysisAdapter,
     LiveTripAnalysisAdapter,
@@ -199,6 +200,26 @@ def test_route_corridor_heat_unit_is_explicit_and_validated() -> None:
 
     with pytest.raises(ValueError, match="heat_unit"):
         normalize_trip_analysis(payload, _request(), ExecutionMode.FIXTURE)
+
+
+def test_cautious_request_records_one_band_earlier_policy_for_each_heat_section() -> None:
+    payload = _payload()
+    response = normalize_trip_analysis(
+        payload,
+        replace(_request(), cautious=True),
+        ExecutionMode.FIXTURE,
+    )
+
+    assert response.best_time is not None
+    assert response.routes is not None
+    best_policy = response.best_time.heat_interpretation
+    route_policy = response.routes.heat_interpretation
+    assert best_policy is not None
+    assert route_policy is not None
+    assert best_policy["guidance_policy"] is GuidancePolicy.CAUTIOUS
+    assert best_policy["policy_applied"] == "cautious_guidance_one_band_earlier"
+    assert best_policy["band"] is HeatBand.PROVIDER_MODERATE
+    assert route_policy["band"] is HeatBand.PROVIDER_HIGHER
 
 
 def test_duplicate_hourly_evidence_is_rejected() -> None:


### PR DESCRIPTION
﻿## Summary

- add a typed heat-interpretation contract with exact NOAA Heat Index boundaries and separately documented product-only `tcm` bands
- apply standard and cautious action thresholds to best-time and route decisions while preserving route-confidence and shade tie-break rules
- render and validate metric identity, product bands, NOAA availability, and cautious policy state through the frontend
- add boundary, missing-data, metric-specific, cautious-decision, API-contract, UI, and fallback regression coverage

## Acceptance criteria

- [x] Celsius conversion is tested at every declared NOAA boundary, including conversion followed by classification
- [x] NOAA/NWS category names and boundaries are used only for actual Heat Index values
- [x] FortyGuard `tcm` remains explicitly identified as a provider metric
- [x] Provider-only UI shows the Celsius value, product band, and unavailable NOAA Heat Index state separately
- [x] Cautious guidance moves the action threshold one band earlier, records the policy, and changes applicable decisions
- [x] User-facing copy avoids safety, comfort, diagnosis, and clinical-risk claims
- [x] Unit, policy, adapter, contract, frontend, and E2E tests cover the required states

## Validation

- `uv run ruff format --check app tests`
- `uv run ruff check app tests`
- `uv run mypy app tests`
- `uv run python -m pytest -q -m "not integration"` (416 passed)
- `uv run python -m pytest -q -m integration` (10 passed)
- `npm run format:check`
- `npm run frontend:lint`
- `npm run frontend:typecheck`
- `npm run frontend:test` (16 passed)
- `npm run frontend:build`
- `npm run e2e` (1 passed)
- `uv run pip-audit`
- root and frontend `npm audit --audit-level=high`

Closes #13
