### PR TITLE
feat(hotels): Add OSM hotel discovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,6 +102,18 @@ directly.
   unavailable error. Every replay is labelled (`source="cache"/"fixture"`,
   `stale=True`, true data date) and never presented as a current forecast
   (ADR 0004).
+- **OSM object identity** — The immutable pair of OpenStreetMap object type
+  (`node`, `way`, or `relation`) and numeric ID. Hotel candidates preserve all
+  contributing object identities after a confirmed merge; a name or location
+  is not an object identity.
+- **Usable hotel** — A discovered `tourism=hotel` object or confirmed merged
+  group with a nonblank name and valid WGS84 node coordinates or way/relation
+  center. Fewer than five usable hotels is explicitly unavailable, not an
+  empty success.
+- **Conservative hotel deduplication** — Hotel objects merge on identical OSM
+  identity, compatible explicit relation membership, or a normalized name
+  corroborated by matching address, website, or operator. Proximity and name
+  alone never establish identity.
 - **Source of truth for provider behavior** — The official FortyGuard docs
   (reconciled in `docs/research/issue-7-san-antonio-provider-validation.md`
   and ADR 0001), with the quickstart repo as reference only.

--- a/app/domain/hotels.py
+++ b/app/domain/hotels.py
@@ -1,0 +1,77 @@
+"""Provider-neutral contracts for hotel discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+import math
+
+
+@dataclass(frozen=True)
+class BoundingBox:
+    """A bounded WGS84 area in Overpass south/west/north/east order."""
+
+    south: float
+    west: float
+    north: float
+    east: float
+
+    def __post_init__(self) -> None:
+        values = (self.south, self.west, self.north, self.east)
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("bounding box coordinates must be finite")
+        if not (-90 <= self.south < self.north <= 90):
+            raise ValueError("bounding box latitude bounds are invalid")
+        if not (-180 <= self.west < self.east <= 180):
+            raise ValueError("bounding box longitude bounds are invalid")
+
+    def to_payload(self) -> dict[str, float]:
+        return {
+            "south": self.south,
+            "west": self.west,
+            "north": self.north,
+            "east": self.east,
+        }
+
+
+@dataclass(frozen=True, order=True)
+class OsmIdentity:
+    object_type: str
+    object_id: int
+
+    def __post_init__(self) -> None:
+        if self.object_type not in {"node", "way", "relation"}:
+            raise ValueError("OSM object type must be node, way, or relation")
+        if self.object_id < 1:
+            raise ValueError("OSM object ID must be positive")
+
+
+@dataclass(frozen=True)
+class HotelCandidate:
+    primary_identity: OsmIdentity
+    source_identities: tuple[OsmIdentity, ...]
+    name: str
+    latitude: float
+    longitude: float
+    address: tuple[tuple[str, str], ...] = ()
+    website: str | None = None
+    operator: str | None = None
+
+
+class DiscoveryState(str, Enum):
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class HotelDiscoveryResult:
+    state: DiscoveryState
+    candidates: tuple[HotelCandidate, ...]
+    discovered_count: int
+    usable_count: int
+    source_timestamp: datetime | None
+    retrieved_at: datetime
+    source: str
+    stale: bool
+    reason: str | None = None

--- a/app/integrations/overpass/__init__.py
+++ b/app/integrations/overpass/__init__.py
@@ -1,0 +1,1 @@
+"""OpenStreetMap Overpass integration."""

--- a/app/integrations/overpass/client.py
+++ b/app/integrations/overpass/client.py
@@ -1,0 +1,48 @@
+"""Bounded Overpass client for hotel queries."""
+
+from __future__ import annotations
+
+from time import sleep as default_sleep
+from typing import Callable, Protocol
+
+from app.domain.hotels import BoundingBox
+from app.integrations.overpass.errors import OverpassRateLimited
+
+
+class OverpassTransport(Protocol):
+    def execute(self, query: str) -> dict[str, object]: ...
+
+
+class OverpassClient:
+    def __init__(
+        self,
+        transport: OverpassTransport,
+        *,
+        max_attempts: int = 2,
+        retry_delay_seconds: float = 30,
+        sleep: Callable[[float], None] = default_sleep,
+    ) -> None:
+        if max_attempts < 1:
+            raise ValueError("Overpass max attempts must be positive")
+        if retry_delay_seconds < 0:
+            raise ValueError("Overpass retry delay must be non-negative")
+        self._transport = transport
+        self._max_attempts = max_attempts
+        self._retry_delay_seconds = retry_delay_seconds
+        self._sleep = sleep
+
+    def query(self, aoi: BoundingBox) -> dict[str, object]:
+        query = build_hotel_query(aoi)
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                return self._transport.execute(query)
+            except OverpassRateLimited:
+                if attempt == self._max_attempts:
+                    raise
+                self._sleep(self._retry_delay_seconds)
+        raise AssertionError("unreachable")
+
+
+def build_hotel_query(aoi: BoundingBox) -> str:
+    bounds = ",".join(format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east))
+    return f'[out:json][timeout:60];\nnwr["tourism"="hotel"]({bounds});\nout center;'

--- a/app/integrations/overpass/errors.py
+++ b/app/integrations/overpass/errors.py
@@ -1,0 +1,9 @@
+"""Overpass integration failures."""
+
+
+class OverpassError(RuntimeError):
+    """A request or response failure from Overpass."""
+
+
+class OverpassRateLimited(OverpassError):
+    """Overpass rejected a request with HTTP 429."""

--- a/app/integrations/overpass/transport.py
+++ b/app/integrations/overpass/transport.py
@@ -1,0 +1,57 @@
+"""HTTP transport boundary for Overpass."""
+
+from __future__ import annotations
+
+import json
+import socket
+from typing import Callable, Mapping
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from app.integrations.overpass.errors import OverpassError, OverpassRateLimited
+
+
+class HttpOverpassTransport:
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        user_agent: str,
+        timeout_seconds: float = 30,
+        opener: Callable[..., object] = urlopen,
+    ) -> None:
+        normalized_agent = user_agent.strip().lower()
+        if len(normalized_agent) < 20 or "contact" not in normalized_agent:
+            raise ValueError("Overpass requires a descriptive User-Agent with contact information")
+        if timeout_seconds <= 0:
+            raise ValueError("Overpass timeout must be positive")
+        self.endpoint = endpoint
+        self.user_agent = user_agent
+        self.timeout_seconds = timeout_seconds
+        self._opener = opener
+
+    def execute(self, query: str) -> dict[str, object]:
+        request = Request(
+            self.endpoint,
+            data=urlencode({"data": query}).encode(),
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": self.user_agent,
+            },
+            method="POST",
+        )
+        try:
+            with self._opener(request, timeout=self.timeout_seconds) as response:  # type: ignore[attr-defined]
+                parsed = json.loads(response.read())
+        except HTTPError as error:
+            if error.code == 429:
+                raise OverpassRateLimited("Overpass rate limit exceeded") from None
+            raise OverpassError(f"Overpass HTTP request failed ({error.code})") from None
+        except (TimeoutError, URLError, OSError, socket.timeout) as error:
+            raise OverpassError(f"Overpass request failed: {type(error).__name__}") from None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise OverpassError("Overpass returned invalid JSON") from None
+        if not isinstance(parsed, Mapping):
+            raise OverpassError("Overpass response must be an object")
+        return dict(parsed)

--- a/app/services/hotel_discovery.py
+++ b/app/services/hotel_discovery.py
@@ -1,0 +1,331 @@
+"""Hotel discovery orchestration and conservative OSM deduplication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import math
+from typing import Callable, Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+from app.domain.hotels import (
+    BoundingBox,
+    DiscoveryState,
+    HotelCandidate,
+    HotelDiscoveryResult,
+    OsmIdentity,
+)
+from app.domain.provenance import CacheKey
+from app.integrations.overpass.client import OverpassClient
+from app.integrations.overpass.errors import OverpassError
+from app.services.cache import CacheService
+
+SCHEMA_VERSION = "v1"
+PROVIDER_CONFIG_VERSION = "overpass-config-v1"
+MINIMUM_USABLE_HOTELS = 5
+
+
+@dataclass
+class _HotelObject:
+    identity: OsmIdentity
+    name: str | None
+    latitude: float | None
+    longitude: float | None
+    address: tuple[tuple[str, str], ...]
+    website: str | None
+    operator: str | None
+    members: tuple[OsmIdentity, ...]
+
+
+class HotelDiscoveryService:
+    def __init__(
+        self,
+        client: OverpassClient,
+        cache: CacheService,
+        *,
+        provider_endpoint: str,
+        district_aoi: BoundingBox,
+        clock: Callable[[], datetime],
+    ) -> None:
+        self._client = client
+        self._cache = cache
+        self._provider_endpoint = provider_endpoint
+        self.district_aoi = district_aoi
+        self._clock = clock
+
+    def discover(self) -> HotelDiscoveryResult:
+        request_payload = self.district_aoi.to_payload()
+        retrieved_at = self._clock()
+        source = "provider"
+        stale = False
+        try:
+            response = self._client.query(self.district_aoi)
+            source_timestamp = _source_timestamp(response)
+            objects, discovered_count = _normalize(response)
+            self._cache.put(
+                self._provider_endpoint,
+                SCHEMA_VERSION,
+                request_payload,
+                response,
+                retrieved_at=retrieved_at,
+                data_date=source_timestamp.date().isoformat(),
+                provider_config_version=PROVIDER_CONFIG_VERSION,
+            )
+        except OverpassError:
+            key = CacheKey.create(
+                self._provider_endpoint,
+                SCHEMA_VERSION,
+                request_payload,
+                PROVIDER_CONFIG_VERSION,
+            )
+            cached = self._cache.get(key)
+            if cached is None:
+                return HotelDiscoveryResult(
+                    DiscoveryState.UNAVAILABLE,
+                    (),
+                    0,
+                    0,
+                    None,
+                    retrieved_at,
+                    "provider",
+                    False,
+                    "provider_failure",
+                )
+            response = dict(cached.payload)
+            source_timestamp = _source_timestamp(response)
+            retrieved_at = cached.provenance.retrieved_at
+            source = "cache"
+            stale = True
+            try:
+                objects, discovered_count = _normalize(response)
+            except OverpassError:
+                return HotelDiscoveryResult(
+                    DiscoveryState.UNAVAILABLE,
+                    (),
+                    0,
+                    0,
+                    source_timestamp,
+                    retrieved_at,
+                    source,
+                    stale,
+                    "provider_failure",
+                )
+        candidates = _deduplicate(objects)
+        state = (
+            DiscoveryState.AVAILABLE
+            if len(candidates) >= MINIMUM_USABLE_HOTELS
+            else DiscoveryState.UNAVAILABLE
+        )
+        return HotelDiscoveryResult(
+            state,
+            candidates,
+            discovered_count,
+            len(candidates),
+            source_timestamp,
+            retrieved_at,
+            source,
+            stale,
+            None if state is DiscoveryState.AVAILABLE else "insufficient_usable_hotels",
+        )
+
+
+def _source_timestamp(response: Mapping[str, object]) -> datetime:
+    osm3s = response.get("osm3s")
+    raw = osm3s.get("timestamp_osm_base") if isinstance(osm3s, Mapping) else None
+    if not isinstance(raw, str) or not raw.strip():
+        raise OverpassError("Overpass response is missing its OSM source timestamp")
+    try:
+        timestamp = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        raise OverpassError("Overpass OSM source timestamp is invalid") from None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp
+
+
+def _normalize(response: Mapping[str, object]) -> tuple[list[_HotelObject], int]:
+    elements = response.get("elements")
+    if not isinstance(elements, list):
+        raise OverpassError("Overpass response elements must be a list")
+    normalized: list[_HotelObject] = []
+    for element in elements:
+        if not isinstance(element, Mapping):
+            continue
+        object_type = element.get("type")
+        object_id = element.get("id")
+        if (
+            object_type not in {"node", "way", "relation"}
+            or not isinstance(object_id, int)
+            or isinstance(object_id, bool)
+            or object_id < 1
+        ):
+            continue
+        tags = element.get("tags")
+        if not isinstance(tags, Mapping) or tags.get("tourism") != "hotel":
+            continue
+        lat, lon = _coordinates(element, object_type)
+        normalized.append(
+            _HotelObject(
+                OsmIdentity(object_type, object_id),
+                _text(tags.get("name")),
+                lat,
+                lon,
+                tuple(
+                    sorted(
+                        (str(key)[5:], value.strip())
+                        for key, value in tags.items()
+                        if str(key).startswith("addr:") and isinstance(value, str) and value.strip()
+                    )
+                ),
+                _website(tags),
+                _text(tags.get("operator")),
+                _members(element),
+            )
+        )
+    return normalized, len(normalized)
+
+
+def _coordinates(
+    element: Mapping[str, object], object_type: str
+) -> tuple[float | None, float | None]:
+    source = element if object_type == "node" else element.get("center")
+    if not isinstance(source, Mapping):
+        return None, None
+    lat, lon = source.get("lat"), source.get("lon")
+    if (
+        isinstance(lat, (int, float))
+        and not isinstance(lat, bool)
+        and isinstance(lon, (int, float))
+        and not isinstance(lon, bool)
+        and math.isfinite(lat)
+        and math.isfinite(lon)
+        and -90 <= lat <= 90
+        and -180 <= lon <= 180
+    ):
+        return float(lat), float(lon)
+    return None, None
+
+
+def _members(element: Mapping[str, object]) -> tuple[OsmIdentity, ...]:
+    members = element.get("members")
+    if not isinstance(members, list):
+        return ()
+    identities: list[OsmIdentity] = []
+    for member in members:
+        if not isinstance(member, Mapping):
+            continue
+        object_type, object_id = member.get("type"), member.get("ref")
+        if (
+            object_type in {"node", "way", "relation"}
+            and isinstance(object_id, int)
+            and not isinstance(object_id, bool)
+            and object_id > 0
+        ):
+            identities.append(OsmIdentity(object_type, object_id))
+    return tuple(identities)
+
+
+def _deduplicate(objects: list[_HotelObject]) -> tuple[HotelCandidate, ...]:
+    groups: list[list[_HotelObject]] = []
+    for candidate in objects:
+        matching = [
+            group for group in groups if any(_same_hotel(candidate, item) for item in group)
+        ]
+        if not matching:
+            groups.append([candidate])
+            continue
+        target = matching[0]
+        target.append(candidate)
+        for extra in matching[1:]:
+            target.extend(extra)
+            groups.remove(extra)
+
+    results: list[HotelCandidate] = []
+    for group in groups:
+        named = [item for item in group if item.name and item.latitude is not None]
+        if not named:
+            continue
+        representative = max(
+            named,
+            key=lambda item: (
+                item.identity.object_type == "relation",
+                len(item.address) + bool(item.website) + bool(item.operator),
+                -item.identity.object_id,
+            ),
+        )
+        identities = tuple(dict.fromkeys(item.identity for item in group))
+        results.append(
+            HotelCandidate(
+                representative.identity,
+                identities,
+                representative.name or "",
+                representative.latitude or 0.0,
+                representative.longitude or 0.0,
+                representative.address,
+                representative.website,
+                representative.operator,
+            )
+        )
+    return tuple(results)
+
+
+def _same_hotel(left: _HotelObject, right: _HotelObject) -> bool:
+    if left.identity == right.identity:
+        return True
+    linked = left.identity in right.members or right.identity in left.members
+    if linked and _compatible(left.name, right.name):
+        return True
+    names_match = _normalized(left.name) and _normalized(left.name) == _normalized(right.name)
+    if not names_match:
+        return False
+    address_match = bool(left.address) and _normalized_address(left.address) == _normalized_address(
+        right.address
+    )
+    website_match = bool(left.website) and left.website == right.website
+    operator_match = bool(left.operator) and _normalized(left.operator) == _normalized(
+        right.operator
+    )
+    return address_match or website_match or operator_match
+
+
+def _compatible(left: str | None, right: str | None) -> bool:
+    return left is None or right is None or _normalized(left) == _normalized(right)
+
+
+def _normalized(value: str | None) -> str:
+    return " ".join((value or "").casefold().split())
+
+
+def _normalized_address(address: tuple[tuple[str, str], ...]) -> tuple[tuple[str, str], ...]:
+    return tuple((key.casefold(), _normalized(value)) for key, value in address)
+
+
+def _text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _website(tags: Mapping[object, object]) -> str | None:
+    raw = next(
+        (
+            _text(tags.get(key))
+            for key in ("website", "contact:website", "url")
+            if _text(tags.get(key))
+        ),
+        None,
+    )
+    if raw is None:
+        return None
+    try:
+        parsed = urlsplit(raw if "://" in raw else f"https://{raw}")
+    except ValueError:
+        raise OverpassError("Overpass hotel website is invalid") from None
+    host = (parsed.hostname or "").casefold()
+    if not host:
+        return None
+    try:
+        port = f":{parsed.port}" if parsed.port else ""
+    except ValueError:
+        raise OverpassError("Overpass hotel website is invalid") from None
+    return urlunsplit(
+        (parsed.scheme.casefold(), host + port, parsed.path.rstrip("/"), parsed.query, "")
+    )

