### PR TITLE
feat(heat): Implement neighbourhood hotel heat score

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -25,9 +25,16 @@ from app.domain.contracts import (
     TripMode,
 )
 from app.domain.ledger import BudgetExceededError
+from app.domain.hotel_heat_score import COMPONENTS, NeighbourhoodHeatScorer
+from app.domain.hotels import BoundingBox
 from app.integrations.fortyguard.contracts import AnalyticType, EnvParamsRequest, HeatmapRequest
 from app.integrations.fortyguard.errors import ProviderError
 from app.services.execution import EnvParamsExecution, HeatmapExecution, UnavailableError
+from app.services.hotel_heat_score import (
+    HotelHeatAnalysisOutcome,
+    HotelHeatAnalysisService,
+    build_fixture_hotel_heat_analysis_service,
+)
 
 
 def _result_json(result: Any) -> dict[str, object]:
@@ -154,6 +161,8 @@ def create_app(
     allow_live: bool = False,
     frontend_dist: Path | None = None,
     trip_adapter: TripAnalysisAdapter | None = None,
+    hotel_heat_analysis_service: HotelHeatAnalysisService | None = None,
+    district_aoi: BoundingBox = BoundingBox(29.421, -98.490, 29.429, -98.482),
 ) -> FastAPI:
     """Create the server-owned product API used by local runs and deployment."""
     configured_execution: HeatmapExecution = execution or HeatmapExecution(
@@ -161,6 +170,14 @@ def create_app(
     )
     configured_env_params: EnvParamsExecution = env_params_execution or EnvParamsExecution(
         fixture_path=fixture_path.parent / "env-params.json"
+    )
+    configured_hotel_analysis = (
+        hotel_heat_analysis_service
+        if hotel_heat_analysis_service is not None
+        else build_fixture_hotel_heat_analysis_service(
+            fixture_path.parent / "hotel-heat-analysis.json",
+            district_aoi=district_aoi,
+        )
     )
     app = FastAPI(title="Heat-Aware Tourism Guide")
 
@@ -235,6 +252,34 @@ def create_app(
                 trip_adapter=trip_adapter,
             )
         except (KeyError, TypeError, ValueError) as error:
+            raise _http_error(error) from error
+
+    @app.post("/api/hotels/rank")
+    def rank_hotels(body: dict[str, object]) -> dict[str, object]:
+        try:
+            allowed_fields = {"district_name", "execution_mode", "weights"}
+            unexpected = set(body) - allowed_fields
+            if unexpected:
+                raise ValueError(
+                    "unsupported hotel ranking fields: " + ", ".join(sorted(unexpected))
+                )
+            district_name = body.get("district_name")
+            if not isinstance(district_name, str) or not district_name.strip():
+                raise ValueError("district_name must be a non-empty string")
+            execution_mode = _execution_mode(body, allow_live=allow_live)
+            weights = _hotel_weights(body.get("weights"))
+            return _hotel_heat_result(
+                configured_hotel_analysis.analyze(district_name, execution_mode, weights=weights)
+            )
+        except (
+            BudgetExceededError,
+            KeyError,
+            TypeError,
+            ValueError,
+            OSError,
+            RuntimeError,
+            ProviderError,
+        ) as error:
             raise _http_error(error) from error
 
     if frontend_dist is not None and frontend_dist.is_dir():
@@ -391,3 +436,57 @@ def _finite_number(value: object, field: str) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
         raise ValueError(f"{field} must be finite numeric")
     return float(value)
+
+
+def _hotel_weights(value: object) -> dict[str, float] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise ValueError("weights must be a JSON object")
+    weights = {key: _finite_number(item, f"weights.{key}") for key, item in value.items()}
+    # Use the domain validator so the API and local reranking have identical rules.
+    NeighbourhoodHeatScorer().score((), weights=weights)
+    return weights
+
+
+def _hotel_heat_result(outcome: HotelHeatAnalysisOutcome) -> dict[str, object]:
+    score = outcome.score
+    return {
+        "state": outcome.state.value,
+        "district_name": outcome.district_name,
+        "execution_mode": outcome.execution_mode.value,
+        "reason": outcome.reason,
+        "discovered_count": outcome.discovered_count,
+        "usable_count": outcome.usable_count,
+        "components": {
+            name: asdict(outcome.components[name])
+            for name in COMPONENTS
+            if name in outcome.components
+        },
+        "ranking": None
+        if score is None
+        else {
+            "weights": dict(score.weights),
+            "weight_label": score.weight_label,
+            "complete_candidate_count": score.complete_candidate_count,
+            "ranked_output": score.ranked_output,
+            "hotels": [
+                {
+                    "identity": asdict(hotel.identity),
+                    "name": hotel.name,
+                    "complete": hotel.complete,
+                    "relative_aggregate": hotel.relative_aggregate,
+                    "rank": hotel.rank,
+                    "relative_percentile": hotel.relative_percentile,
+                    "components": {
+                        component: {
+                            **asdict(hotel.components[component].assignment),
+                            "percentile": hotel.components[component].percentile,
+                        }
+                        for component in COMPONENTS
+                    },
+                }
+                for hotel in score.hotels
+            ],
+        },
+    }

--- a/app/domain/analysis.py
+++ b/app/domain/analysis.py
@@ -124,6 +124,7 @@ class PointMatch:
     quality: str
     distance_m: float | None
     metadata: SpatialMetadata | None = None
+    tile_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -301,7 +302,13 @@ def join_point_to_tiles(
         value = matched_values[0] if len(set(matched_values)) == 1 else None
         metadata = _merged_metadata(all_matched) if value is not None else None
         quality = "mixed_provenance" if value is not None and metadata is None else "boundary"
-        return PointMatch(value if metadata is not None else None, quality, 0.0, metadata)
+        return PointMatch(
+            value if metadata is not None else None,
+            quality,
+            0.0,
+            metadata,
+            min((tile.identity for tile in all_matched), default=None),
+        )
     if containing_tiles:
         value = (
             containing_tiles[0].value if len(set(t.value for t in containing_tiles)) == 1 else None
@@ -310,7 +317,9 @@ def join_point_to_tiles(
         metadata = _merged_metadata(containing_tiles) if value is not None else None
         if value is not None and metadata is None:
             return PointMatch(None, "mixed_provenance", 0.0)
-        return PointMatch(value, quality, 0.0, metadata)
+        return PointMatch(
+            value, quality, 0.0, metadata, min(tile.identity for tile in containing_tiles)
+        )
     if nearest_max_distance_m is None or not unique_tiles:
         return PointMatch(None, "no_match", None)
     crs = _local_crs(point)
@@ -331,7 +340,13 @@ def join_point_to_tiles(
         metadata = _merged_metadata(nearest_tiles)
         if metadata is None:
             return PointMatch(None, "mixed_provenance", distance)
-        return PointMatch(nearest_values.pop(), "nearest_fallback", distance, metadata)
+        return PointMatch(
+            nearest_values.pop(),
+            "nearest_fallback",
+            distance,
+            metadata,
+            min(tile.identity for tile in nearest_tiles),
+        )
     return PointMatch(None, "no_match", distance)
 
 

--- a/app/domain/hotel_heat_score.py
+++ b/app/domain/hotel_heat_score.py
@@ -37,6 +37,9 @@ class ComponentEvidence:
     threshold_celsius: float | None
     provenance: str
     tile_resolution_m: float
+    coverage: float | None = None
+    caveats: tuple[str, ...] = ()
+    provenance_details: Mapping[str, object] | None = None
 
     def __post_init__(self) -> None:
         if self.component not in COMPONENTS:
@@ -53,6 +56,12 @@ class ComponentEvidence:
             raise ValueError("component evidence provenance is required")
         if not _finite_number(self.tile_resolution_m) or self.tile_resolution_m <= 0:
             raise ValueError("tile resolution must be finite and positive")
+        if self.coverage is not None and (
+            not _finite_number(self.coverage) or not 0 <= self.coverage <= 1
+        ):
+            raise ValueError("component evidence coverage must be between 0 and 1")
+        if any(not caveat.strip() for caveat in self.caveats):
+            raise ValueError("component evidence caveats must be non-empty")
 
 
 @dataclass(frozen=True)
@@ -68,6 +77,8 @@ class ComponentAssignment:
     tile_resolution_m: float
     quality: str
     distance_m: float | None
+    coverage: float | None = None
+    caveats: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -101,6 +112,7 @@ class ScoredHotel:
     complete: bool
     relative_aggregate: float | None
     rank: int | None
+    relative_percentile: float | None
 
 
 @dataclass(frozen=True)
@@ -149,6 +161,8 @@ class NeighbourhoodHeatScorer:
                     tile_resolution_m=item.tile_resolution_m,
                     quality=match.quality,
                     distance_m=match.distance_m,
+                    coverage=item.coverage,
+                    caveats=item.caveats,
                 )
             assignments.append(
                 HotelHeatAssignment(
@@ -210,8 +224,19 @@ class NeighbourhoodHeatScorer:
                     for index, candidate in enumerate(ordered_complete, start=1)
                     if aggregates[candidate.identity] == score
                 )
+            distinct_aggregates = sorted(set(aggregates.values()))
+            percentiles_by_identity = {
+                assignment.identity: 100.0
+                * (
+                    1.0
+                    - distinct_aggregates.index(aggregates[assignment.identity])
+                    / max(1, len(distinct_aggregates) - 1)
+                )
+                for assignment in ordered_complete
+            }
             ordered = ordered_complete + [item for item in assignments if not item.complete]
         else:
+            percentiles_by_identity = {}
             ordered = list(assignments)
 
         hotels = tuple(
@@ -230,6 +255,7 @@ class NeighbourhoodHeatScorer:
                 complete=assignment.complete,
                 relative_aggregate=aggregates.get(assignment.identity),
                 rank=ranks.get(assignment.identity),
+                relative_percentile=percentiles_by_identity.get(assignment.identity),
             )
             for assignment in ordered
         )

--- a/app/domain/hotel_heat_score.py
+++ b/app/domain/hotel_heat_score.py
@@ -1,0 +1,253 @@
+"""Pure local assignment and relative scoring for neighbourhood hotel heat."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+from shapely.geometry import Point
+from shapely.geometry.base import BaseGeometry
+
+from app.domain.analysis import TileGeometry, join_point_to_tiles
+from app.domain.hotels import HotelCandidate, OsmIdentity
+
+
+COMPONENTS = ("night", "hot_hours", "persistence", "day")
+DEFAULT_WEIGHTS: Mapping[str, float] = MappingProxyType(
+    {"night": 0.35, "hot_hours": 0.25, "persistence": 0.20, "day": 0.20}
+)
+DEFAULT_WEIGHT_LABEL = "product defaults"
+WEIGHT_SUM_TOLERANCE = 0.001
+NEAREST_FALLBACK_MAX_M = 100.0
+
+
+def _finite_number(value: object) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and math.isfinite(value)
+
+
+@dataclass(frozen=True)
+class ComponentEvidence:
+    """One district analysis whose tiles can be reused for every hotel."""
+
+    component: str
+    tiles: tuple[TileGeometry, ...]
+    unit: str
+    threshold_celsius: float | None
+    provenance: str
+    tile_resolution_m: float
+
+    def __post_init__(self) -> None:
+        if self.component not in COMPONENTS:
+            raise ValueError(f"component must be one of {COMPONENTS}")
+        expected_unit = "C" if self.component in {"night", "day"} else "hours"
+        if self.unit != expected_unit:
+            raise ValueError(f"{self.component} evidence must use {expected_unit}")
+        if self.component in {"hot_hours", "persistence"}:
+            if not _finite_number(self.threshold_celsius):
+                raise ValueError(f"{self.component} evidence requires a finite threshold")
+        elif self.threshold_celsius is not None:
+            raise ValueError(f"{self.component} evidence must not define a threshold")
+        if not self.provenance.strip():
+            raise ValueError("component evidence provenance is required")
+        if not _finite_number(self.tile_resolution_m) or self.tile_resolution_m <= 0:
+            raise ValueError("tile resolution must be finite and positive")
+
+
+@dataclass(frozen=True)
+class ComponentAssignment:
+    """Local evidence assigned to one hotel for one component."""
+
+    component: str
+    value: float | None
+    unit: str
+    threshold_celsius: float | None
+    provenance: str
+    tile_id: str | None
+    tile_resolution_m: float
+    quality: str
+    distance_m: float | None
+
+
+@dataclass(frozen=True)
+class HotelHeatAssignment:
+    identity: OsmIdentity
+    name: str
+    components: Mapping[str, ComponentAssignment]
+
+    @property
+    def complete(self) -> bool:
+        return set(self.components) == set(COMPONENTS) and all(
+            assignment.value is not None and _finite_number(assignment.value)
+            for assignment in self.components.values()
+        )
+
+
+@dataclass(frozen=True)
+class ScoredComponent:
+    assignment: ComponentAssignment
+    percentile: float | None
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.assignment, name)
+
+
+@dataclass(frozen=True)
+class ScoredHotel:
+    identity: OsmIdentity
+    name: str
+    components: Mapping[str, ScoredComponent]
+    complete: bool
+    relative_aggregate: float | None
+    rank: int | None
+
+
+@dataclass(frozen=True)
+class NeighbourhoodHeatScore:
+    hotels: tuple[ScoredHotel, ...]
+    weights: Mapping[str, float]
+    weight_label: str
+    complete_candidate_count: int
+    ranked_output: bool
+
+
+class NeighbourhoodHeatScorer:
+    """Assign shared district tiles and rank hotels using candidate-relative evidence."""
+
+    def assign(
+        self,
+        hotels: Sequence[HotelCandidate],
+        evidence: Mapping[str, ComponentEvidence],
+        *,
+        aoi: BaseGeometry,
+    ) -> tuple[HotelHeatAssignment, ...]:
+        if set(evidence) != set(COMPONENTS) or any(
+            name != item.component for name, item in evidence.items()
+        ):
+            raise ValueError(f"evidence components must be exactly {set(COMPONENTS)}")
+
+        assignments: list[HotelHeatAssignment] = []
+        for hotel in hotels:
+            point = Point(hotel.longitude, hotel.latitude)
+            components: dict[str, ComponentAssignment] = {}
+            for component in COMPONENTS:
+                item = evidence[component]
+                match = join_point_to_tiles(
+                    point,
+                    item.tiles,
+                    aoi=aoi,
+                    nearest_max_distance_m=NEAREST_FALLBACK_MAX_M,
+                )
+                components[component] = ComponentAssignment(
+                    component=component,
+                    value=match.value,
+                    unit=item.unit,
+                    threshold_celsius=item.threshold_celsius,
+                    provenance=item.provenance,
+                    tile_id=match.tile_id,
+                    tile_resolution_m=item.tile_resolution_m,
+                    quality=match.quality,
+                    distance_m=match.distance_m,
+                )
+            assignments.append(
+                HotelHeatAssignment(
+                    hotel.primary_identity, hotel.name, MappingProxyType(components)
+                )
+            )
+        return tuple(assignments)
+
+    def score(
+        self,
+        assignments: Sequence[HotelHeatAssignment],
+        *,
+        weights: Mapping[str, float] | None = None,
+    ) -> NeighbourhoodHeatScore:
+        selected_weights, weight_label = self._weights(weights)
+        identities = [assignment.identity for assignment in assignments]
+        if len(set(identities)) != len(identities):
+            raise ValueError("hotel identities must be unique")
+        complete = [assignment for assignment in assignments if assignment.complete]
+        percentiles: dict[str, dict[OsmIdentity, float]] = {name: {} for name in COMPONENTS}
+
+        for component in COMPONENTS:
+            component_values: set[float] = set()
+            for assignment in complete:
+                value = assignment.components[component].value
+                assert value is not None
+                component_values.add(value)
+            values = sorted(component_values)
+            for assignment in complete:
+                value = assignment.components[component].value
+                assert value is not None
+                percentiles[component][assignment.identity] = (
+                    100.0 * (1.0 - values.index(value) / (len(values) - 1))
+                    if len(values) > 1
+                    else 100.0
+                )
+
+        aggregates = {
+            assignment.identity: round(
+                sum(
+                    (1.0 - percentiles[component][assignment.identity] / 100.0)
+                    * selected_weights[component]
+                    for component in COMPONENTS
+                ),
+                6,
+            )
+            for assignment in complete
+        }
+        ranked_output = len(complete) >= 5
+        ranks: dict[OsmIdentity, int] = {}
+        if ranked_output:
+            ordered_complete = sorted(
+                complete, key=lambda item: (aggregates[item.identity], item.identity)
+            )
+            for position, assignment in enumerate(ordered_complete, start=1):
+                score = aggregates[assignment.identity]
+                ranks[assignment.identity] = next(
+                    index
+                    for index, candidate in enumerate(ordered_complete, start=1)
+                    if aggregates[candidate.identity] == score
+                )
+            ordered = ordered_complete + [item for item in assignments if not item.complete]
+        else:
+            ordered = list(assignments)
+
+        hotels = tuple(
+            ScoredHotel(
+                identity=assignment.identity,
+                name=assignment.name,
+                components=MappingProxyType(
+                    {
+                        component: ScoredComponent(
+                            assignment.components[component],
+                            percentiles[component].get(assignment.identity),
+                        )
+                        for component in COMPONENTS
+                    }
+                ),
+                complete=assignment.complete,
+                relative_aggregate=aggregates.get(assignment.identity),
+                rank=ranks.get(assignment.identity),
+            )
+            for assignment in ordered
+        )
+        return NeighbourhoodHeatScore(
+            hotels=hotels,
+            weights=MappingProxyType(selected_weights),
+            weight_label=weight_label,
+            complete_candidate_count=len(complete),
+            ranked_output=ranked_output,
+        )
+
+    @staticmethod
+    def _weights(weights: Mapping[str, float] | None) -> tuple[dict[str, float], str]:
+        selected = dict(DEFAULT_WEIGHTS if weights is None else weights)
+        if set(selected) != set(COMPONENTS) or any(
+            not _finite_number(value) or value < 0 for value in selected.values()
+        ):
+            raise ValueError("weights must be complete, finite, and nonnegative")
+        if abs(sum(selected.values()) - 1.0) > WEIGHT_SUM_TOLERANCE:
+            raise ValueError("weights must sum to 1")
+        return selected, DEFAULT_WEIGHT_LABEL if weights is None else "custom"

--- a/app/domain/hotel_heat_score.py
+++ b/app/domain/hotel_heat_score.py
@@ -40,6 +40,7 @@ class ComponentEvidence:
     coverage: float | None = None
     caveats: tuple[str, ...] = ()
     provenance_details: Mapping[str, object] | None = None
+    correlation_key: str | None = None
 
     def __post_init__(self) -> None:
         if self.component not in COMPONENTS:
@@ -79,6 +80,7 @@ class ComponentAssignment:
     distance_m: float | None
     coverage: float | None = None
     caveats: tuple[str, ...] = ()
+    correlation_key: str | None = None
 
 
 @dataclass(frozen=True)
@@ -163,6 +165,7 @@ class NeighbourhoodHeatScorer:
                     distance_m=match.distance_m,
                     coverage=item.coverage,
                     caveats=item.caveats,
+                    correlation_key=item.correlation_key or component,
                 )
             assignments.append(
                 HotelHeatAssignment(
@@ -200,17 +203,26 @@ class NeighbourhoodHeatScorer:
                     else 100.0
                 )
 
-        aggregates = {
-            assignment.identity: round(
+        aggregates = {}
+        for assignment in complete:
+            groups: dict[str, tuple[str, float]] = {}
+            for component in COMPONENTS:
+                key = assignment.components[component].correlation_key or component
+                current = groups.get(key)
+                if current is None:
+                    groups[key] = (component, selected_weights[component])
+                else:
+                    groups[key] = (current[0], current[1] + selected_weights[component])
+            active_weight = sum(weight for _, weight in groups.values())
+            aggregates[assignment.identity] = round(
                 sum(
                     (1.0 - percentiles[component][assignment.identity] / 100.0)
-                    * selected_weights[component]
-                    for component in COMPONENTS
+                    * weight
+                    / active_weight
+                    for component, weight in groups.values()
                 ),
                 6,
             )
-            for assignment in complete
-        }
         ranked_output = len(complete) >= 5
         ranks: dict[OsmIdentity, int] = {}
         if ranked_output:

--- a/app/domain/hotels.py
+++ b/app/domain/hotels.py
@@ -71,7 +71,7 @@ class HotelDiscoveryResult:
     discovered_count: int
     usable_count: int
     source_timestamp: datetime | None
-    retrieved_at: datetime
+    retrieved_at: datetime | None
     source: str
     stale: bool
     reason: str | None = None

--- a/app/domain/ledger.py
+++ b/app/domain/ledger.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
+from threading import Lock
 from typing import Callable, Mapping, Sequence
 
 
@@ -65,6 +66,9 @@ class CreditLedger:
         self.planned_optional: dict[str, int] = {}
         self._on_record = on_record
         self._on_reconcile = on_reconcile
+        self._reservations: set[int] = set()
+        self._next_reservation = 0
+        self._lock = Lock()
 
     @property
     def call_count(self) -> int:
@@ -92,26 +96,50 @@ class CreditLedger:
     def remaining(self) -> int:
         if self.budget is None:
             raise RuntimeError("record-only ledger has no budget")
-        return self.budget - self.call_count
+        with self._lock:
+            return self.budget - self.call_count - len(self._reservations)
 
     def plan_optional(self, subject: str, credits: int) -> None:
         if credits < 0:
             raise ValueError("planned credits must be non-negative")
         self.planned_optional[subject] = credits
 
-    def authorize_call(self) -> None:
+    def authorize_call(self) -> int | None:
         """Check the budget *before* spending. Raises if no call is left."""
-        if self.budget is not None and self.remaining <= 0:
-            raise BudgetExceededError(
-                f"call budget exceeded: {self.call_count} of {self.budget} calls used"
-            )
+        with self._lock:
+            if self.budget is not None:
+                if self.budget - self.call_count - len(self._reservations) <= 0:
+                    raise BudgetExceededError(
+                        f"call budget exceeded: {self.call_count} of {self.budget} calls used"
+                    )
+                self._next_reservation += 1
+                self._reservations.add(self._next_reservation)
+                return self._next_reservation
+            return None
 
-    def record(self, usage: UsageRecord) -> None:
-        if any(record.activity_id == usage.activity_id for record in self.records):
-            return
-        if usage.credits_used is not None and usage.credits_used < 0:
-            raise ValueError("reported credits must be non-negative")
-        self.records.append(usage)
+    def release_call(self, reservation: int | None = None) -> None:
+        """Return a reserved slot when submission does not complete a call."""
+        with self._lock:
+            if reservation is not None:
+                self._reservations.discard(reservation)
+            elif self._reservations:
+                self._reservations.pop()
+
+    def record(self, usage: UsageRecord, *, reservation: int | None = None) -> None:
+        with self._lock:
+            if any(record.activity_id == usage.activity_id for record in self.records):
+                if reservation is not None:
+                    self._reservations.discard(reservation)
+                elif self._reservations:
+                    self._reservations.pop()
+                return
+            if usage.credits_used is not None and usage.credits_used < 0:
+                raise ValueError("reported credits must be non-negative")
+            self.records.append(usage)
+            if reservation is not None:
+                self._reservations.discard(reservation)
+            elif self._reservations:
+                self._reservations.pop()
         if self._on_record is not None:
             self._on_record(usage)
 

--- a/app/integrations/fortyguard/client.py
+++ b/app/integrations/fortyguard/client.py
@@ -57,65 +57,75 @@ class FortyGuardClient:
         interval_seconds: float = 5.0,
         status_404_grace_checks: int = 3,
     ) -> tuple[Mapping[str, object], ActivityMetadata]:
+        reservation: int | None = None
         if self._ledger is not None:
-            self._ledger.authorize_call()
-        response = self._transport.post(endpoint, payload, self._api_key)
-        status_code = response.get("status_code")
-        if isinstance(status_code, int) and status_code >= 400:
-            raise classify_provider_error(status_code, "activity submission failed")
-        activity_id = response.get("activity_id")
-        if not isinstance(activity_id, str) or not activity_id:
-            raise ProviderError(ProviderErrorKind.MALFORMED_RESPONSE, detail="missing activity id")
-        submitted_at = self._clock()
-        self._emit(
-            "fortyguard.submitted",
-            {
-                "activity_id": activity_id,
-                "endpoint": endpoint,
-                "request": sanitize_payload(payload),
-            },
-        )
-        transitions: list[str] = []
-
-        def get_status(_: str) -> Mapping[str, object]:
-            return self._transport.get(f"/v1/status/{activity_id}", self._api_key)
-
-        result = poll_activity(
-            activity_id,
-            get_status=get_status,
-            sleep=sleep,
-            max_polls=max_polls,
-            interval_seconds=interval_seconds,
-            status_404_grace_checks=status_404_grace_checks,
-            on_transition=transitions.append,
-            on_event=self._emit,
-        )
-        metadata = ActivityMetadata(
-            activity_id,
-            submitted_at,
-            endpoint,
-            tuple(sorted(payload)),
-            tuple(transitions),
-            _response_metadata(result),
-        )
-        credits_used = result.get("credits_used")
-        if credits_used is not None and (
-            isinstance(credits_used, bool) or not isinstance(credits_used, int) or credits_used < 0
-        ):
-            raise ProviderError(
-                ProviderErrorKind.MALFORMED_RESPONSE, detail="invalid credit usage metadata"
+            reservation = self._ledger.authorize_call()
+        try:
+            response = self._transport.post(endpoint, payload, self._api_key)
+            status_code = response.get("status_code")
+            if isinstance(status_code, int) and status_code >= 400:
+                raise classify_provider_error(status_code, "activity submission failed")
+            activity_id = response.get("activity_id")
+            if not isinstance(activity_id, str) or not activity_id:
+                raise ProviderError(
+                    ProviderErrorKind.MALFORMED_RESPONSE, detail="missing activity id"
+                )
+            submitted_at = self._clock()
+            self._emit(
+                "fortyguard.submitted",
+                {
+                    "activity_id": activity_id,
+                    "endpoint": endpoint,
+                    "request": sanitize_payload(payload),
+                },
             )
-        if self._ledger is not None:
-            # The call happened, so it is logged whether or not the provider
-            # priced it. A silent provider means unknown cost, not zero cost
-            # (ADR 0004 §5); credits are reconciled from the account endpoint.
-            self._ledger.record(
-                UsageRecord(activity_id, endpoint, credits_used, self._clock(), "completed")
+            transitions: list[str] = []
+
+            def get_status(_: str) -> Mapping[str, object]:
+                return self._transport.get(f"/v1/status/{activity_id}", self._api_key)
+
+            result = poll_activity(
+                activity_id,
+                get_status=get_status,
+                sleep=sleep,
+                max_polls=max_polls,
+                interval_seconds=interval_seconds,
+                status_404_grace_checks=status_404_grace_checks,
+                on_transition=transitions.append,
+                on_event=self._emit,
             )
-        self._emit(
-            "fortyguard.completed", {"activity_id": activity_id, **_response_metadata(result)}
-        )
-        return result, metadata
+            metadata = ActivityMetadata(
+                activity_id,
+                submitted_at,
+                endpoint,
+                tuple(sorted(payload)),
+                tuple(transitions),
+                _response_metadata(result),
+            )
+            credits_used = result.get("credits_used")
+            if credits_used is not None and (
+                isinstance(credits_used, bool)
+                or not isinstance(credits_used, int)
+                or credits_used < 0
+            ):
+                raise ProviderError(
+                    ProviderErrorKind.MALFORMED_RESPONSE, detail="invalid credit usage metadata"
+                )
+            if self._ledger is not None:
+                # The call happened, so it is logged whether or not the provider
+                # priced it. A silent provider means unknown cost, not zero cost
+                # (ADR 0004 §5); credits are reconciled from the account endpoint.
+                self._ledger.record(
+                    UsageRecord(activity_id, endpoint, credits_used, self._clock(), "completed"),
+                    reservation=reservation,
+                )
+            self._emit(
+                "fortyguard.completed", {"activity_id": activity_id, **_response_metadata(result)}
+            )
+            return result, metadata
+        finally:
+            if reservation is not None and self._ledger is not None:
+                self._ledger.release_call(reservation)
 
     def _emit(self, event: str, fields: Mapping[str, object]) -> None:
         if self._event_sink is not None:

--- a/app/services/hotel_heat_score.py
+++ b/app/services/hotel_heat_score.py
@@ -94,6 +94,14 @@ class HotelHeatAnalysisService:
         self._supported_modes = supported_modes or frozenset(ExecutionMode)
         self._district_name = district_name
 
+    def discover(self) -> HotelDiscoveryResult:
+        """Expose the discovery seam for composition and deterministic replay."""
+        return self._hotel_discovery()
+
+    def load_component(self, component: str) -> ComponentEvidence | None:
+        """Load one component through the configured execution boundary."""
+        return self._component_loader(component)
+
     def analyze(
         self,
         district_name: str,
@@ -246,7 +254,7 @@ class HotelHeatAnalysisService:
                 component=component,
                 available=False,
                 unit=unit,
-                threshold_celsius=None,
+                threshold_celsius=35.0 if component in {"hot_hours", "persistence"} else None,
                 provenance=None,
                 coverage=None,
                 confidence=None,

--- a/app/services/hotel_heat_score.py
+++ b/app/services/hotel_heat_score.py
@@ -1,0 +1,562 @@
+"""Provider-neutral orchestration for district hotel heat ranking."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+import json
+import math
+from pathlib import Path
+from types import MappingProxyType
+from typing import Callable, Mapping, cast
+
+from shapely.geometry import Point, box
+from shapely.geometry.base import BaseGeometry
+
+from app.domain.analysis import SpatialMetadata, TileGeometry
+from app.domain.contracts import ExecutionMode
+from app.domain.provenance import AcquisitionRecord
+from app.domain.hotel_heat_score import (
+    COMPONENTS,
+    ComponentEvidence,
+    HotelHeatAssignment,
+    NeighbourhoodHeatScore,
+    NeighbourhoodHeatScorer,
+)
+from app.domain.hotels import (
+    BoundingBox,
+    DiscoveryState,
+    HotelCandidate,
+    HotelDiscoveryResult,
+    OsmIdentity,
+)
+from app.integrations.fortyguard.errors import ProviderError
+from app.domain.ledger import BudgetExceededError
+from app.services.sidecars import load_acquisition_record
+
+
+HotelDiscoveryCallable = Callable[[], HotelDiscoveryResult]
+ComponentLoaderCallable = Callable[[str], ComponentEvidence | None]
+
+
+class HotelHeatAnalysisState(str, Enum):
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class ComponentAnalysisMetadata:
+    component: str
+    available: bool
+    unit: str
+    threshold_celsius: float | None
+    provenance: str | None
+    coverage: float | None
+    confidence: str | None
+    caveats: tuple[str, ...]
+    provenance_details: Mapping[str, object] | None = None
+    missing_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class HotelHeatAnalysisOutcome:
+    state: HotelHeatAnalysisState
+    district_name: str
+    execution_mode: ExecutionMode
+    discovered_count: int
+    usable_count: int
+    evidence: Mapping[str, ComponentEvidence]
+    assignments: tuple[HotelHeatAssignment, ...]
+    components: Mapping[str, ComponentAnalysisMetadata]
+    score: NeighbourhoodHeatScore | None
+    reason: str | None = None
+
+
+class HotelHeatAnalysisService:
+    """Load district evidence once, assign it locally, and retain rerankable inputs."""
+
+    def __init__(
+        self,
+        hotel_discovery: HotelDiscoveryCallable,
+        component_loader: ComponentLoaderCallable,
+        *,
+        aoi: BaseGeometry,
+        scorer: NeighbourhoodHeatScorer | None = None,
+        supported_modes: frozenset[ExecutionMode] | None = None,
+        district_name: str | None = None,
+    ) -> None:
+        self._hotel_discovery = hotel_discovery
+        self._component_loader = component_loader
+        self._aoi = aoi
+        self._scorer = scorer or NeighbourhoodHeatScorer()
+        self._supported_modes = supported_modes or frozenset(ExecutionMode)
+        self._district_name = district_name
+
+    def analyze(
+        self,
+        district_name: str,
+        execution_mode: ExecutionMode,
+        *,
+        weights: Mapping[str, float] | None = None,
+    ) -> HotelHeatAnalysisOutcome:
+        if not district_name.strip():
+            raise ValueError("district_name must be a non-empty string")
+        if execution_mode not in self._supported_modes:
+            return self._unavailable(district_name, execution_mode, "execution_mode_unavailable")
+        if self._district_name is not None and district_name != self._district_name:
+            return self._unavailable(district_name, execution_mode, "district_not_available")
+        discovery = self._hotel_discovery()
+        if discovery.state is DiscoveryState.UNAVAILABLE:
+            return HotelHeatAnalysisOutcome(
+                HotelHeatAnalysisState.UNAVAILABLE,
+                district_name,
+                execution_mode,
+                discovery.discovered_count,
+                discovery.usable_count,
+                MappingProxyType({}),
+                (),
+                MappingProxyType({}),
+                None,
+                discovery.reason or "hotel_discovery_unavailable",
+            )
+
+        evidence, components = self._load_components(district_name, execution_mode)
+        if len(evidence) != len(COMPONENTS):
+            return HotelHeatAnalysisOutcome(
+                HotelHeatAnalysisState.UNAVAILABLE,
+                district_name,
+                execution_mode,
+                discovery.discovered_count,
+                discovery.usable_count,
+                MappingProxyType(evidence),
+                (),
+                MappingProxyType(components),
+                None,
+                "missing_component_evidence",
+            )
+
+        assignments = self._scorer.assign(discovery.candidates, evidence, aoi=self._aoi)
+        score = self._scorer.score(assignments, weights=weights)
+        state = (
+            HotelHeatAnalysisState.AVAILABLE
+            if score.ranked_output
+            else HotelHeatAnalysisState.UNAVAILABLE
+        )
+        return HotelHeatAnalysisOutcome(
+            state,
+            district_name,
+            execution_mode,
+            discovery.discovered_count,
+            discovery.usable_count,
+            MappingProxyType(evidence),
+            assignments,
+            MappingProxyType(components),
+            score,
+            None if score.ranked_output else "insufficient_complete_hotels",
+        )
+
+    @staticmethod
+    def _unavailable(
+        district_name: str, execution_mode: ExecutionMode, reason: str
+    ) -> HotelHeatAnalysisOutcome:
+        return HotelHeatAnalysisOutcome(
+            HotelHeatAnalysisState.UNAVAILABLE,
+            district_name,
+            execution_mode,
+            0,
+            0,
+            MappingProxyType({}),
+            (),
+            MappingProxyType({}),
+            None,
+            reason,
+        )
+
+    def rerank(
+        self,
+        outcome: HotelHeatAnalysisOutcome,
+        *,
+        weights: Mapping[str, float] | None = None,
+    ) -> HotelHeatAnalysisOutcome:
+        """Recompute relative ranking solely from retained local assignments."""
+        if not outcome.assignments:
+            raise ValueError("hotel heat analysis has no assignments to rerank")
+        score = self._scorer.score(outcome.assignments, weights=weights)
+        state = (
+            HotelHeatAnalysisState.AVAILABLE
+            if score.ranked_output
+            else HotelHeatAnalysisState.UNAVAILABLE
+        )
+        return HotelHeatAnalysisOutcome(
+            state,
+            outcome.district_name,
+            outcome.execution_mode,
+            outcome.discovered_count,
+            outcome.usable_count,
+            outcome.evidence,
+            outcome.assignments,
+            outcome.components,
+            score,
+            None if score.ranked_output else "insufficient_complete_hotels",
+        )
+
+    def _load_components(
+        self, district_name: str, execution_mode: ExecutionMode
+    ) -> tuple[dict[str, ComponentEvidence], dict[str, ComponentAnalysisMetadata]]:
+        evidence: dict[str, ComponentEvidence] = {}
+        missing: dict[str, str] = {}
+        with ThreadPoolExecutor(max_workers=len(COMPONENTS)) as executor:
+            futures = {
+                executor.submit(self._component_loader, component): component
+                for component in COMPONENTS
+            }
+            for future in as_completed(futures):
+                component = futures[future]
+                try:
+                    item = future.result()
+                except (ProviderError, OSError, TimeoutError, ValueError):
+                    missing[component] = "component_load_failed"
+                    continue
+                except BudgetExceededError:
+                    raise
+                if item is None:
+                    missing[component] = "component_not_available"
+                elif item.component != component:
+                    missing[component] = "component_mismatch"
+                else:
+                    evidence[component] = item
+
+        components = {
+            component: self._component_metadata(
+                component, evidence.get(component), missing.get(component)
+            )
+            for component in COMPONENTS
+        }
+        return evidence, components
+
+    @staticmethod
+    def _component_metadata(
+        component: str, evidence: ComponentEvidence | None, missing_reason: str | None
+    ) -> ComponentAnalysisMetadata:
+        unit = "C" if component in {"night", "day"} else "hours"
+        if evidence is None:
+            return ComponentAnalysisMetadata(
+                component=component,
+                available=False,
+                unit=unit,
+                threshold_celsius=None,
+                provenance=None,
+                coverage=None,
+                confidence=None,
+                caveats=(),
+                missing_reason=missing_reason,
+            )
+        return ComponentAnalysisMetadata(
+            component=component,
+            available=True,
+            unit=evidence.unit,
+            threshold_celsius=evidence.threshold_celsius,
+            provenance=evidence.provenance,
+            coverage=evidence.coverage,
+            confidence=_confidence(evidence.coverage),
+            caveats=evidence.caveats,
+            provenance_details=evidence.provenance_details,
+        )
+
+
+def _confidence(coverage: float | None) -> str | None:
+    if coverage is None:
+        return None
+    if coverage >= 0.95:
+        return "high"
+    if coverage >= 0.7:
+        return "limited"
+    return "insufficient"
+
+
+def build_fixture_hotel_heat_analysis_service(
+    fixture_path: Path, *, district_aoi: BoundingBox
+) -> HotelHeatAnalysisService:
+    """Load and validate the canonical offline district analysis fixture."""
+    payload = _object(json.loads(fixture_path.read_text(encoding="utf-8")), "fixture")
+    if payload.get("schema_version") != "hotel-heat-analysis-v1":
+        raise ValueError("unsupported hotel heat fixture schema_version")
+
+    district = _string(payload, "district_name")
+    fixture_aoi = _bbox(_object(payload.get("aoi"), "aoi"), "aoi")
+    if fixture_aoi != district_aoi:
+        raise ValueError("hotel heat fixture AOI does not match configured district AOI")
+    aoi_geometry = box(district_aoi.west, district_aoi.south, district_aoi.east, district_aoi.north)
+
+    discovery_payload = _object(payload.get("hotel_discovery"), "hotel_discovery")
+    candidates = tuple(
+        _hotel(_object(item, "hotel_discovery.hotels[]"), aoi_geometry)
+        for item in _array(discovery_payload, "hotels")
+    )
+    if len({hotel.primary_identity for hotel in candidates}) != len(candidates):
+        raise ValueError("hotel heat fixture contains duplicate primary OSM identities")
+    discovered_count = _integer(discovery_payload, "discovered_count")
+    if discovered_count < len(candidates) or len(candidates) < 5:
+        raise ValueError("hotel heat fixture requires at least five usable discovered hotels")
+    acquisition = load_acquisition_record(fixture_path)
+    if acquisition is None:
+        raise ValueError("hotel heat fixture requires an acquisition sidecar")
+    if acquisition.schema_version != "hotel-heat-analysis-v1":
+        raise ValueError("hotel heat fixture sidecar schema does not match payload")
+    expected_request = {
+        "district_name": district,
+        "aoi": district_aoi.to_payload(),
+        "components": list(COMPONENTS),
+        "threshold_celsius": 35,
+        "tile_resolution_m": 80,
+    }
+    if acquisition.request_configuration != expected_request:
+        raise ValueError("hotel heat fixture sidecar request does not match payload")
+    if acquisition.source == "synthesized" and acquisition.retrieved_at is not None:
+        raise ValueError("synthesized hotel heat fixtures cannot have retrieval times")
+    retrieved_at = acquisition.retrieved_at
+    if acquisition.data_date is None:
+        raise ValueError("hotel heat fixture sidecar requires a data date")
+    source_timestamp = _timestamp(discovery_payload, "source_timestamp")
+    discovery = HotelDiscoveryResult(
+        DiscoveryState.AVAILABLE,
+        candidates,
+        discovered_count,
+        len(candidates),
+        source_timestamp,
+        retrieved_at,
+        "fixture",
+        False,
+    )
+
+    component_payloads = _object(payload.get("components"), "components")
+    if set(component_payloads) != set(COMPONENTS):
+        raise ValueError("hotel heat fixture must contain exactly four shared components")
+    evidence = {
+        component: _component(
+            component,
+            _object(component_payloads[component], f"components.{component}"),
+            aoi_geometry,
+            acquisition,
+        )
+        for component in COMPONENTS
+    }
+    return HotelHeatAnalysisService(
+        lambda: discovery,
+        evidence.get,
+        aoi=aoi_geometry,
+        supported_modes=frozenset({ExecutionMode.FIXTURE}),
+        district_name=district,
+    )
+
+
+def _component(
+    component: str,
+    payload: dict[str, object],
+    aoi: BaseGeometry,
+    acquisition: AcquisitionRecord,
+) -> ComponentEvidence:
+    unit = _string(payload, "unit")
+    threshold_value = payload.get("threshold_celsius")
+    threshold = None if threshold_value is None else _number(threshold_value, "threshold_celsius")
+    provenance = _string(payload, "provenance")
+    resolution = _number(payload.get("tile_resolution_m"), "tile_resolution_m")
+    if resolution != 80.0:
+        raise ValueError(f"{component} fixture evidence must use 80 m resolution")
+    if component in {"hot_hours", "persistence"} and threshold != 35.0:
+        raise ValueError(f"{component} fixture evidence must use a 35 C threshold")
+    coverage = _number(payload.get("coverage"), "coverage")
+    caveats = tuple(
+        _nonempty_string(item, f"components.{component}.caveats[]")
+        for item in _array(payload, "caveats")
+    )
+    tiles = _grid_tiles(component, unit, threshold, provenance, payload, aoi)
+    if not tiles or len({tile.identity for tile in tiles}) != len(tiles):
+        raise ValueError(f"{component} must contain uniquely identified tiles")
+    return ComponentEvidence(
+        component,
+        tiles,
+        unit,
+        threshold,
+        provenance,
+        resolution,
+        coverage=coverage,
+        caveats=caveats,
+        provenance_details={
+            "source": "fixture",
+            "retrieved_at": acquisition.retrieved_at.isoformat()
+            if acquisition.retrieved_at is not None
+            else None,
+            "data_date": acquisition.data_date,
+            "stale": False,
+            "forecast": False,
+            "activity_id": acquisition.activity_id,
+            "transformations": [
+                {"name": item.name, "version": item.version} for item in acquisition.transformations
+            ],
+        },
+    )
+
+
+def _grid_tiles(
+    component: str,
+    unit: str,
+    threshold: float | None,
+    provenance: str,
+    component_payload: dict[str, object],
+    aoi: BaseGeometry,
+) -> tuple[TileGeometry, ...]:
+    rows = _integer(component_payload, "grid_rows")
+    if rows < 1:
+        raise ValueError(f"{component} grid_rows must be positive")
+    tiles: list[TileGeometry] = []
+    for column_index, value in enumerate(_array(component_payload, "tiles"), start=1):
+        payload = _object(value, f"components.{component}.tiles[]")
+        bounds = payload.get("bounds")
+        if not isinstance(bounds, list) or len(bounds) != 4:
+            raise ValueError(f"{component} grid column bounds must contain west,south,east,north")
+        west, south, east, north = (
+            _number(item, f"components.{component}.tiles[].bounds") for item in bounds
+        )
+        if west >= east or south >= north:
+            raise ValueError(f"{component} grid column bounds are invalid")
+        column_geometry = box(west, south, east, north)
+        if not aoi.covers(column_geometry):
+            raise ValueError(f"{component} grid columns must be inside the configured district AOI")
+        valid_time = _string(payload, "valid_time")
+        try:
+            datetime.fromisoformat(valid_time.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValueError(
+                f"{component} tile valid_time must be an ISO 8601 date or timestamp"
+            ) from None
+        metadata = SpatialMetadata(
+            metric=component,
+            unit=unit,
+            source=provenance,
+            valid_time=valid_time,
+            forecast=_boolean(payload, "forecast"),
+            threshold_celsius=threshold,
+            direction="above" if threshold is not None else None,
+        )
+        cell_height = (north - south) / rows
+        tiles.extend(
+            TileGeometry(
+                f"{component}-r{row_index + 1:02d}-c{column_index:02d}",
+                box(
+                    west,
+                    south + row_index * cell_height,
+                    east,
+                    south + (row_index + 1) * cell_height,
+                ),
+                _number(payload.get("value"), "tile.value"),
+                metadata,
+            )
+            for row_index in range(rows)
+        )
+    return tuple(tiles)
+
+
+def _hotel(payload: dict[str, object], aoi: BaseGeometry) -> HotelCandidate:
+    primary = _identity(_object(payload.get("primary_identity"), "primary_identity"))
+    identities = tuple(
+        _identity(_object(item, "source_identities[]"))
+        for item in _array(payload, "source_identities")
+    )
+    if primary not in identities or len(set(identities)) != len(identities):
+        raise ValueError("hotel source identities must be unique and include the primary identity")
+    latitude = _number(payload.get("latitude"), "hotel.latitude")
+    longitude = _number(payload.get("longitude"), "hotel.longitude")
+    if not aoi.covers(Point(longitude, latitude)):
+        raise ValueError("hotel coordinates must be inside the configured district AOI")
+    address_payload = _object(payload.get("address", {}), "hotel.address")
+    address = tuple(
+        (key, _nonempty_string(value, f"hotel.address.{key}"))
+        for key, value in sorted(address_payload.items())
+    )
+    return HotelCandidate(
+        primary,
+        identities,
+        _string(payload, "name"),
+        latitude,
+        longitude,
+        address,
+        _optional_string(payload.get("website"), "hotel.website"),
+        _optional_string(payload.get("operator"), "hotel.operator"),
+    )
+
+
+def _identity(payload: dict[str, object]) -> OsmIdentity:
+    return OsmIdentity(_string(payload, "object_type"), _integer(payload, "object_id"))
+
+
+def _bbox(payload: dict[str, object], field: str) -> BoundingBox:
+    return BoundingBox(
+        _number(payload.get("south"), f"{field}.south"),
+        _number(payload.get("west"), f"{field}.west"),
+        _number(payload.get("north"), f"{field}.north"),
+        _number(payload.get("east"), f"{field}.east"),
+    )
+
+
+def _object(value: object, field: str) -> dict[str, object]:
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{field} must be an object")
+    return cast(dict[str, object], value)
+
+
+def _array(payload: dict[str, object], field: str) -> list[object]:
+    value = payload.get(field)
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be an array")
+    return cast(list[object], value)
+
+
+def _string(payload: dict[str, object], field: str) -> str:
+    return _nonempty_string(payload.get(field), field)
+
+
+def _nonempty_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _optional_string(value: object, field: str) -> str | None:
+    return None if value is None else _nonempty_string(value, field)
+
+
+def _number(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be numeric")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{field} must be finite")
+    return number
+
+
+def _integer(payload: dict[str, object], field: str) -> int:
+    value = payload.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer")
+    return value
+
+
+def _boolean(payload: dict[str, object], field: str) -> bool:
+    value = payload.get(field)
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a boolean")
+    return value
+
+
+def _timestamp(payload: dict[str, object], field: str) -> datetime:
+    value = _string(payload, field)
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"{field} must be an ISO 8601 timestamp") from None
+    if timestamp.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return timestamp

--- a/app/wiring.py
+++ b/app/wiring.py
@@ -8,20 +8,29 @@ ledger, and execution from application settings.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 import json
 import logging
 from pathlib import Path
 from typing import Mapping, Sequence
 
 from fastapi import FastAPI
+from shapely.geometry.base import BaseGeometry
 
 from app.api import create_app
-from app.domain.contracts import TripAnalysisAdapter
+from app.domain.contracts import ExecutionMode, TripAnalysisAdapter
+from app.domain.hotel_heat_score import ComponentEvidence
+from app.domain.hotels import BoundingBox
 from app.domain.ledger import CreditLedger
 from app.domain.security import sanitize_payload
 from app.integrations.fortyguard.client import FortyGuardClient
+from app.integrations.fortyguard.contracts import (
+    AnalyticType,
+    HeatmapRequest,
+    normalize_heatmap_response,
+)
 from app.integrations.fortyguard.live import (
+    LiveAreaHeatmapAdapter,
     LiveEnvParamsAdapter,
     LiveFortyGuardTransport,
     LiveHeatmapAdapter,
@@ -30,6 +39,8 @@ from app.integrations.overpass.client import OverpassClient
 from app.integrations.overpass.transport import HttpOverpassTransport
 from app.services.cache import CacheService
 from app.services.hotel_discovery import HotelDiscoveryService
+from app.services.hotel_heat_score import HotelHeatAnalysisService
+from app.services.hotel_heat_score import build_fixture_hotel_heat_analysis_service
 from app.services.execution import EnvParamsExecution, HeatmapExecution
 from app.services.ledger_store import JsonlLedgerStore
 from app.services.trip_adapters import (
@@ -102,6 +113,121 @@ def build_hotel_discovery_service(
     )
 
 
+def build_live_hotel_heat_analysis_service(
+    settings: AppSettings,
+    *,
+    client: FortyGuardClient,
+    cache: CacheService | None = None,
+) -> HotelHeatAnalysisService:
+    """Compose four shared district analyses behind the hotel ranking boundary."""
+    discovery = build_hotel_discovery_service(settings, cache=cache)
+    district = settings.overpass.district_aoi
+    area = settings.area
+    adapter = LiveAreaHeatmapAdapter(
+        client,
+        polling=settings.polling,
+        buffer_m=area.buffer_m,
+        max_vertices=area.max_vertices,
+        use_bounding_box=area.use_bounding_box,
+    )
+    route = _bbox_route(district)
+
+    def load(component: str) -> ComponentEvidence:
+        analytic = (
+            AnalyticType.TCM
+            if component in {"night", "day"}
+            else (AnalyticType.EXCEEDANCE if component == "hot_hours" else AnalyticType.PERSISTENCE)
+        )
+        payload = adapter.load(
+            route,
+            analytic_type=analytic,
+            start_date=date.today(),
+            forecast=True,
+            threshold_celsius=35.0 if analytic is not AnalyticType.TCM else None,
+            direction="above" if analytic is not AnalyticType.TCM else None,
+            granularity=area.granularity,
+        )
+        result = normalize_heatmap_response(
+            payload.payload,
+            request=HeatmapRequest(
+                analytic,
+                sum(point[0] for point in route) / len(route),
+                sum(point[1] for point in route) / len(route),
+                date.today(),
+                True,
+                35.0 if analytic is not AnalyticType.TCM else None,
+                "above" if analytic is not AnalyticType.TCM else None,
+                area.granularity,
+            ),
+            retrieved_at=datetime.now(timezone.utc),
+            activity_id=payload.activity_id,
+            source="provider",
+            data_date=date.today().isoformat(),
+            transformations=payload.transformations,
+        )
+        units = "C" if analytic is AnalyticType.TCM else "hours"
+        caveats = (
+            (
+                "date-level TCM value; night window 00:00-05:00 is not a verified interval maximum; "
+                "night and day use the same date-level basis",
+            )
+            if component == "night"
+            else (
+                "date-level TCM value; day window 10:00-17:00 is not a verified interval maximum; "
+                "night and day use the same date-level basis",
+            )
+            if component == "day"
+            else ()
+        )
+        coverage = result.polygon_lookup(_bbox_geometry(district)).coverage
+        return ComponentEvidence(
+            component,
+            tuple(result._spatial_tiles()),
+            units,
+            35.0 if analytic is not AnalyticType.TCM else None,
+            "provider:fortyguard",
+            float(area.granularity),
+            coverage=coverage,
+            caveats=caveats,
+            provenance_details={
+                "source": result.provenance.source,
+                "retrieved_at": result.provenance.retrieved_at.isoformat(),
+                "data_date": result.provenance.data_date,
+                "stale": result.provenance.stale,
+                "forecast": result.provenance.forecast,
+                "activity_id": result.provenance.activity_id,
+                "transformations": [
+                    {"name": item.name, "version": item.version}
+                    for item in result.provenance.transformations
+                ],
+            },
+        )
+
+    return HotelHeatAnalysisService(
+        discovery.discover,
+        load,
+        aoi=_bbox_geometry(district),
+        supported_modes=frozenset({ExecutionMode.LIVE}),
+        district_name="Downtown San Antonio",
+    )
+
+
+def _bbox_route(bbox: BoundingBox) -> tuple[tuple[float, float], ...]:
+    return (
+        (bbox.south, bbox.west),
+        (bbox.south, bbox.east),
+        (bbox.north, bbox.east),
+        (bbox.north, bbox.west),
+        (bbox.south, bbox.west),
+    )
+
+
+def _bbox_geometry(bbox: BoundingBox) -> BaseGeometry:
+    from shapely.geometry import box
+
+    return box(bbox.west, bbox.south, bbox.east, bbox.north)
+
+
 def build_live_heatmap_execution(
     settings: AppSettings,
     *,
@@ -161,6 +287,7 @@ def create_production_app(
     env_params_fixture_path: Path | None = None,
     frontend_dist: Path | None = None,
     trip_adapter: TripAnalysisAdapter | None = None,
+    hotel_heat_analysis_service: HotelHeatAnalysisService | None = None,
 ) -> FastAPI:
     """Create the production app; misconfigured live mode fails fast at startup."""
     from app.settings import load_settings
@@ -203,6 +330,16 @@ def create_production_app(
                 lambda request: {"unavailable": "live trip adapter is not configured"}
             ),
         )
+    if hotel_heat_analysis_service is None:
+        if resolved.allow_live:
+            hotel_heat_analysis_service = build_live_hotel_heat_analysis_service(
+                resolved, client=client, cache=cache
+            )
+        else:
+            hotel_heat_analysis_service = build_fixture_hotel_heat_analysis_service(
+                heatmap_fixture.parent / "hotel-heat-analysis.json",
+                district_aoi=resolved.overpass.district_aoi,
+            )
     return create_app(
         heatmap_fixture,
         execution=execution,
@@ -210,4 +347,6 @@ def create_production_app(
         allow_live=resolved.allow_live,
         frontend_dist=dist,
         trip_adapter=trip_adapter,
+        hotel_heat_analysis_service=hotel_heat_analysis_service,
+        district_aoi=resolved.overpass.district_aoi,
     )

--- a/app/wiring.py
+++ b/app/wiring.py
@@ -13,6 +13,7 @@ import json
 import logging
 from pathlib import Path
 from dataclasses import replace
+from threading import Lock
 from typing import Callable, Mapping, Sequence
 
 from fastapi import FastAPI
@@ -136,6 +137,8 @@ def build_live_hotel_heat_analysis_service(
         use_bounding_box=area.use_bounding_box,
     )
     route = _bbox_route(district)
+    shared_tcm: dict[str, ComponentEvidence] = {}
+    shared_tcm_lock = Lock()
     fixture_service = (
         build_fixture_hotel_heat_analysis_service(fixture_path, district_aoi=district)
         if fixture_path is not None
@@ -148,6 +151,11 @@ def build_live_hotel_heat_analysis_service(
             if component in {"night", "day"}
             else (AnalyticType.EXCEEDANCE if component == "hot_hours" else AnalyticType.PERSISTENCE)
         )
+        if analytic is AnalyticType.TCM:
+            with shared_tcm_lock:
+                cached_tcm = shared_tcm.get("evidence")
+            if cached_tcm is not None:
+                return replace(cached_tcm, component=component)
         try:
             payload = adapter.load(
                 route,
@@ -195,7 +203,7 @@ def build_live_hotel_heat_analysis_service(
                         data_date=cached.provenance.data_date,
                         stale=True,
                     )
-                    return ComponentEvidence(
+                    evidence = ComponentEvidence(
                         component,
                         tuple(replayed._spatial_tiles()),
                         "C" if analytic is AnalyticType.TCM else "hours",
@@ -212,7 +220,11 @@ def build_live_hotel_heat_analysis_service(
                             "activity_id": cached.provenance.activity_id,
                             "transformations": [],
                         },
+                        correlation_key=(
+                            "shared-date-tcm" if component in {"night", "day"} else None
+                        ),
                     )
+                    return evidence
             if fixture_service is None:
                 return None
             fixture_evidence = fixture_service.load_component(component)
@@ -220,12 +232,13 @@ def build_live_hotel_heat_analysis_service(
                 return None
             details = dict(fixture_evidence.provenance_details or {})
             details["stale"] = True
-            return replace(
+            replayed_evidence = replace(
                 fixture_evidence,
                 provenance="fixture:canonical-district-hotel-analysis",
                 caveats=fixture_evidence.caveats + ("replayed matching fixture evidence; stale",),
                 provenance_details=details,
             )
+            return replayed_evidence
         request_date = date.today()
         midpoint = route[len(route) // 2]
         result = normalize_heatmap_response(
@@ -282,7 +295,7 @@ def build_live_hotel_heat_analysis_service(
             else ()
         )
         coverage = result.polygon_lookup(_bbox_geometry(district)).coverage
-        return ComponentEvidence(
+        evidence = ComponentEvidence(
             component,
             tuple(result._spatial_tiles()),
             units,
@@ -303,7 +316,12 @@ def build_live_hotel_heat_analysis_service(
                     for item in result.provenance.transformations
                 ],
             },
+            correlation_key="shared-date-tcm" if analytic is AnalyticType.TCM else None,
         )
+        if analytic is AnalyticType.TCM:
+            with shared_tcm_lock:
+                shared_tcm["evidence"] = evidence
+        return evidence
 
     return HotelHeatAnalysisService(
         lambda: _live_discovery_with_fixture(

--- a/app/wiring.py
+++ b/app/wiring.py
@@ -12,7 +12,8 @@ from datetime import date, datetime, timezone
 import json
 import logging
 from pathlib import Path
-from typing import Mapping, Sequence
+from dataclasses import replace
+from typing import Callable, Mapping, Sequence
 
 from fastapi import FastAPI
 from shapely.geometry.base import BaseGeometry
@@ -20,8 +21,9 @@ from shapely.geometry.base import BaseGeometry
 from app.api import create_app
 from app.domain.contracts import ExecutionMode, TripAnalysisAdapter
 from app.domain.hotel_heat_score import ComponentEvidence
-from app.domain.hotels import BoundingBox
+from app.domain.hotels import BoundingBox, DiscoveryState, HotelDiscoveryResult
 from app.domain.ledger import CreditLedger
+from app.domain.provenance import CacheKey
 from app.domain.security import sanitize_payload
 from app.integrations.fortyguard.client import FortyGuardClient
 from app.integrations.fortyguard.contracts import (
@@ -29,6 +31,7 @@ from app.integrations.fortyguard.contracts import (
     HeatmapRequest,
     normalize_heatmap_response,
 )
+from app.integrations.fortyguard.errors import ProviderError
 from app.integrations.fortyguard.live import (
     LiveAreaHeatmapAdapter,
     LiveEnvParamsAdapter,
@@ -36,6 +39,7 @@ from app.integrations.fortyguard.live import (
     LiveHeatmapAdapter,
 )
 from app.integrations.overpass.client import OverpassClient
+from app.integrations.overpass.errors import OverpassError
 from app.integrations.overpass.transport import HttpOverpassTransport
 from app.services.cache import CacheService
 from app.services.hotel_discovery import HotelDiscoveryService
@@ -118,6 +122,7 @@ def build_live_hotel_heat_analysis_service(
     *,
     client: FortyGuardClient,
     cache: CacheService | None = None,
+    fixture_path: Path | None = None,
 ) -> HotelHeatAnalysisService:
     """Compose four shared district analyses behind the hotel ranking boundary."""
     discovery = build_hotel_discovery_service(settings, cache=cache)
@@ -131,29 +136,105 @@ def build_live_hotel_heat_analysis_service(
         use_bounding_box=area.use_bounding_box,
     )
     route = _bbox_route(district)
+    fixture_service = (
+        build_fixture_hotel_heat_analysis_service(fixture_path, district_aoi=district)
+        if fixture_path is not None
+        else None
+    )
 
-    def load(component: str) -> ComponentEvidence:
+    def load(component: str) -> ComponentEvidence | None:
         analytic = (
             AnalyticType.TCM
             if component in {"night", "day"}
             else (AnalyticType.EXCEEDANCE if component == "hot_hours" else AnalyticType.PERSISTENCE)
         )
-        payload = adapter.load(
-            route,
-            analytic_type=analytic,
-            start_date=date.today(),
-            forecast=True,
-            threshold_celsius=35.0 if analytic is not AnalyticType.TCM else None,
-            direction="above" if analytic is not AnalyticType.TCM else None,
-            granularity=area.granularity,
-        )
+        try:
+            payload = adapter.load(
+                route,
+                analytic_type=analytic,
+                start_date=date.today(),
+                forecast=True,
+                threshold_celsius=35.0 if analytic is not AnalyticType.TCM else None,
+                direction="above" if analytic is not AnalyticType.TCM else None,
+                granularity=area.granularity,
+            )
+        except (ConnectionError, OSError, ProviderError, TimeoutError, ValueError):
+            if cache is not None:
+                midpoint = route[len(route) // 2]
+                request_date = date.today()
+                request = HeatmapRequest(
+                    analytic,
+                    midpoint[0],
+                    midpoint[1],
+                    request_date,
+                    True,
+                    35.0 if analytic is not AnalyticType.TCM else None,
+                    "above" if analytic is not AnalyticType.TCM else None,
+                    area.granularity,
+                )
+                cache_payload = {
+                    "analytic_type": analytic.value,
+                    "latitude": midpoint[0],
+                    "longitude": midpoint[1],
+                    "start_date": request_date.isoformat(),
+                    "forecast": True,
+                    "threshold_celsius": request.threshold_celsius,
+                    "direction": request.direction,
+                    "granularity": area.granularity,
+                }
+                cached = cache.get(
+                    CacheKey.create("/v1/heatmap", "v1", cache_payload, "fortyguard-config-v1")
+                )
+                if cached is not None:
+                    replayed = normalize_heatmap_response(
+                        cached.payload,
+                        request=request,
+                        retrieved_at=cached.provenance.retrieved_at,
+                        activity_id=cached.provenance.activity_id,
+                        source="cache",
+                        data_date=cached.provenance.data_date,
+                        stale=True,
+                    )
+                    return ComponentEvidence(
+                        component,
+                        tuple(replayed._spatial_tiles()),
+                        "C" if analytic is AnalyticType.TCM else "hours",
+                        request.threshold_celsius,
+                        "cache:fortyguard",
+                        float(area.granularity),
+                        caveats=("replayed cached evidence; stale",),
+                        provenance_details={
+                            "source": "cache",
+                            "retrieved_at": cached.provenance.retrieved_at.isoformat(),
+                            "data_date": cached.provenance.data_date,
+                            "stale": True,
+                            "forecast": cached.provenance.forecast,
+                            "activity_id": cached.provenance.activity_id,
+                            "transformations": [],
+                        },
+                    )
+            if fixture_service is None:
+                return None
+            fixture_evidence = fixture_service.load_component(component)
+            if fixture_evidence is None:
+                return None
+            details = dict(fixture_evidence.provenance_details or {})
+            details["stale"] = True
+            return replace(
+                fixture_evidence,
+                provenance="fixture:canonical-district-hotel-analysis",
+                caveats=fixture_evidence.caveats + ("replayed matching fixture evidence; stale",),
+                provenance_details=details,
+            )
+        request_date = date.today()
+        midpoint = route[len(route) // 2]
         result = normalize_heatmap_response(
             payload.payload,
             request=HeatmapRequest(
                 analytic,
-                sum(point[0] for point in route) / len(route),
-                sum(point[1] for point in route) / len(route),
-                date.today(),
+                midpoint[0],
+                midpoint[1],
+                request_date,
                 True,
                 35.0 if analytic is not AnalyticType.TCM else None,
                 "above" if analytic is not AnalyticType.TCM else None,
@@ -162,9 +243,30 @@ def build_live_hotel_heat_analysis_service(
             retrieved_at=datetime.now(timezone.utc),
             activity_id=payload.activity_id,
             source="provider",
-            data_date=date.today().isoformat(),
+            data_date=request_date.isoformat(),
             transformations=payload.transformations,
         )
+        if cache is not None:
+            cache.put(
+                "/v1/heatmap",
+                "v1",
+                {
+                    "analytic_type": analytic.value,
+                    "latitude": midpoint[0],
+                    "longitude": midpoint[1],
+                    "start_date": request_date.isoformat(),
+                    "forecast": True,
+                    "threshold_celsius": 35.0 if analytic is not AnalyticType.TCM else None,
+                    "direction": "above" if analytic is not AnalyticType.TCM else None,
+                    "granularity": area.granularity,
+                },
+                payload.payload,
+                retrieved_at=result.provenance.retrieved_at,
+                data_date=result.provenance.data_date,
+                activity_id=result.provenance.activity_id,
+                forecast=True,
+                provider_config_version="fortyguard-config-v1",
+            )
         units = "C" if analytic is AnalyticType.TCM else "hours"
         caveats = (
             (
@@ -204,12 +306,30 @@ def build_live_hotel_heat_analysis_service(
         )
 
     return HotelHeatAnalysisService(
-        discovery.discover,
+        lambda: _live_discovery_with_fixture(
+            discovery.discover, fixture_service.discover if fixture_service is not None else None
+        ),
         load,
         aoi=_bbox_geometry(district),
         supported_modes=frozenset({ExecutionMode.LIVE}),
         district_name="Downtown San Antonio",
     )
+
+
+def _live_discovery_with_fixture(
+    live: Callable[[], HotelDiscoveryResult], fallback: Callable[[], HotelDiscoveryResult] | None
+) -> HotelDiscoveryResult:
+    try:
+        result = live()
+        if result.state is not DiscoveryState.UNAVAILABLE:
+            return result
+    except (ConnectionError, OSError, OverpassError, ValueError):
+        if fallback is None:
+            raise
+    if fallback is None:
+        return result
+    replayed = fallback()
+    return replace(replayed, source="fixture", stale=True)
 
 
 def _bbox_route(bbox: BoundingBox) -> tuple[tuple[float, float], ...]:
@@ -333,7 +453,10 @@ def create_production_app(
     if hotel_heat_analysis_service is None:
         if resolved.allow_live:
             hotel_heat_analysis_service = build_live_hotel_heat_analysis_service(
-                resolved, client=client, cache=cache
+                resolved,
+                client=client,
+                cache=cache,
+                fixture_path=heatmap_fixture.parent / "hotel-heat-analysis.json",
             )
         else:
             hotel_heat_analysis_service = build_fixture_hotel_heat_analysis_service(

--- a/fixtures/hotel-heat-analysis.acquisition.json
+++ b/fixtures/hotel-heat-analysis.acquisition.json
@@ -1,0 +1,23 @@
+{
+  "source": "synthesized",
+  "endpoint": "local:canonical-district-hotel-analysis",
+  "request_configuration": {
+    "district_name": "Downtown San Antonio",
+    "aoi": {
+      "south": 29.421,
+      "west": -98.49,
+      "north": 29.429,
+      "east": -98.482
+    },
+    "components": ["night", "hot_hours", "persistence", "day"],
+    "threshold_celsius": 35,
+    "tile_resolution_m": 80
+  },
+  "retrieved_at": null,
+  "data_date": "2026-08-24",
+  "status": "complete",
+  "schema_version": "hotel-heat-analysis-v1",
+  "provider_config_version": "fortyguard-config-v1",
+  "activity_id": null,
+  "transformations": []
+}

--- a/fixtures/hotel-heat-analysis.json
+++ b/fixtures/hotel-heat-analysis.json
@@ -1,0 +1,412 @@
+{
+  "schema_version": "hotel-heat-analysis-v1",
+  "district_name": "Downtown San Antonio",
+  "aoi": {
+    "south": 29.421,
+    "west": -98.49,
+    "north": 29.429,
+    "east": -98.482
+  },
+  "hotel_discovery": {
+    "source": "fixture",
+    "source_timestamp": "2026-08-24T12:00:00-05:00",
+    "retrieved_at": null,
+    "stale": false,
+    "discovered_count": 7,
+    "hotels": [
+      {
+        "primary_identity": { "object_type": "node", "object_id": 110001 },
+        "source_identities": [{ "object_type": "node", "object_id": 110001 }],
+        "name": "Alamo Plaza Hotel",
+        "latitude": 29.425,
+        "longitude": -98.4896,
+        "address": { "street": "East Houston Street" },
+        "website": "https://example.test/alamo-plaza",
+        "operator": "Canonical Lodging"
+      },
+      {
+        "primary_identity": { "object_type": "way", "object_id": 220002 },
+        "source_identities": [{ "object_type": "way", "object_id": 220002 }],
+        "name": "River Walk House",
+        "latitude": 29.425,
+        "longitude": -98.488,
+        "address": { "street": "Navarro Street" },
+        "website": "https://example.test/river-walk"
+      },
+      {
+        "primary_identity": { "object_type": "relation", "object_id": 330003 },
+        "source_identities": [
+          { "object_type": "relation", "object_id": 330003 }
+        ],
+        "name": "Mission Courtyard Hotel",
+        "latitude": 29.425,
+        "longitude": -98.4864,
+        "address": { "street": "Losoya Street" },
+        "operator": "Mission Stays"
+      },
+      {
+        "primary_identity": { "object_type": "node", "object_id": 110004 },
+        "source_identities": [{ "object_type": "node", "object_id": 110004 }],
+        "name": "Commerce Street Inn",
+        "latitude": 29.425,
+        "longitude": -98.4848,
+        "address": { "street": "East Commerce Street" }
+      },
+      {
+        "primary_identity": { "object_type": "way", "object_id": 220005 },
+        "source_identities": [{ "object_type": "way", "object_id": 220005 }],
+        "name": "Hemisfair Hotel",
+        "latitude": 29.425,
+        "longitude": -98.4832,
+        "address": { "street": "Bowie Street" },
+        "website": "https://example.test/hemisfair"
+      },
+      {
+        "primary_identity": { "object_type": "node", "object_id": 110006 },
+        "source_identities": [{ "object_type": "node", "object_id": 110006 }],
+        "name": "Market Square Lodge",
+        "latitude": 29.425,
+        "longitude": -98.4824,
+        "address": { "street": "East Market Street" }
+      }
+    ]
+  },
+  "components": {
+    "night": {
+      "unit": "C",
+      "threshold_celsius": null,
+      "provenance": "fixture:canonical-district-night-tcm",
+      "tile_resolution_m": 80,
+      "grid_rows": 11,
+      "coverage": 0.96,
+      "caveats": [
+        "Night heat is a date-level historical analysis for 2026-08-24, not a forecast or a nightly climatology.",
+        "Hotel values share nominal 80 m tiles; hotels assigned the same tile retain ties."
+      ],
+      "tiles": [
+        {
+          "id": "night-01",
+          "bounds": [-98.49, 29.421, -98.4892, 29.429],
+          "value": 28.4,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-02",
+          "bounds": [-98.4892, 29.421, -98.4884, 29.429],
+          "value": 28.8,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-03",
+          "bounds": [-98.4884, 29.421, -98.4876, 29.429],
+          "value": 29.1,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-04",
+          "bounds": [-98.4876, 29.421, -98.4868, 29.429],
+          "value": 29.1,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-05",
+          "bounds": [-98.4868, 29.421, -98.486, 29.429],
+          "value": 29.7,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-06",
+          "bounds": [-98.486, 29.421, -98.4852, 29.429],
+          "value": 30.0,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-07",
+          "bounds": [-98.4852, 29.421, -98.4844, 29.429],
+          "value": 30.2,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-08",
+          "bounds": [-98.4844, 29.421, -98.4836, 29.429],
+          "value": 30.5,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-09",
+          "bounds": [-98.4836, 29.421, -98.4828, 29.429],
+          "value": 30.8,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "night-10",
+          "bounds": [-98.4828, 29.421, -98.482, 29.429],
+          "value": 30.8,
+          "valid_time": "2026-08-24T02:00:00-05:00",
+          "forecast": false
+        }
+      ]
+    },
+    "hot_hours": {
+      "unit": "hours",
+      "threshold_celsius": 35,
+      "provenance": "fixture:canonical-district-exceedance-above-35C",
+      "tile_resolution_m": 80,
+      "grid_rows": 11,
+      "coverage": 0.94,
+      "caveats": [
+        "Hot hours counts hours above 35 C on the historical date 2026-08-24; it is not a multi-day average.",
+        "Coverage is district-analysis coverage and does not imply building-level conditions."
+      ],
+      "tiles": [
+        {
+          "id": "hot-hours-01",
+          "bounds": [-98.49, 29.421, -98.4892, 29.429],
+          "value": 3,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-02",
+          "bounds": [-98.4892, 29.421, -98.4884, 29.429],
+          "value": 4,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-03",
+          "bounds": [-98.4884, 29.421, -98.4876, 29.429],
+          "value": 4,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-04",
+          "bounds": [-98.4876, 29.421, -98.4868, 29.429],
+          "value": 5,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-05",
+          "bounds": [-98.4868, 29.421, -98.486, 29.429],
+          "value": 6,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-06",
+          "bounds": [-98.486, 29.421, -98.4852, 29.429],
+          "value": 6,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-07",
+          "bounds": [-98.4852, 29.421, -98.4844, 29.429],
+          "value": 7,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-08",
+          "bounds": [-98.4844, 29.421, -98.4836, 29.429],
+          "value": 8,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-09",
+          "bounds": [-98.4836, 29.421, -98.4828, 29.429],
+          "value": 8,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "hot-hours-10",
+          "bounds": [-98.4828, 29.421, -98.482, 29.429],
+          "value": 9,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        }
+      ]
+    },
+    "persistence": {
+      "unit": "hours",
+      "threshold_celsius": 35,
+      "provenance": "fixture:canonical-district-persistence-above-35C",
+      "tile_resolution_m": 80,
+      "grid_rows": 11,
+      "coverage": 0.93,
+      "caveats": [
+        "Persistence is the longest consecutive run above 35 C on 2026-08-24, not persistence across dates.",
+        "The date-level duration should not be read as a forecast for the selected trip date."
+      ],
+      "tiles": [
+        {
+          "id": "persistence-01",
+          "bounds": [-98.49, 29.421, -98.4892, 29.429],
+          "value": 2,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-02",
+          "bounds": [-98.4892, 29.421, -98.4884, 29.429],
+          "value": 2,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-03",
+          "bounds": [-98.4884, 29.421, -98.4876, 29.429],
+          "value": 3,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-04",
+          "bounds": [-98.4876, 29.421, -98.4868, 29.429],
+          "value": 4,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-05",
+          "bounds": [-98.4868, 29.421, -98.486, 29.429],
+          "value": 4,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-06",
+          "bounds": [-98.486, 29.421, -98.4852, 29.429],
+          "value": 5,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-07",
+          "bounds": [-98.4852, 29.421, -98.4844, 29.429],
+          "value": 5,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-08",
+          "bounds": [-98.4844, 29.421, -98.4836, 29.429],
+          "value": 6,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-09",
+          "bounds": [-98.4836, 29.421, -98.4828, 29.429],
+          "value": 7,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        },
+        {
+          "id": "persistence-10",
+          "bounds": [-98.4828, 29.421, -98.482, 29.429],
+          "value": 7,
+          "valid_time": "2026-08-24",
+          "forecast": false
+        }
+      ]
+    },
+    "day": {
+      "unit": "C",
+      "threshold_celsius": null,
+      "provenance": "fixture:canonical-district-day-tcm",
+      "tile_resolution_m": 80,
+      "grid_rows": 11,
+      "coverage": 0.95,
+      "caveats": [
+        "Day heat is a date-level historical snapshot at 15:00 local time on 2026-08-24, not a daily maximum.",
+        "Day and night snapshots describe their explicit times only and must not be generalized to other dates."
+      ],
+      "tiles": [
+        {
+          "id": "day-01",
+          "bounds": [-98.49, 29.421, -98.4892, 29.429],
+          "value": 36.2,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-02",
+          "bounds": [-98.4892, 29.421, -98.4884, 29.429],
+          "value": 36.8,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-03",
+          "bounds": [-98.4884, 29.421, -98.4876, 29.429],
+          "value": 37.1,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-04",
+          "bounds": [-98.4876, 29.421, -98.4868, 29.429],
+          "value": 37.5,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-05",
+          "bounds": [-98.4868, 29.421, -98.486, 29.429],
+          "value": 37.5,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-06",
+          "bounds": [-98.486, 29.421, -98.4852, 29.429],
+          "value": 38.0,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-07",
+          "bounds": [-98.4852, 29.421, -98.4844, 29.429],
+          "value": 38.4,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-08",
+          "bounds": [-98.4844, 29.421, -98.4836, 29.429],
+          "value": 38.8,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-09",
+          "bounds": [-98.4836, 29.421, -98.4828, 29.429],
+          "value": 39.1,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        },
+        {
+          "id": "day-10",
+          "bounds": [-98.4828, 29.421, -98.482, 29.429],
+          "value": 39.1,
+          "valid_time": "2026-08-24T15:00:00-05:00",
+          "forecast": false
+        }
+      ]
+    }
+  }
+}

--- a/frontend/src/app/AppState.tsx
+++ b/frontend/src/app/AppState.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import type {
   CuratedTripSetup,
-  HotelResponse,
+  HotelRankResponse,
   LocationSelection,
   MockMode,
   TripResponse,
@@ -19,7 +19,7 @@ type AppState = {
   walkDate: string;
   trip: TripResponse | null;
   hotelLocation: LocationSelection | null;
-  ranking: HotelResponse | null;
+  ranking: HotelRankResponse | null;
   mode: MockMode;
   tripAnalysis: TripAnalysisResponse | null;
   curatedTripSetup: CuratedTripSetup;
@@ -29,7 +29,7 @@ type AppContextValue = AppState & {
   setWalkDate: (value: string) => void;
   setTrip: (value: TripResponse | null) => void;
   setHotelLocation: (value: LocationSelection) => void;
-  setRanking: (value: HotelResponse | null) => void;
+  setRanking: (value: HotelRankResponse | null) => void;
   setMode: (value: MockMode) => void;
   setTripAnalysis: (value: TripAnalysisResponse | null) => void;
   setCuratedTripSetup: (value: CuratedTripSetup) => void;

--- a/frontend/src/components/Shared.tsx
+++ b/frontend/src/components/Shared.tsx
@@ -32,14 +32,21 @@ export function LocationPicker({
   title,
   description,
   onContinue,
+  locations,
+  allowMapSelection = true,
 }: {
   title: string;
   description: string;
   onContinue: (location: LocationSelection) => void;
+  locations?: LocationSelection[];
+  allowMapSelection?: boolean;
 }) {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<LocationSelection | null>(null);
-  const results = useMemo(() => dataClient.searchLocations(query), [query]);
+  const results = useMemo(
+    () => dataClient.searchLocations(query, locations),
+    [locations, query]
+  );
   const center: [number, number] = selected
     ? [selected.latitude, selected.longitude]
     : [29.8, -95.5];
@@ -102,7 +109,7 @@ export function LocationPicker({
               attribution="&copy; OpenStreetMap contributors"
               url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
-            <MapClick onSelect={setSelected} />
+            {allowMapSelection && <MapClick onSelect={setSelected} />}
             {selected && (
               <CircleMarker
                 center={[selected.latitude, selected.longitude]}
@@ -115,9 +122,11 @@ export function LocationPicker({
               />
             )}
           </MapContainer>
-          <span className="map-hint">
-            Click anywhere on the map to set a custom point.
-          </span>
+          {allowMapSelection && (
+            <span className="map-hint">
+              Click anywhere on the map to set a custom point.
+            </span>
+          )}
         </div>
       </div>
       <div className="selection-bar">
@@ -131,7 +140,11 @@ export function LocationPicker({
           ) : (
             <>
               <span>No place selected</span>
-              <strong>Search or click the map to continue</strong>
+              <strong>
+                {allowMapSelection
+                  ? "Search or click the map to continue"
+                  : "Search to continue"}
+              </strong>
             </>
           )}
         </div>

--- a/frontend/src/features/hotels/HotelScreens.test.tsx
+++ b/frontend/src/features/hotels/HotelScreens.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppProvider, useAppState } from "../../app/AppState";
+import { mockHotelRanking } from "../../mocks/mockHotelRanking";
+import { scenarioLocations } from "../../mocks/data";
+import { HotelDetailScreen, HotelRankingScreen } from "./HotelScreens";
+
+function HotelRankingHarness() {
+  const { hotelLocation, setHotelLocation } = useAppState();
+  useEffect(() => setHotelLocation(scenarioLocations[0]), []);
+  return hotelLocation ? <HotelRankingScreen /> : null;
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("hotel ranking screens", () => {
+  it("loads the backend contract and displays district and assignment evidence", async () => {
+    vi.useFakeTimers();
+    const pending = mockHotelRanking(scenarioLocations[0]);
+    await vi.advanceTimersByTimeAsync(1400);
+    const response = await pending;
+    vi.useRealTimers();
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(
+          jsonResponse(
+            url === "/health" ? { status: "ok", mode: "fixture" } : response
+          )
+        )
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    window.history.replaceState({}, "", "/hotels/results");
+    const user = userEvent.setup();
+
+    render(
+      <BrowserRouter>
+        <AppProvider>
+          <Routes>
+            <Route path="/hotels/results" element={<HotelRankingHarness />} />
+            <Route path="/hotels/:hotelId" element={<HotelDetailScreen />} />
+          </Routes>
+        </AppProvider>
+      </BrowserRouter>
+    );
+
+    expect(await screen.findByText("Component evidence")).toBeInTheDocument();
+    expect(
+      screen.getByText("Current weighting: product defaults")
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("94%").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        "Candidate-relative evidence; not an absolute heat score."
+      ).length
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("°C").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("hours").length).toBeGreaterThan(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/hotels/rank",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          district_name: "Downtown San Antonio",
+          execution_mode: "fixture",
+        }),
+      })
+    );
+
+    for (const [label, value] of [
+      ["Night heat weight", "100"],
+      ["Hot hours weight", "0"],
+      ["Persistence weight", "0"],
+      ["Day heat weight", "0"],
+    ] as const) {
+      const input = screen.getByLabelText(label);
+      await user.clear(input);
+      await user.type(input, value);
+    }
+    await user.click(
+      screen.getByRole("button", { name: "Apply local weights" })
+    );
+    expect(screen.getByText("Current weighting: custom")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await user.click(
+      screen.getByRole("link", { name: "View details for Canopy House" })
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Assignment quality")).toHaveLength(4)
+    );
+    expect(screen.getAllByText("containing tile")).toHaveLength(4);
+    expect(screen.getAllByText("80 m")).toHaveLength(4);
+    expect(
+      screen.getByText(
+        "Dimensionless percentile aggregate; no mixed-unit raw values are summed."
+      )
+    ).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/features/hotels/HotelScreens.test.tsx
+++ b/frontend/src/features/hotels/HotelScreens.test.tsx
@@ -102,9 +102,10 @@ describe("hotel ranking screens", () => {
       screen.getByRole("link", { name: "View details for Canopy House" })
     );
 
-    await waitFor(() =>
-      expect(screen.getAllByText("Assignment quality")).toHaveLength(4)
-    );
+    await waitFor(() => {
+      expect(screen.getAllByText("Assignment quality")).toHaveLength(4);
+      expect(screen.getAllByText("Confidence")).toHaveLength(4);
+    });
     expect(screen.getAllByText("containing tile")).toHaveLength(4);
     expect(screen.getAllByText("80 m")).toHaveLength(4);
     expect(

--- a/frontend/src/features/hotels/HotelScreens.tsx
+++ b/frontend/src/features/hotels/HotelScreens.tsx
@@ -3,18 +3,27 @@ import {
   Hotel as HotelIcon,
   SlidersHorizontal,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
 import { useAppState } from "../../app/AppState";
 import {
   DegradedNotice,
   LocationPicker,
-  ProvenanceFooter,
   ResultProblem,
   ResultSkeleton,
 } from "../../components/Shared";
 import { dataClient } from "../../services/dataClient";
-import type { Hotel, ResultState } from "../../types";
+import type {
+  HotelComponentAssignment,
+  HotelComponentName,
+  HotelRankingHotel,
+  ResultState,
+} from "../../types";
+import {
+  HOTEL_COMPONENT_LABELS,
+  HOTEL_COMPONENTS,
+  rerankHotels,
+} from "./rerankHotels";
 
 export function HotelLocationScreen() {
   const navigate = useNavigate();
@@ -33,27 +42,52 @@ export function HotelLocationScreen() {
 
 function useHotelRequest() {
   const { hotelLocation, mode, ranking, setRanking } = useAppState();
+  const requestedLocation = useRef<string | null>(null);
+  const requestVersion = useRef(0);
   const [status, setStatus] = useState<ResultState>(
-    ranking ? (mode === "degraded" ? "degraded" : "success") : "loading"
+    ranking
+      ? ranking.state === "available"
+        ? "success"
+        : "degraded"
+      : "loading"
   );
   const load = useCallback(() => {
-    if (!hotelLocation) return;
+    const previewMode = new URLSearchParams(window.location.search).has(
+      "state"
+    );
+    const requestKey = hotelLocation
+      ? `${hotelLocation.id}:${previewMode ? mode : "api"}`
+      : null;
+    if (!hotelLocation || requestedLocation.current === requestKey) {
+      return;
+    }
+    const version = ++requestVersion.current;
+    requestedLocation.current = requestKey;
     setStatus("loading");
     dataClient
-      .rankHotels(hotelLocation, { mode })
+      .rankHotels(hotelLocation, previewMode ? { mode } : {})
       .then((value) => {
-        setRanking(value);
-        setStatus(
-          mode === "degraded"
-            ? "degraded"
-            : value.usableCount < 5
-              ? "degraded"
-              : "success"
-        );
+        if (requestVersion.current !== version) return;
+        const withPercentiles = value.ranking
+          ? rerankHotels(
+              value,
+              value.ranking.weights,
+              value.ranking.weight_label
+            )
+          : value;
+        setRanking(withPercentiles);
+        setStatus(value.state === "available" ? "success" : "degraded");
       })
-      .catch((error: Error & { code?: string }) =>
-        setStatus(error.code === "EMPTY" ? "empty" : "error")
-      );
+      .catch((error: Error & { code?: string }) => {
+        if (requestVersion.current !== version) return;
+        requestedLocation.current = null;
+        setStatus(error.code === "EMPTY" ? "empty" : "error");
+      })
+      .finally(() => {
+        if (requestVersion.current === version) {
+          requestedLocation.current = null;
+        }
+      });
   }, [hotelLocation, mode, setRanking]);
   useEffect(() => {
     if (!ranking) load();
@@ -61,31 +95,197 @@ function useHotelRequest() {
   return { status, ranking, load };
 }
 
-function HotelComponents({ hotel }: { hotel: Hotel }) {
+function formatValue(component: HotelComponentAssignment) {
+  return component.value === null
+    ? "Unavailable"
+    : `${component.value.toFixed(1)} ${component.unit === "C" ? "°C" : component.unit}`;
+}
+
+function HotelComponents({ hotel }: { hotel: HotelRankingHotel }) {
   return (
     <div className="component-list">
-      {hotel.components.map((component) => (
-        <div key={component.label}>
-          <span>{component.label}</span>
-          <strong>{component.value.toFixed(1)}</strong>
-        </div>
-      ))}
+      {HOTEL_COMPONENTS.map((name) => {
+        const component = hotel.components[name];
+        return (
+          <div key={name}>
+            <span>{HOTEL_COMPONENT_LABELS[name]}</span>
+            <strong>{formatValue(component)}</strong>
+            <small>
+              {component.percentile === null
+                ? "Not ranked"
+                : `${Math.round(component.percentile)}th component percentile`}
+            </small>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
+function WeightEditor({
+  initialWeights,
+  onApply,
+}: {
+  initialWeights: Record<HotelComponentName, number>;
+  onApply: (weights: Record<HotelComponentName, number>) => void;
+}) {
+  const defaults = Object.fromEntries(
+    HOTEL_COMPONENTS.map((name) => [name, initialWeights[name] * 100])
+  ) as Record<HotelComponentName, number>;
+  const [weights, setWeights] = useState(defaults);
+  const total = HOTEL_COMPONENTS.reduce((sum, name) => sum + weights[name], 0);
+
+  function apply() {
+    if (total !== 100) return;
+    onApply(
+      Object.fromEntries(
+        HOTEL_COMPONENTS.map((name) => [name, weights[name] / 100])
+      ) as Record<HotelComponentName, number>
+    );
+  }
+
+  return (
+    <div className="weight-editor">
+      <div className="section-title">
+        <div>
+          <span>Local preferences</span>
+          <h2>Rerank the candidate set</h2>
+        </div>
+        <strong className={total === 100 ? "valid-total" : "invalid-total"}>
+          {total}% total
+        </strong>
+      </div>
+      {HOTEL_COMPONENTS.map((name) => (
+        <label key={name}>
+          <span>
+            <strong>{HOTEL_COMPONENT_LABELS[name]}</strong>
+            <small>Candidate-relative component percentile</small>
+          </span>
+          <input
+            aria-label={`${HOTEL_COMPONENT_LABELS[name]} weight`}
+            type="number"
+            min="0"
+            max="100"
+            value={weights[name]}
+            onChange={(event) =>
+              setWeights((current) => ({
+                ...current,
+                [name]: Math.max(0, Number(event.target.value)),
+              }))
+            }
+          />
+          <span>%</span>
+        </label>
+      ))}
+      <div className="weight-actions">
+        <button type="button" disabled={total !== 100} onClick={apply}>
+          Apply local weights
+        </button>
+        <button
+          className="secondary-button"
+          type="button"
+          onClick={() => {
+            setWeights(defaults);
+            onApply(initialWeights);
+          }}
+        >
+          Reset product defaults
+        </button>
+      </div>
+      {total !== 100 && (
+        <p className="validation-message" role="alert">
+          Weights must total 100% before reranking.
+        </p>
+      )}
+      <small>
+        Reranking uses cached component percentiles for every candidate and does
+        not request another provider analysis.
+      </small>
+    </div>
+  );
+}
+
+function EvidenceSummary({
+  ranking,
+}: {
+  ranking: NonNullable<ReturnType<typeof useHotelRequest>["ranking"]>;
+}) {
+  return (
+    <section className="evidence-summary" aria-labelledby="evidence-heading">
+      <div className="section-title">
+        <div>
+          <span>Shared district analyses</span>
+          <h2 id="evidence-heading">Component evidence</h2>
+        </div>
+      </div>
+      <div className="evidence-grid">
+        {HOTEL_COMPONENTS.map((name) => {
+          const component = ranking.components[name];
+          if (!component) return null;
+          return (
+            <article key={name}>
+              <h3>{HOTEL_COMPONENT_LABELS[name]}</h3>
+              <dl>
+                <div>
+                  <dt>Unit</dt>
+                  <dd>{component.unit === "C" ? "°C" : component.unit}</dd>
+                </div>
+                {component.threshold_celsius !== null && (
+                  <div>
+                    <dt>Threshold</dt>
+                    <dd>{component.threshold_celsius} °C</dd>
+                  </div>
+                )}
+                <div>
+                  <dt>Coverage</dt>
+                  <dd>
+                    {component.coverage === null
+                      ? "Not reported"
+                      : `${Math.round(component.coverage * 100)}%`}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Confidence</dt>
+                  <dd>{component.confidence ?? "Not reported"}</dd>
+                </div>
+                <div>
+                  <dt>Provenance</dt>
+                  <dd>{component.provenance ?? "Unavailable"}</dd>
+                </div>
+              </dl>
+              {component.provenance_details && (
+                <p>
+                  Data date:{" "}
+                  {String(component.provenance_details.data_date ?? "unknown")};
+                  source:{" "}
+                  {String(component.provenance_details.source ?? "unknown")}
+                </p>
+              )}
+              {component.caveats.map((caveat) => (
+                <p key={caveat}>{caveat}</p>
+              ))}
+              {component.missing_reason && <p>{component.missing_reason}</p>}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 export function HotelRankingScreen() {
-  const { hotelLocation } = useAppState();
+  const { hotelLocation, setRanking } = useAppState();
   const { status, ranking, load } = useHotelRequest();
   if (!hotelLocation) return <Navigate to="/hotels/location" replace />;
+  const result = ranking?.ranking;
   return (
     <section className="screen result-screen">
       <div className="screen-heading compact">
         <span className="step-label">Hotel ranking</span>
-        <h1>{hotelLocation.name}</h1>
+        <h1>{ranking?.district_name ?? hotelLocation.name}</h1>
         <p>
-          Lower component values rank ahead under the displayed product
-          weighting.
+          Lower candidate-relative exposure ranks ahead. This is not an absolute
+          objective score.
         </p>
       </div>
       {status === "loading" && <ResultSkeleton rows={5} />}
@@ -96,47 +296,87 @@ export function HotelRankingScreen() {
         <>
           {status === "degraded" && (
             <DegradedNotice>
-              Fewer than five hotels or incomplete coverage makes this ranking
-              less representative.
+              {ranking.reason ??
+                "Coverage is insufficient for a representative ranking."}
             </DegradedNotice>
           )}
-          <article className="weights-summary">
-            <SlidersHorizontal size={20} />
-            <div>
-              <strong>Current weighting configuration</strong>
-              <p>
-                {Object.entries(ranking.weights)
-                  .map(([name, weight]) => `${name} ${weight}%`)
-                  .join(" · ")}
-              </p>
-            </div>
-          </article>
-          <div className="hotel-list">
-            {ranking.hotels.map((hotel, index) => (
-              <article className="hotel-card" key={hotel.id}>
-                <span className="rank-number">{index + 1}</span>
-                <div className="hotel-main">
-                  <div>
-                    <h2>{hotel.name}</h2>
-                    <p>
-                      {hotel.percentile}th percentile for lower modeled exposure
-                    </p>
-                    {hotel.tieLabel && (
-                      <span className="tie-chip">{hotel.tieLabel}</span>
-                    )}
-                  </div>
-                  <HotelComponents hotel={hotel} />
+          {result && (
+            <>
+              <article className="weights-summary">
+                <SlidersHorizontal size={20} />
+                <div>
+                  <strong>Current weighting: {result.weight_label}</strong>
+                  <p>
+                    {HOTEL_COMPONENTS.map(
+                      (name) =>
+                        `${HOTEL_COMPONENT_LABELS[name]} ${Math.round(result.weights[name] * 100)}%`
+                    ).join(" · ")}
+                  </p>
                 </div>
-                <Link
-                  aria-label={`View details for ${hotel.name}`}
-                  to={`/hotels/${hotel.id}`}
-                >
-                  <ArrowRight size={20} />
-                </Link>
               </article>
-            ))}
-          </div>
-          <ProvenanceFooter value={ranking.provenance} />
+              <WeightEditor
+                initialWeights={{
+                  night: 0.35,
+                  hot_hours: 0.25,
+                  persistence: 0.2,
+                  day: 0.2,
+                }}
+                onApply={(weights) =>
+                  setRanking(
+                    rerankHotels(
+                      ranking,
+                      weights,
+                      weights.night === 0.35 &&
+                        weights.hot_hours === 0.25 &&
+                        weights.persistence === 0.2 &&
+                        weights.day === 0.2
+                        ? "product defaults"
+                        : "custom"
+                    )
+                  )
+                }
+              />
+              <div className="hotel-list">
+                {result.hotels.map((hotel) => {
+                  const id = `${hotel.identity.object_type}-${hotel.identity.object_id}`;
+                  const tied =
+                    result.hotels.filter(
+                      (candidate) =>
+                        candidate.rank !== null && candidate.rank === hotel.rank
+                    ).length > 1;
+                  return (
+                    <article className="hotel-card" key={id}>
+                      <span className="rank-number">{hotel.rank ?? "–"}</span>
+                      <div className="hotel-main">
+                        <div>
+                          <h2>{hotel.name}</h2>
+                          <p>
+                            {hotel.relative_percentile === null ||
+                            hotel.relative_percentile === undefined
+                              ? "Unranked: incomplete component evidence"
+                              : `${Math.round(hotel.relative_percentile)}th percentile for lower modeled exposure`}
+                          </p>
+                          {tied && (
+                            <span className="tie-chip">
+                              Tied at this position
+                            </span>
+                          )}
+                        </div>
+                        <HotelComponents hotel={hotel} />
+                      </div>
+                      <Link
+                        aria-label={`View details for ${hotel.name}`}
+                        to={`/hotels/${id}`}
+                      >
+                        <ArrowRight size={20} />
+                      </Link>
+                    </article>
+                  );
+                })}
+              </div>
+            </>
+          )}
+          <EvidenceSummary ranking={ranking} />
         </>
       )}
     </section>
@@ -146,85 +386,85 @@ export function HotelRankingScreen() {
 export function HotelDetailScreen() {
   const { ranking } = useAppState();
   const { hotelId } = useParams();
-  const hotel = ranking?.hotels.find((candidate) => candidate.id === hotelId);
-  const defaults = ranking?.weights ?? {};
-  const [weights, setWeights] = useState(defaults);
-  if (!ranking) return <Navigate to="/hotels/results" replace />;
-  if (!hotel) return <Navigate to="/hotels/results" replace />;
-  const total = Object.values(weights).reduce((sum, value) => sum + value, 0);
-  const weightedValue = useMemo(
-    () =>
-      hotel.components.reduce(
-        (sum, component) =>
-          sum + component.value * ((weights[component.label] ?? 0) / 100),
-        0
-      ),
-    [hotel, weights]
+  const hotel = ranking?.ranking?.hotels.find(
+    (candidate) =>
+      `${candidate.identity.object_type}-${candidate.identity.object_id}` ===
+      hotelId
   );
+  if (!ranking || !hotel) return <Navigate to="/hotels/results" replace />;
   return (
     <section className="screen narrow-screen">
       <div className="screen-heading">
-        <span className="step-label">Hotel detail</span>
+        <span className="step-label">Hotel evidence</span>
         <h1>{hotel.name}</h1>
         <p>
-          {hotel.percentile}th percentile under the default product preferences.{" "}
-          {hotel.tieLabel}
+          {hotel.rank === null
+            ? "Unranked because component evidence is incomplete."
+            : `Rank ${hotel.rank} within this candidate set under ${ranking.ranking?.weight_label}.`}
         </p>
       </div>
       <article className="local-score">
         <HotelIcon size={25} />
         <div>
-          <span>Locally weighted comparison value</span>
-          <strong>{weightedValue.toFixed(1)}</strong>
+          <span>Relative aggregate</span>
+          <strong>
+            {hotel.relative_aggregate?.toFixed(3) ?? "Unavailable"}
+          </strong>
           <small>
-            Lower is better within this returned hotel set; this is not an
-            objective score.
+            Dimensionless percentile aggregate; no mixed-unit raw values are
+            summed.
           </small>
         </div>
       </article>
-      <div className="weight-editor">
-        <div className="section-title">
-          <div>
-            <span>Local preferences</span>
-            <h2>Adjust component weights</h2>
-          </div>
-          <strong className={total === 100 ? "valid-total" : "invalid-total"}>
-            {total}% total
-          </strong>
-        </div>
-        {hotel.components.map((component) => (
-          <label key={component.label}>
-            <span>
-              <strong>{component.label}</strong>
-              <small>Raw component value: {component.value.toFixed(1)}</small>
-            </span>
-            <input
-              type="number"
-              min="0"
-              max="100"
-              value={weights[component.label] ?? 0}
-              onChange={(event) =>
-                setWeights((current) => ({
-                  ...current,
-                  [component.label]: Number(event.target.value),
-                }))
-              }
-            />
-            <span>%</span>
-          </label>
-        ))}
-        <button
-          className="secondary-button"
-          type="button"
-          onClick={() => setWeights(defaults)}
-        >
-          Reset defaults
-        </button>
-        {total !== 100 && (
-          <p className="validation-message">
-            Weights must total 100% for a comparable result.
-          </p>
-        )}
+      <div className="assignment-evidence">
+        {HOTEL_COMPONENTS.map((name) => {
+          const component = hotel.components[name];
+          return (
+            <article key={name}>
+              <h2>{HOTEL_COMPONENT_LABELS[name]}</h2>
+              <strong>{formatValue(component)}</strong>
+              <dl>
+                <div>
+                  <dt>Assignment quality</dt>
+                  <dd>{component.quality.replaceAll("_", " ")}</dd>
+                </div>
+                <div>
+                  <dt>Tile resolution</dt>
+                  <dd>{component.tile_resolution_m} m</dd>
+                </div>
+                <div>
+                  <dt>Distance</dt>
+                  <dd>
+                    {component.distance_m === null
+                      ? "Not reported"
+                      : `${component.distance_m} m`}
+                  </dd>
+                </div>
+                {component.threshold_celsius !== null && (
+                  <div>
+                    <dt>Threshold</dt>
+                    <dd>{component.threshold_celsius} °C</dd>
+                  </div>
+                )}
+                <div>
+                  <dt>Coverage</dt>
+                  <dd>
+                    {component.coverage === null
+                      ? "Not reported"
+                      : `${Math.round(component.coverage * 100)}%`}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Provenance</dt>
+                  <dd>{component.provenance}</dd>
+                </div>
+              </dl>
+              {component.caveats?.map((caveat) => (
+                <p key={caveat}>{caveat}</p>
+              ))}
+            </article>
+          );
+        })}
       </div>
       <Link className="text-link" to="/hotels/results">
         Return to hotel ranking

--- a/frontend/src/features/hotels/HotelScreens.tsx
+++ b/frontend/src/features/hotels/HotelScreens.tsx
@@ -13,6 +13,7 @@ import {
   ResultSkeleton,
 } from "../../components/Shared";
 import { dataClient } from "../../services/dataClient";
+import { hotelLocations } from "../../mocks/data";
 import type {
   HotelComponentAssignment,
   HotelComponentName,
@@ -32,6 +33,8 @@ export function HotelLocationScreen() {
     <LocationPicker
       title="Where should hotels be ranked?"
       description="Choose the area whose nearby hotels you want to compare by outdoor heat exposure."
+      locations={hotelLocations}
+      allowMapSelection={false}
       onContinue={(location) => {
         setHotelLocation(location);
         navigate("/hotels/results");

--- a/frontend/src/features/hotels/HotelScreens.tsx
+++ b/frontend/src/features/hotels/HotelScreens.tsx
@@ -455,6 +455,18 @@ export function HotelDetailScreen() {
                   </dd>
                 </div>
                 <div>
+                  <dt>Confidence</dt>
+                  <dd>
+                    {component.coverage === null
+                      ? "Not reported"
+                      : component.coverage >= 0.95
+                        ? "High"
+                        : component.coverage >= 0.7
+                          ? "Limited"
+                          : "Insufficient"}
+                  </dd>
+                </div>
+                <div>
                   <dt>Provenance</dt>
                   <dd>{component.provenance}</dd>
                 </div>

--- a/frontend/src/features/hotels/rerankHotels.test.ts
+++ b/frontend/src/features/hotels/rerankHotels.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import type {
+  HotelComponentName,
+  HotelRankResponse,
+  HotelRankingHotel,
+} from "../../types";
+import { HOTEL_COMPONENTS, rerankHotels } from "./rerankHotels";
+
+function hotel(
+  id: number,
+  name: string,
+  percentiles: Record<HotelComponentName, number | null>
+): HotelRankingHotel {
+  return {
+    identity: { object_type: "node", object_id: id },
+    name,
+    complete: Object.values(percentiles).every((value) => value !== null),
+    relative_aggregate: null,
+    rank: null,
+    components: Object.fromEntries(
+      HOTEL_COMPONENTS.map((component) => [
+        component,
+        {
+          component,
+          value: percentiles[component],
+          unit: component === "night" || component === "day" ? "C" : "hours",
+          threshold_celsius:
+            component === "hot_hours" || component === "persistence"
+              ? 35
+              : null,
+          provenance: "fixture",
+          tile_id: `${component}-${id}`,
+          tile_resolution_m: 80,
+          quality: "containing_tile",
+          distance_m: 0,
+          coverage: 1,
+          confidence: "high",
+          caveats: [],
+          percentile: percentiles[component],
+        },
+      ])
+    ) as unknown as HotelRankingHotel["components"],
+  };
+}
+
+const response: HotelRankResponse = {
+  state: "available",
+  district_name: "Downtown",
+  execution_mode: "fixture",
+  reason: null,
+  discovered_count: 6,
+  usable_count: 6,
+  components: {},
+  ranking: {
+    weights: { night: 0.35, hot_hours: 0.25, persistence: 0.2, day: 0.2 },
+    weight_label: "product defaults",
+    complete_candidate_count: 5,
+    ranked_output: true,
+    hotels: [
+      hotel(1, "Night winner", {
+        night: 100,
+        hot_hours: 0,
+        persistence: 0,
+        day: 0,
+      }),
+      hotel(2, "Day winner", {
+        night: 0,
+        hot_hours: 0,
+        persistence: 0,
+        day: 100,
+      }),
+      hotel(3, "Tie one", {
+        night: 50,
+        hot_hours: 50,
+        persistence: 50,
+        day: 50,
+      }),
+      hotel(4, "Tie two", {
+        night: 50,
+        hot_hours: 50,
+        persistence: 50,
+        day: 50,
+      }),
+      hotel(5, "Middle", {
+        night: 25,
+        hot_hours: 25,
+        persistence: 25,
+        day: 25,
+      }),
+      hotel(6, "Incomplete", {
+        night: null,
+        hot_hours: 100,
+        persistence: 100,
+        day: 100,
+      }),
+    ],
+  },
+};
+
+describe("local hotel reranking", () => {
+  it("reranks the whole complete candidate set and preserves ties", () => {
+    const ranked = rerankHotels(response, {
+      night: 1,
+      hot_hours: 0,
+      persistence: 0,
+      day: 0,
+    });
+
+    expect(ranked.ranking?.hotels.map((candidate) => candidate.name)).toEqual([
+      "Night winner",
+      "Tie one",
+      "Tie two",
+      "Middle",
+      "Day winner",
+      "Incomplete",
+    ]);
+    expect(ranked.ranking?.hotels.map((candidate) => candidate.rank)).toEqual([
+      1,
+      2,
+      2,
+      4,
+      5,
+      null,
+    ]);
+    expect(
+      ranked.ranking?.hotels.map((candidate) => candidate.relative_percentile)
+    ).toEqual([
+      100,
+      100 * (1 - 1 / 3),
+      100 * (1 - 1 / 3),
+      100 * (1 - 2 / 3),
+      0,
+      null,
+    ]);
+    expect(ranked.ranking?.hotels[0].relative_aggregate).toBe(0);
+    expect(ranked.ranking?.hotels[4].relative_aggregate).toBe(1);
+    expect(ranked.ranking?.weight_label).toBe("custom");
+  });
+
+  it("keeps fewer than five complete candidates explicitly unranked", () => {
+    const unavailable = {
+      ...response,
+      state: "unavailable" as const,
+      ranking: response.ranking
+        ? { ...response.ranking, hotels: response.ranking.hotels.slice(0, 4) }
+        : null,
+    };
+
+    const ranked = rerankHotels(unavailable, {
+      night: 1,
+      hot_hours: 0,
+      persistence: 0,
+      day: 0,
+    });
+
+    expect(ranked.ranking?.ranked_output).toBe(false);
+    expect(
+      ranked.ranking?.hotels.every((candidate) => candidate.rank === null)
+    ).toBe(true);
+    expect(
+      ranked.ranking?.hotels.every(
+        (candidate) => candidate.relative_percentile === null
+      )
+    ).toBe(true);
+  });
+});

--- a/frontend/src/features/hotels/rerankHotels.ts
+++ b/frontend/src/features/hotels/rerankHotels.ts
@@ -36,15 +36,30 @@ export function rerankHotels(
       )
   );
   const aggregates = new Map(
-    complete.map((hotel) => [
-      identity(hotel),
-      Number(
-        HOTEL_COMPONENTS.reduce((total, component) => {
-          const percentile = hotel.components[component].percentile;
-          return total + (1 - (percentile ?? 0) / 100) * weights[component];
-        }, 0).toFixed(6)
-      ),
-    ])
+    complete.map((hotel) => {
+      const groups = new Map<string, [HotelComponentName, number]>();
+      HOTEL_COMPONENTS.forEach((component) => {
+        const key = hotel.components[component].correlation_key ?? component;
+        const current = groups.get(key);
+        if (!current) {
+          groups.set(key, [component, weights[component]]);
+        } else {
+          groups.set(key, [current[0], current[1] + weights[component]]);
+        }
+      });
+      const activeWeight = [...groups.values()].reduce(
+        (total, [, weight]) => total + weight,
+        0
+      );
+      const aggregate = [...groups.values()].reduce(
+        (total, [component, weight]) =>
+          total +
+          ((1 - (hotel.components[component].percentile ?? 0) / 100) * weight) /
+            activeWeight,
+        0
+      );
+      return [identity(hotel), Number(aggregate.toFixed(6))];
+    })
   );
   const aggregateValues = [...new Set(aggregates.values())].sort(
     (a, b) => a - b

--- a/frontend/src/features/hotels/rerankHotels.ts
+++ b/frontend/src/features/hotels/rerankHotels.ts
@@ -1,0 +1,112 @@
+import type {
+  HotelComponentName,
+  HotelRankResponse,
+  HotelRankingHotel,
+} from "../../types";
+
+export const HOTEL_COMPONENTS: HotelComponentName[] = [
+  "night",
+  "hot_hours",
+  "persistence",
+  "day",
+];
+
+export const HOTEL_COMPONENT_LABELS: Record<HotelComponentName, string> = {
+  night: "Night heat",
+  hot_hours: "Hot hours",
+  persistence: "Persistence",
+  day: "Day heat",
+};
+
+function identity(hotel: HotelRankingHotel) {
+  return `${hotel.identity.object_type}-${hotel.identity.object_id}`;
+}
+
+export function rerankHotels(
+  response: HotelRankResponse,
+  weights: Record<HotelComponentName, number>,
+  weightLabel: "product defaults" | "custom" = "custom"
+): HotelRankResponse {
+  if (!response.ranking) return response;
+  const complete = response.ranking.hotels.filter(
+    (hotel) =>
+      hotel.complete &&
+      HOTEL_COMPONENTS.every(
+        (component) => hotel.components[component].percentile !== null
+      )
+  );
+  const aggregates = new Map(
+    complete.map((hotel) => [
+      identity(hotel),
+      Number(
+        HOTEL_COMPONENTS.reduce((total, component) => {
+          const percentile = hotel.components[component].percentile;
+          return total + (1 - (percentile ?? 0) / 100) * weights[component];
+        }, 0).toFixed(6)
+      ),
+    ])
+  );
+  const aggregateValues = [...new Set(aggregates.values())].sort(
+    (a, b) => a - b
+  );
+  const rankedOutput = complete.length >= 5;
+  if (!rankedOutput) {
+    return {
+      ...response,
+      ranking: {
+        ...response.ranking,
+        weights,
+        weight_label: weightLabel,
+        complete_candidate_count: complete.length,
+        ranked_output: false,
+        hotels: response.ranking.hotels.map((hotel) => ({
+          ...hotel,
+          relative_aggregate: aggregates.get(identity(hotel)) ?? null,
+          rank: null,
+          relative_percentile: null,
+        })),
+      },
+    };
+  }
+  const orderedComplete = [...complete].sort((left, right) => {
+    const difference =
+      (aggregates.get(identity(left)) ?? 0) -
+      (aggregates.get(identity(right)) ?? 0);
+    return difference || identity(left).localeCompare(identity(right));
+  });
+  const ranked = orderedComplete.map((hotel) => {
+    const aggregate = aggregates.get(identity(hotel)) ?? 0;
+    const valueIndex = aggregateValues.indexOf(aggregate);
+    return {
+      ...hotel,
+      relative_aggregate: aggregate,
+      rank:
+        orderedComplete.findIndex(
+          (candidate) => aggregates.get(identity(candidate)) === aggregate
+        ) + 1,
+      relative_percentile:
+        aggregateValues.length === 1
+          ? 100
+          : 100 * (1 - valueIndex / (aggregateValues.length - 1)),
+    };
+  });
+  const incomplete = response.ranking.hotels
+    .filter((hotel) => !aggregates.has(identity(hotel)))
+    .map((hotel) => ({
+      ...hotel,
+      relative_aggregate: null,
+      rank: null,
+      relative_percentile: null,
+    }));
+  return {
+    ...response,
+    ranking: {
+      ...response.ranking,
+      weights,
+      weight_label: weightLabel,
+      complete_candidate_count: complete.length,
+      ranked_output: true,
+      hotels: [...ranked, ...incomplete],
+    },
+  };
+}

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -253,6 +253,15 @@ const makeHotels = (
 };
 
 export const scenarioLocations = locations;
+export const hotelLocations: LocationSelection[] = [
+  {
+    id: "downtown-san-antonio",
+    name: "Downtown San Antonio",
+    context: "Supported hotel ranking district",
+    latitude: 29.425,
+    longitude: -98.486,
+  },
+];
 export const scenarioIds = ["harbor", "civic", "garden"];
 export function resolveLocation(id?: string) {
   return locations.find((location) => location.id === id) ?? locations[0];
@@ -281,7 +290,7 @@ export function mockHotelRanking(
 ): Promise<HotelRankResponse> {
   return delayed(
     resolveMode(options),
-    () => makeHotels(location, location.id === "civic"),
+    () => makeHotels(location, resolveMode(options) === "degraded"),
     options.signal
   );
 }

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -1,5 +1,7 @@
 import type {
-  HotelResponse,
+  HotelComponentName,
+  HotelRankResponse,
+  HotelRankingHotel,
   LocationSelection,
   MockMode,
   RequestOptions,
@@ -152,7 +154,7 @@ const makeTrip = (
 const makeHotels = (
   location: LocationSelection,
   few = false
-): HotelResponse => {
+): HotelRankResponse => {
   const names = [
     "Canopy House",
     "Civic Lantern",
@@ -161,51 +163,92 @@ const makeHotels = (
     "The Meridian",
     "Market House",
   ];
-  const values = few ? [31, 31, 44] : [24, 29, 35, 41, 48, 53];
+  const componentValues: Record<HotelComponentName, number[]> = {
+    night: few ? [27, 27, 31] : [25, 27, 29, 31, 33, 35],
+    hot_hours: few ? [5, 5, 8] : [9, 8, 7, 6, 5, 4],
+    persistence: few ? [3, 3, 5] : [6, 5, 4, 3, 2, 1],
+    day: few ? [38, 38, 41] : [34, 35, 36, 37, 38, 39],
+  };
+  const count = few ? 3 : 6;
+  const components = Object.fromEntries(
+    (["night", "hot_hours", "persistence", "day"] as const).map((component) => [
+      component,
+      {
+        component,
+        available: true,
+        unit: component === "night" || component === "day" ? "C" : "hours",
+        threshold_celsius:
+          component === "hot_hours" || component === "persistence" ? 35 : null,
+        provenance: "district fixture analysis",
+        coverage: few ? 0.72 : 0.94,
+        confidence: few ? "limited" : "limited",
+        caveats: ["Candidate-relative evidence; not an absolute heat score."],
+        missing_reason: null,
+      },
+    ])
+  ) as HotelRankResponse["components"];
   return {
-    location,
-    usableCount: values.length,
-    weights: {
-      "Night heat": 35,
-      "Hot hours": 25,
-      Persistence: 20,
-      "Day heat": 20,
+    state: few ? "unavailable" : "available",
+    district_name: location.name,
+    execution_mode: "fixture",
+    reason: few ? "insufficient_complete_hotels" : null,
+    discovered_count: count,
+    usable_count: count,
+    components,
+    ranking: {
+      weights: { night: 0.35, hot_hours: 0.25, persistence: 0.2, day: 0.2 },
+      weight_label: "product defaults",
+      complete_candidate_count: count,
+      ranked_output: !few,
+      hotels: Array.from({ length: count }, (_, index) => ({
+        identity: { object_type: "node" as const, object_id: index + 1 },
+        name: names[index],
+        complete: true,
+        relative_aggregate: few ? null : index / (count - 1),
+        rank: few ? null : index + 1,
+        components: Object.fromEntries(
+          (["night", "hot_hours", "persistence", "day"] as const).map(
+            (component) => {
+              const values = componentValues[component];
+              const value = values[index];
+              const unique = [...new Set(values)].sort((a, b) => a - b);
+              const percentile =
+                unique.length === 1
+                  ? 100
+                  : 100 * (1 - unique.indexOf(value) / (unique.length - 1));
+              return [
+                component,
+                {
+                  component,
+                  value,
+                  unit:
+                    component === "night" || component === "day"
+                      ? "C"
+                      : "hours",
+                  threshold_celsius:
+                    component === "hot_hours" || component === "persistence"
+                      ? 35
+                      : null,
+                  provenance: "district fixture analysis",
+                  tile_id:
+                    few && index < 2
+                      ? `${component}-tie`
+                      : `${component}-${index}`,
+                  tile_resolution_m: 80,
+                  quality: "containing_tile",
+                  distance_m: 0,
+                  coverage: few ? 0.72 : 0.94,
+                  caveats: [
+                    "Candidate-relative evidence; not an absolute heat score.",
+                  ],
+                  percentile,
+                },
+              ];
+            }
+          )
+        ) as HotelRankingHotel["components"],
+      })),
     },
-    provenance: {
-      source: "mock",
-      dataDate: "2026-08-23",
-      confidence: few ? "Moderate" : "High",
-      coverage: few
-        ? "3 usable hotels; below the preferred 5"
-        : "6 usable hotels",
-      note: "Weights are configurable product preferences, not scientific truth.",
-    },
-    hotels: values.map((value, index) => ({
-      id: `hotel-${index + 1}`,
-      name: names[index],
-      percentile: Math.round(100 - value * 1.2),
-      tieLabel: few && index < 2 ? "Tied at this position" : undefined,
-      latitude: location.latitude + index * 0.001,
-      longitude: location.longitude + index * 0.001,
-      components: [
-        { label: "Night heat", value, contribution: value * 0.35 },
-        {
-          label: "Hot hours",
-          value: value + 3,
-          contribution: (value + 3) * 0.25,
-        },
-        {
-          label: "Persistence",
-          value: value - 2,
-          contribution: (value - 2) * 0.2,
-        },
-        {
-          label: "Day heat",
-          value: value + 5,
-          contribution: (value + 5) * 0.2,
-        },
-      ],
-    })),
   };
 };
 
@@ -235,7 +278,7 @@ export function mockTripAnalyze(
 export function mockHotelRanking(
   location: LocationSelection,
   options: RequestOptions = {}
-): Promise<HotelResponse> {
+): Promise<HotelRankResponse> {
   return delayed(
     resolveMode(options),
     () => makeHotels(location, location.id === "civic"),

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -278,9 +278,9 @@ export const dataClient = {
     }
     return value;
   },
-  searchLocations(query: string) {
+  searchLocations(query: string, locations = scenarioLocations) {
     const normalized = query.trim().toLowerCase();
-    return scenarioLocations.filter(
+    return locations.filter(
       (location) =>
         !normalized ||
         `${location.name} ${location.context}`

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -3,6 +3,10 @@ import { mockHotelRanking } from "../mocks/mockHotelRanking";
 import { mockTripAnalyze } from "../mocks/mockTripAnalyze";
 import type {
   ExecutionMode,
+  HotelRankRequest,
+  HotelRankResponse,
+  LocationSelection,
+  RequestOptions,
   TripAnalysisRequest,
   TripAnalysisResponse,
 } from "../types";
@@ -13,6 +17,23 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function isResultSection(value: unknown) {
   return value === null || isObject(value);
+}
+
+function isHotelRankResponse(value: unknown): value is HotelRankResponse {
+  return (
+    isObject(value) &&
+    (value.state === "available" || value.state === "unavailable") &&
+    typeof value.district_name === "string" &&
+    (value.execution_mode === "fixture" || value.execution_mode === "live") &&
+    typeof value.discovered_count === "number" &&
+    typeof value.usable_count === "number" &&
+    isObject(value.components) &&
+    (value.ranking === null ||
+      (isObject(value.ranking) &&
+        isObject(value.ranking.weights) &&
+        typeof value.ranking.weight_label === "string" &&
+        Array.isArray(value.ranking.hotels)))
+  );
 }
 
 function validUnavailable(value: unknown) {
@@ -230,7 +251,33 @@ export const dataClient = {
     }
     return value;
   },
-  rankHotels: mockHotelRanking,
+  async rankHotels(
+    location: LocationSelection,
+    options: RequestOptions = {}
+  ): Promise<HotelRankResponse> {
+    // Explicit mock scenarios remain available for deterministic previews and tests.
+    if (options.mode !== undefined || options.scenario !== undefined) {
+      return mockHotelRanking(location, options);
+    }
+    const executionMode = await this.getHealth(options.signal);
+    const request: HotelRankRequest = {
+      // The current hotel flow is scoped to the canonical district AOI.
+      district_name: "Downtown San Antonio",
+      execution_mode: executionMode,
+    };
+    const value = await readJson(
+      await fetch("/api/hotels/rank", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+        signal: options.signal,
+      })
+    );
+    if (!isHotelRankResponse(value)) {
+      throw new Error("Invalid hotel ranking response");
+    }
+    return value;
+  },
   searchLocations(query: string) {
     const normalized = query.trim().toLowerCase();
     return scenarioLocations.filter(

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -608,6 +608,11 @@ dd {
   display: grid;
   gap: 17px;
 }
+.weight-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
 .weight-editor label {
   display: grid;
   grid-template-columns: 1fr 90px 20px;
@@ -626,6 +631,46 @@ dd {
 .invalid-total,
 .validation-message {
   color: var(--accent);
+}
+.evidence-summary,
+.assignment-evidence {
+  margin-top: 28px;
+}
+.evidence-grid,
+.assignment-evidence {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.evidence-grid article,
+.assignment-evidence article {
+  padding: 20px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+.evidence-grid h3,
+.assignment-evidence h2 {
+  margin-top: 0;
+}
+.evidence-grid dl,
+.assignment-evidence dl {
+  display: grid;
+  gap: 7px;
+}
+.evidence-grid dl div,
+.assignment-evidence dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+.evidence-grid dt,
+.assignment-evidence dt {
+  color: var(--muted);
+}
+.evidence-grid dd,
+.assignment-evidence dd {
+  margin: 0;
+  text-align: right;
 }
 .trip-setup {
   max-width: 1120px;
@@ -884,6 +929,10 @@ dd {
   }
   .component-list {
     grid-template-columns: repeat(2, 1fr);
+  }
+  .evidence-grid,
+  .assignment-evidence {
+    grid-template-columns: 1fr;
   }
   .provenance dl {
     display: grid;

--- a/frontend/src/test/app.test.tsx
+++ b/frontend/src/test/app.test.tsx
@@ -27,8 +27,11 @@ describe("mock data boundary", () => {
     const request = mockHotelRanking(scenarioLocations[1]);
     await vi.advanceTimersByTimeAsync(1400);
     const result = await request;
-    expect(result.usableCount).toBeLessThan(5);
-    expect(result.hotels.some((hotel) => hotel.tieLabel)).toBe(true);
+    expect(result.usable_count).toBeLessThan(5);
+    expect(result.ranking?.ranked_output).toBe(false);
+    expect(result.ranking?.hotels[0].components.night.tile_id).toBe(
+      result.ranking?.hotels[1].components.night.tile_id
+    );
     vi.useRealTimers();
   });
 });

--- a/frontend/src/test/app.test.tsx
+++ b/frontend/src/test/app.test.tsx
@@ -24,7 +24,9 @@ describe("mock data boundary", () => {
 
   it("returns a scenario with ties and fewer than five hotels", async () => {
     vi.useFakeTimers();
-    const request = mockHotelRanking(scenarioLocations[1]);
+    const request = mockHotelRanking(scenarioLocations[0], {
+      mode: "degraded",
+    });
     await vi.advanceTimersByTimeAsync(1400);
     const result = await request;
     expect(result.usable_count).toBeLessThan(5);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,26 +43,69 @@ export type TripResponse = {
   provenance: { bestTime: Provenance; routes: Provenance };
 };
 
-export type HotelComponent = {
-  label: string;
-  value: number;
-  contribution: number;
+export type HotelComponentName = "night" | "hot_hours" | "persistence" | "day";
+
+export type HotelComponentMetadata = {
+  component: HotelComponentName;
+  available: boolean;
+  unit: "C" | "hours";
+  threshold_celsius: number | null;
+  provenance: string | null;
+  coverage: number | null;
+  confidence: "high" | "limited" | "insufficient" | null;
+  caveats: string[];
+  provenance_details?: Record<string, unknown> | null;
+  missing_reason: string | null;
 };
-export type Hotel = {
-  id: string;
+
+export type HotelComponentAssignment = {
+  component: HotelComponentName;
+  value: number | null;
+  unit: "C" | "hours";
+  threshold_celsius: number | null;
+  provenance: string;
+  tile_id: string | null;
+  tile_resolution_m: number;
+  quality: string;
+  distance_m: number | null;
+  coverage: number | null;
+  caveats: string[];
+  percentile: number | null;
+};
+
+export type HotelRankingHotel = {
+  identity: { object_type: "node" | "way" | "relation"; object_id: number };
   name: string;
-  percentile: number;
-  tieLabel?: string;
-  components: HotelComponent[];
-  latitude: number;
-  longitude: number;
+  complete: boolean;
+  relative_aggregate: number | null;
+  rank: number | null;
+  components: Record<HotelComponentName, HotelComponentAssignment>;
+  /** Candidate-relative percentile derived locally from relative_aggregate. */
+  relative_percentile?: number | null;
 };
-export type HotelResponse = {
-  location: LocationSelection;
-  hotels: Hotel[];
-  usableCount: number;
-  weights: Record<string, number>;
-  provenance: Provenance;
+
+export type HotelRanking = {
+  weights: Record<HotelComponentName, number>;
+  weight_label: "product defaults" | "custom";
+  complete_candidate_count: number;
+  ranked_output: boolean;
+  hotels: HotelRankingHotel[];
+};
+
+export type HotelRankResponse = {
+  state: "available" | "unavailable";
+  district_name: string;
+  execution_mode: ExecutionMode;
+  reason: string | null;
+  discovered_count: number;
+  usable_count: number;
+  components: Partial<Record<HotelComponentName, HotelComponentMetadata>>;
+  ranking: HotelRanking | null;
+};
+
+export type HotelRankRequest = {
+  district_name: string;
+  execution_mode: ExecutionMode;
 };
 export type RequestOptions = {
   scenario?: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -70,6 +70,7 @@ export type HotelComponentAssignment = {
   distance_m: number | null;
   coverage: number | null;
   caveats: string[];
+  correlation_key?: string | null;
   percentile: number | null;
 };
 

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -2,8 +2,13 @@ from datetime import date
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+from shapely.geometry import Polygon
 
 from app.api import create_app
+from app.domain.contracts import ExecutionMode
+from app.services.hotel_heat_score import HotelHeatAnalysisService
+
+from test_hotel_heat_score_service import _discovery, _evidence
 
 
 def test_fastapi_app_exposes_fixture_heatmap_contract() -> None:
@@ -37,3 +42,64 @@ def test_fastapi_app_does_not_allow_public_live_mode() -> None:
     )
     assert response.status_code == 400
     assert response.json()["detail"]["status"] == "error"
+
+
+def test_hotel_ranking_api_serializes_provider_neutral_result() -> None:
+    aoi = Polygon([(0, 0), (0.01, 0), (0.01, 0.01), (0, 0.01)])
+    service = HotelHeatAnalysisService(
+        _discovery,
+        _evidence,
+        aoi=aoi,
+    )
+    client = TestClient(
+        create_app(
+            Path("fixtures/heatmap-historical.json"),
+            hotel_heat_analysis_service=service,
+        )
+    )
+
+    response = client.post(
+        "/api/hotels/rank",
+        json={"district_name": "Downtown", "execution_mode": ExecutionMode.FIXTURE.value},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "available"
+    assert payload["discovered_count"] == 6
+    assert payload["components"]["night"]["coverage"] == 0.95
+    assert payload["ranking"]["weight_label"] == "product defaults"
+    assert payload["ranking"]["hotels"][0]["components"]["night"]["unit"] == "C"
+    assert "activity_id" not in response.text
+
+
+def test_hotel_ranking_api_rejects_invalid_weights() -> None:
+    client = TestClient(create_app(Path("fixtures/heatmap-historical.json")))
+
+    response = client.post(
+        "/api/hotels/rank",
+        json={
+            "district_name": "Downtown",
+            "execution_mode": "fixture",
+            "weights": {"night": 1.0},
+        },
+    )
+
+    assert response.status_code == 400
+    assert "weights" in response.json()["detail"]["error"]
+
+
+def test_hotel_ranking_api_uses_default_fixture_service_offline() -> None:
+    client = TestClient(create_app(Path("fixtures/heatmap-historical.json")))
+
+    response = client.post(
+        "/api/hotels/rank",
+        json={"district_name": "Downtown San Antonio", "execution_mode": "fixture"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "available"
+    assert payload["usable_count"] == 6
+    assert set(payload["components"]) == {"night", "hot_hours", "persistence", "day"}
+    assert all(component["available"] for component in payload["components"].values())

--- a/tests/test_hotel_heat_score.py
+++ b/tests/test_hotel_heat_score.py
@@ -1,0 +1,193 @@
+import math
+
+import pytest
+from shapely.geometry import Polygon
+
+from app.domain.analysis import SpatialMetadata, TileGeometry
+from app.domain.hotel_heat_score import (
+    COMPONENTS,
+    DEFAULT_WEIGHT_LABEL,
+    DEFAULT_WEIGHTS,
+    ComponentEvidence,
+    NeighbourhoodHeatScorer,
+)
+from app.domain.hotels import HotelCandidate, OsmIdentity
+
+
+AOI = Polygon([(0, 0), (0.01, 0), (0.01, 0.01), (0, 0.01)])
+
+
+def hotel(identity: int, longitude: float, latitude: float = 0.005) -> HotelCandidate:
+    osm_identity = OsmIdentity("node", identity)
+    return HotelCandidate(osm_identity, (osm_identity,), f"Hotel {identity}", latitude, longitude)
+
+
+def evidence(component: str, values: list[float]) -> ComponentEvidence:
+    unit = "C" if component in {"night", "day"} else "hours"
+    threshold = 35.0 if component in {"hot_hours", "persistence"} else None
+    tiles = tuple(
+        TileGeometry(
+            f"{component}-{index}",
+            Polygon(
+                [
+                    (index * 0.001, 0),
+                    ((index + 1) * 0.001, 0),
+                    ((index + 1) * 0.001, 0.01),
+                    (index * 0.001, 0.01),
+                ]
+            ),
+            value,
+            SpatialMetadata(metric=component, unit=unit, source="fixture"),
+        )
+        for index, value in enumerate(values)
+    )
+    return ComponentEvidence(
+        component=component,
+        tiles=tiles,
+        unit=unit,
+        threshold_celsius=threshold,
+        provenance="district-fixture",
+        tile_resolution_m=80.0,
+    )
+
+
+def complete_evidence(values: list[float]) -> dict[str, ComponentEvidence]:
+    return {component: evidence(component, values) for component in COMPONENTS}
+
+
+def test_assignment_uses_spatial_join_and_preserves_evidence_metadata() -> None:
+    scorer = NeighbourhoodHeatScorer()
+    assignments = scorer.assign(
+        [hotel(1, 0.0005), hotel(2, 0.00505)],
+        complete_evidence([10, 20, 30, 40, 50]),
+        aoi=AOI,
+    )
+
+    first = assignments[0].components["night"]
+    assert first.value == 10
+    assert first.tile_id == "night-0"
+    assert first.tile_resolution_m == 80.0
+    assert first.quality == "containing_tile"
+    assert first.unit == "C"
+    assert first.threshold_celsius is None
+    assert first.provenance == "district-fixture"
+
+    fallback = assignments[1].components["hot_hours"]
+    assert fallback.value == 50
+    assert fallback.tile_id == "hot_hours-4"
+    assert fallback.quality == "nearest_fallback"
+    assert fallback.distance_m is not None and fallback.distance_m < 100
+    assert fallback.threshold_celsius == 35.0
+
+
+def test_score_uses_dense_component_percentiles_and_competition_ranking() -> None:
+    scorer = NeighbourhoodHeatScorer()
+    assignments = scorer.assign(
+        [
+            hotel(index + 1, longitude)
+            for index, longitude in enumerate([0.0004, 0.0014, 0.0024, 0.0034, 0.0044])
+        ],
+        complete_evidence([10, 10, 20, 30, 40]),
+        aoi=AOI,
+    )
+
+    result = scorer.score(assignments)
+
+    assert result.weights == DEFAULT_WEIGHTS
+    assert result.weight_label == DEFAULT_WEIGHT_LABEL == "product defaults"
+    assert result.complete_candidate_count == 5
+    assert result.ranked_output is True
+    assert [item.rank for item in result.hotels] == [1, 1, 3, 4, 5]
+    assert [item.relative_aggregate for item in result.hotels] == [
+        0.0,
+        0.0,
+        0.333333,
+        0.666667,
+        1.0,
+    ]
+    assert result.hotels[0].components["night"].percentile == 100.0
+    assert result.hotels[1].components["night"].percentile == 100.0
+    assert result.hotels[2].components["night"].percentile == pytest.approx(200 / 3)
+
+
+def test_hotels_in_the_same_tile_keep_the_same_assignment_and_tie() -> None:
+    scorer = NeighbourhoodHeatScorer()
+    assignments = scorer.assign(
+        [hotel(1, 0.0004), hotel(2, 0.0006)]
+        + [hotel(index, index * 0.001 + 0.0005) for index in range(3, 6)],
+        complete_evidence([10, 20, 30, 40, 50]),
+        aoi=AOI,
+    )
+
+    result = scorer.score(assignments)
+
+    assert assignments[0].components["night"].tile_id == "night-0"
+    assert assignments[1].components["night"].tile_id == "night-0"
+    assert result.hotels[0].rank == result.hotels[1].rank == 1
+
+
+def test_incomplete_hotels_remain_visible_and_fewer_than_five_complete_are_unranked() -> None:
+    scorer = NeighbourhoodHeatScorer()
+    all_evidence = complete_evidence([10, 20, 30, 40])
+    assignments = scorer.assign(
+        [
+            hotel(index + 1, longitude)
+            for index, longitude in enumerate([0.0005, 0.0015, 0.0025, 0.0035, 0.009])
+        ],
+        all_evidence,
+        aoi=AOI,
+    )
+
+    result = scorer.score(assignments)
+
+    assert result.complete_candidate_count == 4
+    assert result.ranked_output is False
+    assert len(result.hotels) == 5
+    assert all(item.rank is None for item in result.hotels)
+    assert result.hotels[-1].complete is False
+    assert result.hotels[-1].relative_aggregate is None
+    assert result.hotels[-1].components["day"].quality == "no_match"
+
+
+def test_custom_weights_recompute_locally_and_are_labelled_custom() -> None:
+    scorer = NeighbourhoodHeatScorer()
+    assignments = scorer.assign(
+        [hotel(index + 1, index * 0.001 + 0.0005) for index in range(5)],
+        {
+            "night": evidence("night", [10, 20, 30, 40, 50]),
+            "hot_hours": evidence("hot_hours", [5, 4, 3, 2, 1]),
+            "persistence": evidence("persistence", [1, 1, 1, 1, 1]),
+            "day": evidence("day", [1, 1, 1, 1, 1]),
+        },
+        aoi=AOI,
+    )
+
+    custom = scorer.score(
+        assignments,
+        weights={"night": 0.0, "hot_hours": 1.0, "persistence": 0.0, "day": 0.0},
+    )
+
+    assert custom.weight_label == "custom"
+    assert [item.identity.object_id for item in custom.hotels] == [5, 4, 3, 2, 1]
+    assert [item.rank for item in custom.hotels] == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.parametrize(  # type: ignore[misc]
+    "weights",
+    [
+        {"night": 0.5, "hot_hours": 0.25, "persistence": 0.25},
+        {"night": -0.1, "hot_hours": 0.4, "persistence": 0.4, "day": 0.3},
+        {"night": math.nan, "hot_hours": 0.25, "persistence": 0.25, "day": 0.5},
+        {"night": 0.5, "hot_hours": 0.25, "persistence": 0.25, "day": 0.002},
+    ],
+)
+def test_custom_weights_must_be_complete_finite_nonnegative_and_sum_within_tolerance(
+    weights: dict[str, float],
+) -> None:
+    with pytest.raises(ValueError, match="weights"):
+        NeighbourhoodHeatScorer().score((), weights=weights)
+
+
+def test_evidence_requires_exact_components() -> None:
+    with pytest.raises(ValueError, match="components"):
+        NeighbourhoodHeatScorer().assign([], {"night": evidence("night", [10])}, aoi=AOI)

--- a/tests/test_hotel_heat_score.py
+++ b/tests/test_hotel_heat_score.py
@@ -172,6 +172,34 @@ def test_custom_weights_recompute_locally_and_are_labelled_custom() -> None:
     assert [item.rank for item in custom.hotels] == [1, 2, 3, 4, 5]
 
 
+def test_correlated_components_share_one_weighted_measurement() -> None:
+    scorer = NeighbourhoodHeatScorer()
+    shared = complete_evidence([10, 20, 30, 40, 50])
+    shared["night"] = ComponentEvidence(
+        **{**shared["night"].__dict__, "correlation_key": "shared-date-tcm"}
+    )
+    shared["day"] = ComponentEvidence(
+        **{
+            **shared["day"].__dict__,
+            "correlation_key": "shared-date-tcm",
+            "tiles": tuple(reversed(shared["day"].tiles)),
+        }
+    )
+    assignments = scorer.assign(
+        [hotel(index + 1, index * 0.001 + 0.0005) for index in range(5)],
+        shared,
+        aoi=AOI,
+    )
+
+    result = scorer.score(assignments)
+
+    # Night ranks hotel 1 best while the correlated day snapshot ranks hotel 5 best.
+    # Only the representative (night, with the larger default weight) is scored.
+    assert [hotel.identity.object_id for hotel in result.hotels] == [1, 2, 3, 4, 5]
+    assert [hotel.rank for hotel in result.hotels] == [1, 2, 3, 4, 5]
+    assert [hotel.relative_aggregate for hotel in result.hotels] == [0.0, 0.25, 0.5, 0.75, 1.0]
+
+
 @pytest.mark.parametrize(  # type: ignore[misc]
     "weights",
     [

--- a/tests/test_hotel_heat_score_service.py
+++ b/tests/test_hotel_heat_score_service.py
@@ -113,6 +113,7 @@ def test_service_reports_missing_component_without_assigning_or_scoring() -> Non
     assert outcome.score is None
     assert outcome.components["persistence"].missing_reason == "component_not_available"
     assert outcome.components["persistence"].available is False
+    assert outcome.components["persistence"].threshold_celsius == 35.0
 
 
 def test_canonical_fixture_preserves_exactly_four_shared_component_analyses() -> None:

--- a/tests/test_hotel_heat_score_service.py
+++ b/tests/test_hotel_heat_score_service.py
@@ -1,0 +1,137 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+
+from shapely.geometry import Polygon
+
+from app.domain.analysis import SpatialMetadata, TileGeometry
+from app.domain.contracts import ExecutionMode
+from app.domain.hotel_heat_score import COMPONENTS, ComponentEvidence
+from app.domain.hotels import (
+    DiscoveryState,
+    HotelCandidate,
+    HotelDiscoveryResult,
+    OsmIdentity,
+)
+from app.services.hotel_heat_score import HotelHeatAnalysisService, HotelHeatAnalysisState
+from app.services.hotel_heat_score import build_fixture_hotel_heat_analysis_service
+from app.settings import OverpassSettings
+
+
+AOI = Polygon([(0, 0), (0.01, 0), (0.01, 0.01), (0, 0.01)])
+
+
+def _discovery() -> HotelDiscoveryResult:
+    candidates = tuple(
+        HotelCandidate(
+            OsmIdentity("node", index + 1),
+            (OsmIdentity("node", index + 1),),
+            f"Hotel {index + 1}",
+            0.005,
+            index * 0.001 + 0.0005,
+        )
+        for index in range(5)
+    )
+    now = datetime(2026, 8, 29, tzinfo=timezone.utc)
+    return HotelDiscoveryResult(
+        DiscoveryState.AVAILABLE, candidates, 6, 5, now, now, "fixture", False
+    )
+
+
+def _evidence(component: str) -> ComponentEvidence:
+    unit = "C" if component in {"night", "day"} else "hours"
+    threshold = None if unit == "C" else 35.0
+    tiles = tuple(
+        TileGeometry(
+            f"{component}-{index}",
+            Polygon(
+                [
+                    (index * 0.001, 0),
+                    ((index + 1) * 0.001, 0),
+                    ((index + 1) * 0.001, 0.01),
+                    (index * 0.001, 0.01),
+                ]
+            ),
+            float(index + 1),
+            SpatialMetadata(metric=component, unit=unit, source="fixture"),
+        )
+        for index in range(5)
+    )
+    return ComponentEvidence(
+        component,
+        tiles,
+        unit,
+        threshold,
+        "district-fixture",
+        80.0,
+        coverage=0.95,
+        caveats=("candidate-relative",),
+    )
+
+
+def test_service_loads_each_component_once_and_reranks_without_more_loads() -> None:
+    calls: list[str] = []
+    lock = Lock()
+
+    def load(component: str) -> ComponentEvidence:
+        with lock:
+            calls.append(component)
+        return _evidence(component)
+
+    service = HotelHeatAnalysisService(_discovery, load, aoi=AOI)
+    initial = service.analyze("Downtown", ExecutionMode.FIXTURE)
+
+    assert initial.state is HotelHeatAnalysisState.AVAILABLE
+    assert sorted(calls) == sorted(COMPONENTS)
+    assert len(calls) == 4
+    assert initial.discovered_count == 6
+    assert initial.usable_count == 5
+    assert initial.components["night"].coverage == 0.95
+    assert initial.components["night"].caveats == ("candidate-relative",)
+
+    reranked = service.rerank(
+        initial,
+        weights={"night": 1.0, "hot_hours": 0.0, "persistence": 0.0, "day": 0.0},
+    )
+
+    assert len(calls) == 4
+    assert reranked.assignments is initial.assignments
+    assert reranked.score is not None and reranked.score.weight_label == "custom"
+
+
+def test_service_reports_missing_component_without_assigning_or_scoring() -> None:
+    def load(component: str) -> ComponentEvidence | None:
+        return None if component == "persistence" else _evidence(component)
+
+    outcome = HotelHeatAnalysisService(_discovery, load, aoi=AOI).analyze(
+        "Downtown", ExecutionMode.FIXTURE
+    )
+
+    assert outcome.state is HotelHeatAnalysisState.UNAVAILABLE
+    assert outcome.reason == "missing_component_evidence"
+    assert outcome.assignments == ()
+    assert outcome.score is None
+    assert outcome.components["persistence"].missing_reason == "component_not_available"
+    assert outcome.components["persistence"].available is False
+
+
+def test_canonical_fixture_preserves_exactly_four_shared_component_analyses() -> None:
+    fixture = Path(__file__).resolve().parents[1] / "fixtures" / "hotel-heat-analysis.json"
+    service = build_fixture_hotel_heat_analysis_service(
+        fixture, district_aoi=OverpassSettings().district_aoi
+    )
+
+    outcome = service.analyze("Downtown San Antonio", ExecutionMode.FIXTURE)
+
+    assert outcome.state is HotelHeatAnalysisState.AVAILABLE
+    assert set(outcome.evidence) == set(COMPONENTS)
+    assert len(outcome.evidence) == 4
+    assert all(evidence.tile_resolution_m == 80.0 for evidence in outcome.evidence.values())
+    assert all(evidence.tiles for evidence in outcome.evidence.values())
+    assert all(
+        tile.metadata.metric == component
+        and tile.metadata.unit == evidence.unit
+        and tile.metadata.source == evidence.provenance
+        for component, evidence in outcome.evidence.items()
+        for tile in evidence.tiles
+    )

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,6 +1,7 @@
 """Call ledger: honest call accounting with call-count budget enforcement (ADR 0004 §5)."""
 
 from datetime import date, datetime, timezone
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -32,6 +33,25 @@ def test_ledger_counts_calls_and_authorizes_against_the_call_budget() -> None:
     assert ledger.remaining == 0
     with pytest.raises(BudgetExceededError, match="call budget exceeded"):
         ledger.authorize_call()
+
+
+def test_ledger_reserves_budget_slots_for_concurrent_calls() -> None:
+    ledger = CreditLedger(budget=1)
+
+    def authorize() -> str:
+        try:
+            ledger.authorize_call()
+        except BudgetExceededError:
+            return "rejected"
+        return "reserved"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: authorize(), range(2)))
+
+    assert sorted(results) == ["rejected", "reserved"]
+    assert ledger.remaining == 0
+    ledger.release_call()
+    assert ledger.remaining == 1
 
 
 def test_ledger_records_calls_the_provider_did_not_price() -> None:

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -265,7 +265,7 @@ def test_default_fixture_production_app_ranks_hotels_with_four_component_evidenc
     assert payload["components"]["persistence"]["threshold_celsius"] == 35.0
 
 
-def test_production_hotel_live_mode_reports_missing_provider_components() -> None:
+def test_production_hotel_live_mode_replays_canonical_fixture_when_provider_unavailable() -> None:
     app = create_production_app(
         AppSettings(
             allow_live=True,
@@ -280,8 +280,12 @@ def test_production_hotel_live_mode_reports_missing_provider_components() -> Non
     )
 
     assert response.status_code == 200
-    assert response.json()["state"] == "unavailable"
-    assert response.json()["reason"] in {"provider_failure", "missing_component_evidence"}
+    payload = response.json()
+    assert payload["state"] == "available"
+    assert all(
+        component["provenance"] == "fixture:canonical-district-hotel-analysis"
+        for component in payload["components"].values()
+    )
 
 
 def test_heatmap_route_accepts_granularity_from_request_body() -> None:

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -237,6 +237,53 @@ def test_create_production_app_enables_live_only_with_settings() -> None:
     assert live_client.get("/health").json()["mode"] == "live"
 
 
+def test_default_fixture_production_app_ranks_hotels_with_four_component_evidence() -> None:
+    app = create_production_app(
+        AppSettings(
+            allow_live=False,
+            fortyguard_api_key=None,
+            fortyguard_base_url="https://api.example.test",
+        )
+    )
+
+    response = TestClient(app).post(
+        "/api/hotels/rank",
+        json={"district_name": "Downtown San Antonio", "execution_mode": "fixture"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "available"
+    assert payload["ranking"]["ranked_output"] is True
+    assert len(payload["ranking"]["hotels"]) == 6
+    assert set(payload["components"]) == {"night", "hot_hours", "persistence", "day"}
+    assert payload["components"]["night"]["unit"] == "C"
+    assert payload["components"]["day"]["unit"] == "C"
+    assert payload["components"]["hot_hours"]["unit"] == "hours"
+    assert payload["components"]["persistence"]["unit"] == "hours"
+    assert payload["components"]["hot_hours"]["threshold_celsius"] == 35.0
+    assert payload["components"]["persistence"]["threshold_celsius"] == 35.0
+
+
+def test_production_hotel_live_mode_reports_missing_provider_components() -> None:
+    app = create_production_app(
+        AppSettings(
+            allow_live=True,
+            fortyguard_api_key="key-1",
+            fortyguard_base_url="https://api.example.test",
+        )
+    )
+
+    response = TestClient(app).post(
+        "/api/hotels/rank",
+        json={"district_name": "Downtown San Antonio", "execution_mode": "live"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "unavailable"
+    assert response.json()["reason"] in {"provider_failure", "missing_component_evidence"}
+
+
 def test_heatmap_route_accepts_granularity_from_request_body() -> None:
     from app.integrations.fortyguard.contracts import HeatmapRequest
     from app.services.execution import HeatmapExecution


### PR DESCRIPTION
## Summary
- rank hotels from shared district-level heat evidence with candidate-relative percentiles and ties
- expose provenance, coverage, assignment quality, caveats, and local reranking
- constrain the hotel flow to canonical Downtown San Antonio and prevent duplicated live TCM evidence from being double-counted
- add fixture, API, frontend, fallback, and concurrent budget coverage

## Verification
- 467 Python tests passed
- 19 frontend tests passed
- Python and frontend typechecks passed
- Ruff, Prettier, and ESLint passed

Closes #17