--- a/app/settings.py
+++ b/app/settings.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 import os
 from pathlib import Path
 from typing import Mapping
 
+from app.domain.hotels import BoundingBox
+
 DEFAULT_BASE_URL = "https://api.fortyguard.com"
 DEFAULT_LEDGER_PATH = Path("data/ledger.jsonl")
+DEFAULT_OVERPASS_ENDPOINT = "https://overpass-api.de/api/interpreter"
+DEFAULT_OVERPASS_USER_AGENT = (
+    "HeatAwareTourismGuide/0.1 (contact: https://github.com/alshawai/heat-aware-tourism-guide)"
+)
 _DEFAULT_ENV_FILE = Path(".env")
 
 
@@ -37,12 +44,25 @@ class FortyGuardAreaSettings:
 
 
 @dataclass(frozen=True)
+class OverpassSettings:
+    """Bounded hotel-discovery provider and district configuration."""
+
+    endpoint: str = DEFAULT_OVERPASS_ENDPOINT
+    user_agent: str = DEFAULT_OVERPASS_USER_AGENT
+    timeout_seconds: float = 30.0
+    max_attempts: int = 2
+    retry_delay_seconds: float = 30.0
+    district_aoi: BoundingBox = BoundingBox(29.421, -98.490, 29.429, -98.482)
+
+
+@dataclass(frozen=True)
 class AppSettings:
     allow_live: bool
     fortyguard_api_key: str | None
     fortyguard_base_url: str
     polling: FortyGuardPollingSettings = FortyGuardPollingSettings()
     area: FortyGuardAreaSettings = FortyGuardAreaSettings()
+    overpass: OverpassSettings = OverpassSettings()
     call_budget: int | None = None
     ledger_path: Path | None = DEFAULT_LEDGER_PATH
 
@@ -173,8 +193,56 @@ def load_settings(
         fortyguard_base_url=base_url,
         polling=polling or _polling_from_env(merged),
         area=area or _area_from_env(merged),
+        overpass=_overpass_from_env(merged),
         call_budget=_call_budget_from_env(merged),
         ledger_path=_ledger_path_from_env(process_env, file_values),
+    )
+
+
+def _overpass_from_env(merged: Mapping[str, str]) -> OverpassSettings:
+    def positive_int(name: str, default: int) -> int:
+        raw = merged.get(name, "").strip()
+        if not raw:
+            return default
+        try:
+            value = int(raw)
+        except ValueError:
+            raise SettingsError(f"{name} must be an integer") from None
+        if value < 1:
+            raise SettingsError(f"{name} must be a positive integer")
+        return value
+
+    def float_value(name: str, default: float, *, allow_zero: bool = False) -> float:
+        raw = merged.get(name, "").strip()
+        if not raw:
+            return default
+        try:
+            value = float(raw)
+        except ValueError:
+            raise SettingsError(f"{name} must be a number") from None
+        if not math.isfinite(value) or (value < 0 if allow_zero else value <= 0):
+            qualifier = "non-negative" if allow_zero else "positive"
+            raise SettingsError(f"{name} must be {qualifier}")
+        return value
+
+    bbox_raw = merged.get("HOTEL_DISTRICT_BBOX", "29.421,-98.490,29.429,-98.482")
+    try:
+        coordinates = tuple(float(part.strip()) for part in bbox_raw.split(","))
+        if len(coordinates) != 4:
+            raise ValueError
+        district_aoi = BoundingBox(*coordinates)
+    except ValueError:
+        raise SettingsError(
+            "HOTEL_DISTRICT_BBOX must be valid south,west,north,east coordinates"
+        ) from None
+
+    return OverpassSettings(
+        endpoint=merged.get("OVERPASS_ENDPOINT", "").strip() or DEFAULT_OVERPASS_ENDPOINT,
+        user_agent=merged.get("OVERPASS_USER_AGENT", "").strip() or DEFAULT_OVERPASS_USER_AGENT,
+        timeout_seconds=float_value("OVERPASS_TIMEOUT_SECONDS", 30.0),
+        max_attempts=positive_int("OVERPASS_MAX_ATTEMPTS", 2),
+        retry_delay_seconds=float_value("OVERPASS_RETRY_DELAY_SECONDS", 30.0, allow_zero=True),
+        district_aoi=district_aoi,
     )
 
 

--- a/app/wiring.py
+++ b/app/wiring.py
@@ -26,7 +26,10 @@ from app.integrations.fortyguard.live import (
     LiveFortyGuardTransport,
     LiveHeatmapAdapter,
 )
+from app.integrations.overpass.client import OverpassClient
+from app.integrations.overpass.transport import HttpOverpassTransport
 from app.services.cache import CacheService
+from app.services.hotel_discovery import HotelDiscoveryService
 from app.services.execution import EnvParamsExecution, HeatmapExecution
 from app.services.ledger_store import JsonlLedgerStore
 from app.services.trip_adapters import (
@@ -72,6 +75,30 @@ def build_live_client(
         clock=lambda: datetime.now(timezone.utc),
         event_sink=json_event_sink,
         ledger=ledger,
+    )
+
+
+def build_hotel_discovery_service(
+    settings: AppSettings, *, cache: CacheService | None = None
+) -> HotelDiscoveryService:
+    """Compose bounded OSM hotel discovery for the configured district."""
+    overpass = settings.overpass
+    transport = HttpOverpassTransport(
+        overpass.endpoint,
+        user_agent=overpass.user_agent,
+        timeout_seconds=overpass.timeout_seconds,
+    )
+    client = OverpassClient(
+        transport,
+        max_attempts=overpass.max_attempts,
+        retry_delay_seconds=overpass.retry_delay_seconds,
+    )
+    return HotelDiscoveryService(
+        client,
+        cache if cache is not None else CacheService(),
+        provider_endpoint=overpass.endpoint,
+        district_aoi=overpass.district_aoi,
+        clock=lambda: datetime.now(timezone.utc),
     )
 
 

--- a/tests/test_hotel_discovery.py
+++ b/tests/test_hotel_discovery.py
@@ -1,0 +1,357 @@
+from datetime import datetime, timezone
+
+from app.domain.hotels import BoundingBox, DiscoveryState, HotelDiscoveryResult, OsmIdentity
+from app.integrations.overpass.client import OverpassClient
+from app.integrations.overpass.errors import OverpassError, OverpassRateLimited
+from app.services.cache import CacheService
+from app.services.hotel_discovery import HotelDiscoveryService
+
+
+AOI = BoundingBox(29.421, -98.490, 29.429, -98.482)
+NOW = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+
+
+class StubTransport:
+    def __init__(self, responses: list[object]) -> None:
+        self.responses = responses
+        self.queries: list[str] = []
+
+    def execute(self, query: str) -> dict[str, object]:
+        self.queries.append(query)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        assert isinstance(response, dict)
+        return response
+
+
+def payload(elements: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "osm3s": {"timestamp_osm_base": "2026-08-29T11:58:00Z"},
+        "elements": elements,
+    }
+
+
+def hotel(
+    osm_id: int,
+    name: str | None,
+    *,
+    osm_type: str = "node",
+    lat: float = 29.424,
+    lon: float = -98.486,
+    tags: dict[str, str] | None = None,
+    members: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    element: dict[str, object] = {
+        "type": osm_type,
+        "id": osm_id,
+        "tags": {
+            "tourism": "hotel",
+            **({"name": name} if name is not None else {}),
+            **(tags or {}),
+        },
+    }
+    if osm_type == "node":
+        element.update(lat=lat, lon=lon)
+    else:
+        element["center"] = {"lat": lat, "lon": lon}
+    if members is not None:
+        element["members"] = members
+    return element
+
+
+def discover(elements: list[dict[str, object]]) -> HotelDiscoveryResult:
+    client = OverpassClient(StubTransport([payload(elements)]), max_attempts=1)
+    return HotelDiscoveryService(
+        client,
+        CacheService(),
+        provider_endpoint="https://overpass.example.test/interpreter",
+        district_aoi=AOI,
+        clock=lambda: NOW,
+    ).discover()
+
+
+def test_discovery_normalizes_nodes_ways_relations_and_source_identity() -> None:
+    result = discover(
+        [
+            hotel(1, "Node Hotel"),
+            hotel(2, "Way Hotel", osm_type="way", lat=29.425),
+            hotel(3, "Relation Hotel", osm_type="relation", lat=29.426),
+        ]
+    )
+
+    assert result.state is DiscoveryState.UNAVAILABLE
+    assert result.source_timestamp == datetime(2026, 8, 29, 11, 58, tzinfo=timezone.utc)
+    assert result.retrieved_at == NOW
+    assert result.discovered_count == 3
+    assert [candidate.primary_identity for candidate in result.candidates] == [
+        OsmIdentity("node", 1),
+        OsmIdentity("way", 2),
+        OsmIdentity("relation", 3),
+    ]
+    assert [(candidate.latitude, candidate.longitude) for candidate in result.candidates] == [
+        (29.424, -98.486),
+        (29.425, -98.486),
+        (29.426, -98.486),
+    ]
+
+
+def test_discovery_deduplicates_identity_relation_membership_and_strong_metadata() -> None:
+    result = discover(
+        [
+            hotel(1, "Exact Hotel"),
+            hotel(1, "Exact Hotel"),
+            hotel(2, None, osm_type="way"),
+            hotel(
+                3,
+                "Member Hotel",
+                osm_type="relation",
+                members=[{"type": "way", "ref": 2, "role": "building"}],
+            ),
+            hotel(
+                4,
+                "Metadata Hotel",
+                tags={"addr:housenumber": "100", "addr:street": "Alamo Plaza"},
+            ),
+            hotel(
+                5,
+                " metadata   HOTEL ",
+                osm_type="way",
+                tags={"addr:housenumber": "100", "addr:street": "ALAMO PLAZA"},
+            ),
+        ]
+    )
+
+    assert result.discovered_count == 6
+    assert result.usable_count == 3
+    assert result.candidates[0].source_identities == (OsmIdentity("node", 1),)
+    assert result.candidates[1].source_identities == (
+        OsmIdentity("way", 2),
+        OsmIdentity("relation", 3),
+    )
+    assert result.candidates[1].name == "Member Hotel"
+    assert result.candidates[2].source_identities == (
+        OsmIdentity("node", 4),
+        OsmIdentity("way", 5),
+    )
+
+
+def test_nearby_hotels_and_names_without_corroboration_remain_distinct() -> None:
+    result = discover(
+        [
+            hotel(1, "Marriott", lat=29.424000, lon=-98.486000),
+            hotel(2, "Marriott", osm_type="way", lat=29.424001, lon=-98.486001),
+            hotel(3, "A Hotel", lat=29.425000, lon=-98.485000),
+            hotel(4, "B Hotel", osm_type="way", lat=29.425000, lon=-98.485000),
+        ]
+    )
+
+    assert result.usable_count == 4
+    assert all(len(candidate.source_identities) == 1 for candidate in result.candidates)
+
+
+def test_website_and_operator_corroborate_names_but_conflicts_do_not_merge() -> None:
+    result = discover(
+        [
+            hotel(1, "Website Hotel", tags={"website": "https://example.test/hotel/"}),
+            hotel(
+                2,
+                " website hotel ",
+                osm_type="way",
+                tags={"contact:website": "https://EXAMPLE.test/hotel"},
+            ),
+            hotel(3, "Operator Hotel", tags={"operator": "Local Lodging"}),
+            hotel(
+                4,
+                "OPERATOR HOTEL",
+                osm_type="way",
+                tags={"operator": " local lodging "},
+            ),
+            hotel(5, "Conflicted Hotel", tags={"operator": "Operator One"}),
+            hotel(
+                6,
+                "Conflicted Hotel",
+                osm_type="way",
+                tags={"operator": "Operator Two"},
+            ),
+        ]
+    )
+
+    assert result.usable_count == 4
+    assert result.candidates[0].source_identities == (
+        OsmIdentity("node", 1),
+        OsmIdentity("way", 2),
+    )
+    assert result.candidates[1].source_identities == (
+        OsmIdentity("node", 3),
+        OsmIdentity("way", 4),
+    )
+    assert result.candidates[2].source_identities == (OsmIdentity("node", 5),)
+    assert result.candidates[3].source_identities == (OsmIdentity("way", 6),)
+
+
+def test_missing_names_or_coordinates_are_not_usable_and_under_five_is_explicit() -> None:
+    nameless = hotel(1, None)
+    no_center = hotel(2, "No Center", osm_type="way")
+    no_center.pop("center")
+    result = discover([nameless, no_center, hotel(3, "One"), hotel(4, "Two"), hotel(5, "Three")])
+
+    assert result.state is DiscoveryState.UNAVAILABLE
+    assert result.discovered_count == 5
+    assert result.usable_count == 3
+    assert result.reason == "insufficient_usable_hotels"
+
+
+def test_exactly_five_usable_hotels_are_available() -> None:
+    result = discover([hotel(osm_id, f"Hotel {osm_id}") for osm_id in range(1, 6)])
+
+    assert result.state is DiscoveryState.AVAILABLE
+    assert result.usable_count == 5
+
+
+def test_provider_failure_replays_exact_cache_with_original_timestamp_and_ids() -> None:
+    cache = CacheService()
+    successful = HotelDiscoveryService(
+        OverpassClient(
+            StubTransport(
+                [payload([hotel(osm_id, f"Cached Hotel {osm_id}") for osm_id in range(1, 6)])]
+            ),
+            max_attempts=1,
+        ),
+        cache,
+        provider_endpoint="https://overpass.example.test/interpreter",
+        district_aoi=AOI,
+        clock=lambda: NOW,
+    )
+    successful.discover()
+    failing = HotelDiscoveryService(
+        OverpassClient(StubTransport([OverpassError("offline")]), max_attempts=1),
+        cache,
+        provider_endpoint="https://overpass.example.test/interpreter",
+        district_aoi=AOI,
+        clock=lambda: datetime(2026, 8, 30, tzinfo=timezone.utc),
+    )
+
+    result = failing.discover()
+
+    assert result.state is DiscoveryState.AVAILABLE
+    assert result.source == "cache"
+    assert result.stale is True
+    assert result.source_timestamp == datetime(2026, 8, 29, 11, 58, tzinfo=timezone.utc)
+    assert result.candidates[0].source_identities == (OsmIdentity("node", 1),)
+
+
+def test_provider_failure_without_cache_is_explicitly_unavailable() -> None:
+    service = HotelDiscoveryService(
+        OverpassClient(StubTransport([OverpassError("offline")]), max_attempts=1),
+        CacheService(),
+        provider_endpoint="https://overpass.example.test/interpreter",
+        district_aoi=AOI,
+        clock=lambda: NOW,
+    )
+
+    result = service.discover()
+
+    assert result.state is DiscoveryState.UNAVAILABLE
+    assert result.reason == "provider_failure"
+    assert result.candidates == ()
+
+
+def test_malformed_provider_response_is_not_cached_and_is_explicitly_unavailable() -> None:
+    cache = CacheService()
+    malformed = {"osm3s": {"timestamp_osm_base": "2026-08-29T11:58:00Z"}}
+    service = HotelDiscoveryService(
+        OverpassClient(StubTransport([malformed]), max_attempts=1),
+        cache,
+        provider_endpoint="https://overpass.example.test/interpreter",
+        district_aoi=AOI,
+        clock=lambda: NOW,
+    )
+
+    result = service.discover()
+
+    assert result.state is DiscoveryState.UNAVAILABLE
+    assert result.reason == "provider_failure"
+
+
+def test_malformed_object_identity_and_website_are_skipped_or_unavailable() -> None:
+    invalid_id = discover([hotel(0, "Invalid ID")])
+    assert invalid_id.state is DiscoveryState.UNAVAILABLE
+    assert invalid_id.discovered_count == 0
+
+    invalid_website = discover([hotel(1, "Invalid Website", tags={"website": "example.test:bad"})])
+    assert invalid_website.state is DiscoveryState.UNAVAILABLE
+    assert invalid_website.reason == "provider_failure"
+
+    invalid_host = discover([hotel(1, "Invalid Host", tags={"website": "http://[invalid"})])
+    assert invalid_host.state is DiscoveryState.UNAVAILABLE
+    assert invalid_host.reason == "provider_failure"
+
+
+def test_malformed_relation_member_id_cannot_merge_an_unrelated_hotel() -> None:
+    relation = hotel(
+        2,
+        "Relation Hotel",
+        osm_type="relation",
+        members=[
+            {"type": "node", "ref": True},
+            {"type": "way", "ref": 0},
+            {"type": "way", "ref": -1},
+        ],
+    )
+
+    result = discover([hotel(1, "Independent Hotel"), relation])
+
+    assert result.usable_count == 2
+    assert all(len(candidate.source_identities) == 1 for candidate in result.candidates)
+
+
+def test_cache_identity_separates_overpass_provider_endpoints() -> None:
+    cache = CacheService()
+    first = HotelDiscoveryService(
+        OverpassClient(
+            StubTransport([payload([hotel(osm_id, f"Hotel {osm_id}") for osm_id in range(1, 6)])]),
+            max_attempts=1,
+        ),
+        cache,
+        provider_endpoint="https://one.example.test/interpreter",
+        district_aoi=AOI,
+        clock=lambda: NOW,
+    )
+    first.discover()
+    second = HotelDiscoveryService(
+        OverpassClient(StubTransport([OverpassError("offline")]), max_attempts=1),
+        cache,
+        provider_endpoint="https://two.example.test/interpreter",
+        district_aoi=AOI,
+        clock=lambda: NOW,
+    )
+
+    assert second.discover().reason == "provider_failure"
+
+
+def test_overpass_client_queries_all_object_types_and_bounds_429_retry() -> None:
+    transport = StubTransport([OverpassRateLimited(), payload([])])
+    sleeps: list[float] = []
+    client = OverpassClient(transport, max_attempts=2, retry_delay_seconds=30, sleep=sleeps.append)
+
+    assert client.query(AOI) == payload([])
+    assert sleeps == [30]
+    assert len(transport.queries) == 2
+    assert 'nwr["tourism"="hotel"](29.421,-98.49,29.429,-98.482);' in transport.queries[0]
+    assert "out center;" in transport.queries[0]
+
+
+def test_overpass_client_stops_after_bounded_429_attempts() -> None:
+    transport = StubTransport([OverpassRateLimited(), OverpassRateLimited()])
+    sleeps: list[float] = []
+    client = OverpassClient(transport, max_attempts=2, retry_delay_seconds=30, sleep=sleeps.append)
+
+    try:
+        client.query(AOI)
+    except OverpassRateLimited:
+        pass
+    else:
+        raise AssertionError("expected rate limiting to be surfaced")
+    assert len(transport.queries) == 2
+    assert sleeps == [30]

--- a/tests/test_overpass_http.py
+++ b/tests/test_overpass_http.py
@@ -1,0 +1,59 @@
+import json
+from email.message import Message
+from urllib.error import HTTPError
+
+import pytest
+
+from app.integrations.overpass.errors import OverpassRateLimited
+from app.integrations.overpass.transport import HttpOverpassTransport
+
+
+def test_http_transport_posts_query_with_descriptive_user_agent() -> None:
+    calls: list[object] = []
+
+    class Response:
+        def read(self) -> bytes:
+            return json.dumps({"elements": []}).encode()
+
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    def opener(request: object, timeout: float) -> Response:
+        calls.append(request)
+        assert timeout == 20
+        return Response()
+
+    transport = HttpOverpassTransport(
+        "https://overpass.example.test/api/interpreter",
+        user_agent="HeatAwareTourismGuide/0.1 (contact: team@example.test)",
+        timeout_seconds=20,
+        opener=opener,
+    )
+    assert transport.execute("[out:json];out;") == {"elements": []}
+    request = calls[0]
+    assert request.full_url == "https://overpass.example.test/api/interpreter"  # type: ignore[attr-defined]
+    assert request.headers["User-agent"] == (  # type: ignore[attr-defined]
+        "HeatAwareTourismGuide/0.1 (contact: team@example.test)"
+    )
+    assert request.data == b"data=%5Bout%3Ajson%5D%3Bout%3B"  # type: ignore[attr-defined]
+
+
+def test_http_transport_classifies_429_for_client_retry() -> None:
+    def opener(request: object, timeout: float) -> object:
+        raise HTTPError("url", 429, "limited", Message(), None)
+
+    transport = HttpOverpassTransport(
+        "https://overpass.example.test/api/interpreter",
+        user_agent="HeatAwareTourismGuide/0.1 (contact: team@example.test)",
+        opener=opener,
+    )
+    with pytest.raises(OverpassRateLimited):
+        transport.execute("query")
+
+
+def test_http_transport_rejects_non_descriptive_user_agent() -> None:
+    with pytest.raises(ValueError, match="descriptive User-Agent"):
+        HttpOverpassTransport("https://overpass.example.test", user_agent="python")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,6 +6,7 @@ from app.settings import (
     AppSettings,
     FortyGuardAreaSettings,
     FortyGuardPollingSettings,
+    OverpassSettings,
     SettingsError,
     load_settings,
 )
@@ -25,6 +26,7 @@ def test_load_settings_reads_core_configuration_from_environment() -> None:
         fortyguard_base_url="https://example.test",
         polling=FortyGuardPollingSettings(),
         area=FortyGuardAreaSettings(),
+        overpass=OverpassSettings(),
     )
 
 
@@ -146,6 +148,54 @@ def test_area_settings_overrides_are_read_from_environment() -> None:
         use_bounding_box=False,
         max_vertices=150,
     )
+
+
+def test_overpass_defaults_are_bounded_and_use_configured_district() -> None:
+    settings = load_settings(environ={}).overpass
+    assert settings.endpoint == "https://overpass-api.de/api/interpreter"
+    assert "contact" in settings.user_agent.lower()
+    assert settings.timeout_seconds == 30.0
+    assert settings.max_attempts == 2
+    assert settings.retry_delay_seconds == 30.0
+    assert settings.district_aoi.to_payload() == {
+        "south": 29.421,
+        "west": -98.49,
+        "north": 29.429,
+        "east": -98.482,
+    }
+
+
+def test_overpass_bounds_and_request_policy_are_configurable() -> None:
+    settings = load_settings(
+        environ={
+            "OVERPASS_ENDPOINT": "https://overpass.example.test/interpreter",
+            "OVERPASS_USER_AGENT": "Tour Guide/1.0 (contact: team@example.test)",
+            "OVERPASS_TIMEOUT_SECONDS": "10",
+            "OVERPASS_MAX_ATTEMPTS": "3",
+            "OVERPASS_RETRY_DELAY_SECONDS": "4",
+            "HOTEL_DISTRICT_BBOX": "29.4,-98.5,29.5,-98.4",
+        }
+    ).overpass
+    assert settings == OverpassSettings(
+        endpoint="https://overpass.example.test/interpreter",
+        user_agent="Tour Guide/1.0 (contact: team@example.test)",
+        timeout_seconds=10,
+        max_attempts=3,
+        retry_delay_seconds=4,
+        district_aoi=settings.district_aoi,
+    )
+    assert settings.district_aoi.to_payload()["south"] == 29.4
+
+
+def test_invalid_overpass_policy_or_district_bounds_are_rejected() -> None:
+    with pytest.raises(SettingsError, match="OVERPASS_MAX_ATTEMPTS"):
+        load_settings(environ={"OVERPASS_MAX_ATTEMPTS": "0"})
+    with pytest.raises(SettingsError, match="OVERPASS_RETRY_DELAY_SECONDS"):
+        load_settings(environ={"OVERPASS_RETRY_DELAY_SECONDS": "-1"})
+    with pytest.raises(SettingsError, match="OVERPASS_RETRY_DELAY_SECONDS"):
+        load_settings(environ={"OVERPASS_RETRY_DELAY_SECONDS": "inf"})
+    with pytest.raises(SettingsError, match="HOTEL_DISTRICT_BBOX"):
+        load_settings(environ={"HOTEL_DISTRICT_BBOX": "29.5,-98.5,29.4,-98.4"})
 
 
 def test_call_budget_defaults_to_record_only_and_is_overridable() -> None:

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -14,6 +14,7 @@ from app.integrations.fortyguard.live import LiveEnvParamsPayload
 from app.services.execution import EnvParamsExecution, HeatmapExecution
 from app.settings import AppSettings, FortyGuardPollingSettings, SettingsError
 from app.wiring import (
+    build_hotel_discovery_service,
     build_live_env_params_execution,
     build_live_heatmap_execution,
     create_production_app,
@@ -182,6 +183,16 @@ def test_build_live_stack_requires_api_key() -> None:
         build_live_heatmap_execution(settings, fixture_path=FIXTURES / "heatmap-historical.json")
     with pytest.raises(SettingsError, match="FORTYGUARD_API_KEY"):
         build_live_env_params_execution(settings, fixture_path=FIXTURES / "env-params.json")
+
+
+def test_build_hotel_discovery_service_uses_configured_overpass_policy() -> None:
+    settings = AppSettings(
+        allow_live=False,
+        fortyguard_api_key=None,
+        fortyguard_base_url="https://api.example.test",
+    )
+    service = build_hotel_discovery_service(settings)
+    assert service.district_aoi == settings.overpass.district_aoi
 
 
 def test_json_event_sink_emits_sanitized_json_log_records(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary
- discover hotel nodes, ways, and relations within the configured district through bounded Overpass requests
- normalize and conservatively deduplicate candidates while preserving OSM identities and source timestamps
- replay exact cached responses and expose provider failure or fewer than five usable hotels as unavailable
- add offline coverage for normalization, relation membership, duplicate evidence, malformed payloads, caching, and HTTP 429 handling

## Verification
- `uv run ruff format --check app tests`
- `uv run ruff check app tests`
- `uv run mypy app tests`
- `uv run python -m pytest -q` (354 passed)
- pre-commit backend and frontend quality gates passed

Closes #16