### PR TITLE
feat(heat): Implement best-time decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,9 +66,15 @@ directly.
   never a real 24-hour forecast; results carry the standing warning.
 - **Env-params series** — Environmental parameters normalized as per-hour
   entries (`valid_time`, nullable metric values) aligned with the provider's
-  `metadata.timestamps`. Missing values stay `None`, never zero. Temporal trip
-  preparation returns this raw series as `series_ready`; it does not classify
-  heat or recommend a visit time.
+  `metadata.timestamps`. Missing values stay `None`, never zero. The best-time
+  decision reuses this series without another provider request.
+- **Environmental concern profile** — The per-hour assessment of all requested
+  provider parameters against declared NOAA, EPA, physiological, and product
+  thresholds. Missing parameters are reported as `not_reported`, never assumed
+  safe, and do not count against an hour during best-time selection.
+- **Framing threshold** — The product-declared 35°C threshold used for
+  exceedance and persistence heatmap calls. It is visible in provenance with
+  its `above` direction and is not presented as a NOAA boundary.
 - **Submit-once** — The billable-submission rule: one POST per
   `submit_and_poll`; transient failures are retried as status GETs only
   (ADR 0003). Transport retries never resubmit billable work.

--- a/app/domain/best_time.py
+++ b/app/domain/best_time.py
@@ -1,0 +1,169 @@
+"""Pure multi-parameter assessment and best-time selection policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from app.domain.contracts import HeatMetricName
+from app.domain.heat_policy import classify_heat
+from app.domain.environmental_parameters import ENVIRONMENT_PARAMETERS
+
+
+@dataclass(frozen=True)
+class ParameterThreshold:
+    elevated: float
+    high: float
+    unit: str
+    source: str
+
+
+PARAMETER_THRESHOLDS: dict[str, ParameterThreshold] = {
+    "heat_index_celsius": ParameterThreshold(26.7, 40.6, "C", "noaa"),
+    "apparent_temperature_celsius": ParameterThreshold(30.0, 40.0, "C", "product"),
+    "wet_bulb_temperature_celsius": ParameterThreshold(28.0, 32.0, "C", "published_physiology"),
+    "air_quality:idx": ParameterThreshold(51.0, 101.0, "index", "epa_aqi"),
+    "air_quality_pm2p5:idx": ParameterThreshold(51.0, 101.0, "index", "epa_aqi"),
+    "air_quality_pm10:idx": ParameterThreshold(51.0, 101.0, "index", "epa_aqi"),
+    "air_quality_no2:idx": ParameterThreshold(51.0, 101.0, "index", "epa_aqi"),
+    "air_quality_o3:idx": ParameterThreshold(51.0, 101.0, "index", "epa_aqi"),
+    "air_quality_so2:idx": ParameterThreshold(51.0, 101.0, "index", "epa_aqi"),
+    "aqi_us_co": ParameterThreshold(51.0, 101.0, "index", "epa_aqi"),
+    "relative_humidity_percent": ParameterThreshold(60.0, 80.0, "%", "product"),
+    "precipitation_mm": ParameterThreshold(0.1, 5.0, "mm", "product"),
+    "solar_irradiance": ParameterThreshold(400.0, 600.0, "W/m2", "product"),
+}
+
+_INFORMATIONAL_UNITS = {
+    "cloud_cover_octas": "octas",
+    "elevation": "m",
+    "methane_ppb": "ppb",
+    "co2_ppm": "ppm",
+}
+
+
+@dataclass(frozen=True)
+class ParameterConcern:
+    parameter: str
+    value: float | None
+    unit: str
+    available: bool
+    concern_level: str
+    threshold: float | None
+    threshold_source: str | None
+
+
+@dataclass(frozen=True)
+class HourlyConcernProfile:
+    hour: int
+    concerns: tuple[ParameterConcern, ...]
+    elevated_count: int
+    high_count: int
+    not_reported_count: int
+    primary_thermal_value: float
+    primary_thermal_metric: HeatMetricName
+
+
+@dataclass(frozen=True)
+class BestTimeDecision:
+    hour: int
+    reason: str
+    profile: HourlyConcernProfile
+
+
+def assess_hour(
+    hour: int,
+    *,
+    tcm_celsius: float,
+    parameters: Mapping[str, float | None],
+) -> HourlyConcernProfile:
+    """Assess all requested environmental parameters for one available TCM hour."""
+    concerns = tuple(
+        _assess_parameter(name, parameters.get(name)) for name in ENVIRONMENT_PARAMETERS
+    )
+    heat_index = parameters.get("heat_index_celsius")
+    primary_value = heat_index if heat_index is not None else tcm_celsius
+    primary_metric = (
+        HeatMetricName.HEAT_INDEX_CELSIUS if heat_index is not None else HeatMetricName.TCM
+    )
+    return HourlyConcernProfile(
+        hour=hour,
+        concerns=concerns,
+        elevated_count=sum(concern.concern_level == "elevated" for concern in concerns),
+        high_count=sum(concern.concern_level == "high" for concern in concerns),
+        not_reported_count=sum(not concern.available for concern in concerns),
+        primary_thermal_value=float(primary_value),
+        primary_thermal_metric=primary_metric,
+    )
+
+
+def select_best_time(
+    profiles: tuple[HourlyConcernProfile, ...], *, cautious: bool
+) -> BestTimeDecision:
+    """Select the least-concerning available hour with deterministic ties."""
+    if not profiles:
+        raise ValueError("at least one hourly concern profile is required")
+    selected = min(profiles, key=lambda profile: _selection_sort_key(profile, cautious))
+    return BestTimeDecision(selected.hour, _recommendation_reason(selected, profiles), selected)
+
+
+def _assess_parameter(name: str, value: float | None) -> ParameterConcern:
+    threshold = PARAMETER_THRESHOLDS.get(name)
+    unit = threshold.unit if threshold is not None else _INFORMATIONAL_UNITS[name]
+    if value is None:
+        return ParameterConcern(name, None, unit, False, "not_reported", None, None)
+    if threshold is None:
+        return ParameterConcern(name, value, unit, True, "none", None, None)
+    level = (
+        "high" if value >= threshold.high else "elevated" if value >= threshold.elevated else "none"
+    )
+    compared_threshold = (
+        threshold.high
+        if level == "high"
+        else threshold.elevated
+        if level == "elevated"
+        else threshold.elevated
+    )
+    return ParameterConcern(
+        name,
+        value,
+        unit,
+        True,
+        level,
+        compared_threshold,
+        threshold.source,
+    )
+
+
+def _selection_sort_key(
+    profile: HourlyConcernProfile, cautious: bool
+) -> tuple[int, bool, int, float, int]:
+    interpretation = classify_heat(
+        profile.primary_thermal_value,
+        metric=profile.primary_thermal_metric,
+        cautious=cautious,
+    )
+    return (
+        profile.high_count,
+        interpretation.action_required,
+        profile.elevated_count,
+        profile.primary_thermal_value,
+        profile.hour,
+    )
+
+
+def _recommendation_reason(
+    selected: HourlyConcernProfile, profiles: tuple[HourlyConcernProfile, ...]
+) -> str:
+    if selected.high_count == 0 and selected.elevated_count == 0:
+        if (
+            len({profile.primary_thermal_value for profile in profiles}) == 1
+            and len({profile.concerns for profile in profiles}) == 1
+        ):
+            return "flat environmental profile; earliest equally suitable period"
+        return "coolest period with no environmental concerns"
+    if all(profile.high_count or profile.elevated_count for profile in profiles):
+        return (
+            f"all periods show elevated conditions; {selected.hour:02d}:00 has the fewest concerns"
+        )
+    return f"lowest overall environmental concern at {selected.hour:02d}:00"

--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -11,9 +11,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 import math
 from datetime import date as calendar_date, datetime
-from typing import Mapping, Protocol
+from typing import TYPE_CHECKING, Mapping, Protocol
 
 from app.domain.environment import TimeWindow
+
+if TYPE_CHECKING:
+    from app.domain.best_time import HourlyConcernProfile
 
 
 # ---------------------------------------------------------------------------
@@ -532,6 +535,12 @@ class BestTimeResult:
     provenance: Provenance
     hourly_coverage: float = 1.0
     heat_interpretation: HeatInterpretation | None = None
+    environmental_concerns: tuple[HourlyConcernProfile, ...] | None = None
+    recommended_hour_tcm_celsius: float | None = None
+    exceedance_hours: float | None = None
+    persistence_hours: float | None = None
+    framing_threshold_celsius: float | None = None
+    framing_direction: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.metric_label, MetricLabel):
@@ -551,8 +560,40 @@ class BestTimeResult:
             raise ValueError("hourly_coverage must be between 0 and 1")
         if self.hourly_coverage != len(hours) / 24:
             raise ValueError("hourly_coverage must match available hourly evidence")
-        if any(entry.metric.label is not self.metric_label for entry in self.hourly):
+        recommended_entry = next(
+            entry for entry in self.hourly if entry.hour == self.recommendation_hour
+        )
+        if recommended_entry.metric.label is not self.metric_label:
+            raise ValueError("best-time metric label must match the recommended hour")
+        if self.environmental_concerns is None and any(
+            entry.metric.label is not self.metric_label for entry in self.hourly
+        ):
             raise ValueError("hourly metric labels must match best-time metric label")
+        if self.environmental_concerns is not None:
+            concern_hours = [profile.hour for profile in self.environmental_concerns]
+            if concern_hours != hours:
+                raise ValueError("environmental concerns must align with hourly evidence")
+        if self.recommended_hour_tcm_celsius is not None and not math.isfinite(
+            self.recommended_hour_tcm_celsius
+        ):
+            raise ValueError("recommended_hour_tcm_celsius must be finite")
+        for name, value in (
+            ("exceedance_hours", self.exceedance_hours),
+            ("persistence_hours", self.persistence_hours),
+        ):
+            if value is not None and (not math.isfinite(value) or value < 0):
+                raise ValueError(f"{name} must be finite and non-negative")
+        framing_present = self.exceedance_hours is not None or self.persistence_hours is not None
+        if framing_present and self.framing_threshold_celsius is None:
+            raise ValueError("available framing metrics require a threshold")
+        if self.framing_threshold_celsius is not None and not math.isfinite(
+            self.framing_threshold_celsius
+        ):
+            raise ValueError("framing_threshold_celsius must be finite")
+        if self.framing_direction not in (None, "above", "below"):
+            raise ValueError("framing_direction must be above or below")
+        if framing_present and self.framing_direction is None:
+            raise ValueError("available framing metrics require a direction")
         recommendation = next(
             entry.metric.value for entry in self.hourly if entry.hour == self.recommendation_hour
         )
@@ -560,8 +601,10 @@ class BestTimeResult:
             self.heat_interpretation is not None
             and self.heat_interpretation.guidance_policy is GuidancePolicy.CAUTIOUS
         )
-        if not policy_selected and recommendation != min(
-            entry.metric.value for entry in self.hourly
+        if (
+            not policy_selected
+            and self.environmental_concerns is None
+            and recommendation != min(entry.metric.value for entry in self.hourly)
         ):
             raise ValueError("recommendation_hour must be a coolest available hour")
 

--- a/app/domain/environmental_parameters.py
+++ b/app/domain/environmental_parameters.py
@@ -1,0 +1,21 @@
+"""Canonical environmental parameter vocabulary used by product policy."""
+
+ENVIRONMENT_PARAMETERS = (
+    "heat_index_celsius",
+    "apparent_temperature_celsius",
+    "wet_bulb_temperature_celsius",
+    "relative_humidity_percent",
+    "precipitation_mm",
+    "cloud_cover_octas",
+    "elevation",
+    "air_quality:idx",
+    "air_quality_pm2p5:idx",
+    "air_quality_pm10:idx",
+    "air_quality_no2:idx",
+    "aqi_us_co",
+    "air_quality_o3:idx",
+    "air_quality_so2:idx",
+    "methane_ppb",
+    "co2_ppm",
+    "solar_irradiance",
+)

--- a/app/integrations/fortyguard/contracts.py
+++ b/app/integrations/fortyguard/contracts.py
@@ -21,12 +21,18 @@ from app.domain.analysis import (
     join_polygon_to_tiles,
 )
 from app.domain.environment import TimeWindow
+from app.domain.environmental_parameters import (
+    ENVIRONMENT_PARAMETERS as DOMAIN_ENVIRONMENT_PARAMETERS,
+)
 from app.domain.provenance import Provenance, Transformation
 from app.domain.security import sanitize_payload
 from app.integrations.fortyguard.client import ActivityMetadata
 
 PROVIDER_CONFIG_VERSION = "fortyguard-config-v1"
 """Provider/request-construction semantics a response was produced under (ADR 0004)."""
+
+# Public integration alias retained for request construction and existing callers.
+ENVIRONMENT_PARAMETERS = DOMAIN_ENVIRONMENT_PARAMETERS
 
 
 class AnalyticType(str, Enum):
@@ -212,27 +218,6 @@ class AreaHeatmapRequest:
             "unit": self.unit,
             "unit_source": self.unit_source,
         }
-
-
-ENVIRONMENT_PARAMETERS = (
-    "heat_index_celsius",
-    "apparent_temperature_celsius",
-    "wet_bulb_temperature_celsius",
-    "relative_humidity_percent",
-    "precipitation_mm",
-    "cloud_cover_octas",
-    "elevation",
-    "air_quality:idx",
-    "air_quality_pm2p5:idx",
-    "air_quality_pm10:idx",
-    "air_quality_no2:idx",
-    "aqi_us_co",
-    "air_quality_o3:idx",
-    "air_quality_so2:idx",
-    "methane_ppb",
-    "co2_ppm",
-    "solar_irradiance",
-)
 
 
 @dataclass(frozen=True)

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Callable, Mapping
 
@@ -34,6 +34,7 @@ from app.domain.contracts import (
     UnavailableResult,
 )
 from app.domain.environment import select_anchor_celsius
+from app.domain.best_time import HourlyConcernProfile, assess_hour, select_best_time
 from app.domain.heat_policy import classify_heat
 from app.integrations.fortyguard.contracts import (
     AnalyticType,
@@ -48,6 +49,10 @@ from app.services.execution import (
     UnavailableError,
 )
 from app.services.sidecars import load_acquisition_record
+
+
+FRAMING_THRESHOLD_CELSIUS = 35.0
+FRAMING_DIRECTION = "above"
 
 
 class FixtureTripAnalysisAdapter:
@@ -112,7 +117,7 @@ class LiveTripAnalysisAdapter:
 
 
 class TemporalTripAnalysisAdapter:
-    """Chain one ranged point heatmap into one ranged environment request."""
+    """Build the best-time decision from one reusable landmark series."""
 
     def __init__(
         self,
@@ -148,6 +153,12 @@ class TemporalTripAnalysisAdapter:
         try:
             heatmap = self.heatmap_execution.run(heatmap_request, live=True)
             anchor = select_anchor_celsius(heatmap.tiles, request.window)
+        except (UnavailableError, ValueError) as error:
+            return _unavailable_response(request, execution_mode, str(error))
+
+        environment: EnvironmentSeriesResult | None = None
+        environment_failure: str | None = None
+        try:
             env_request = EnvParamsRequest(
                 latitude=heatmap_request.latitude,
                 longitude=heatmap_request.longitude,
@@ -159,14 +170,221 @@ class TemporalTripAnalysisAdapter:
             outcome = self.env_params_execution.run(env_request, live=True)
             environment = _environment_result(request, anchor, heatmap, outcome)
         except (UnavailableError, ValueError) as error:
+            environment_failure = str(error)
+
+        exceedance_hours = self._framing_value(heatmap_request, AnalyticType.EXCEEDANCE)
+        persistence_hours = self._framing_value(heatmap_request, AnalyticType.PERSISTENCE)
+        try:
+            best_time = _best_time_result(
+                request,
+                heatmap,
+                environment,
+                environment_failure=environment_failure,
+                exceedance_hours=exceedance_hours,
+                persistence_hours=persistence_hours,
+            )
+        except ValueError as error:
             return _unavailable_response(request, execution_mode, str(error))
         return TripAnalysisResponse(
             request_identity=_request_identity(request),
             mode=request.mode,
             execution_mode=execution_mode,
-            state=ResultState.SERIES_READY,
-            environment=environment,
+            state=ResultState.DEGRADED,
+            best_time=best_time,
+            degraded_reasons={
+                "hotels": "hotel ranking is not implemented on the temporal live path",
+                "routes": "route comparison is not implemented on the temporal live path",
+            },
         )
+
+    def _framing_value(
+        self, tcm_request: HeatmapRequest, analytic_type: AnalyticType
+    ) -> float | None:
+        request = HeatmapRequest(
+            analytic_type=analytic_type,
+            latitude=tcm_request.latitude,
+            longitude=tcm_request.longitude,
+            start_date=tcm_request.start_date,
+            forecast=tcm_request.forecast,
+            threshold_celsius=FRAMING_THRESHOLD_CELSIUS,
+            direction=FRAMING_DIRECTION,
+            start_hour=tcm_request.start_hour,
+            end_hour=tcm_request.end_hour,
+        )
+        try:
+            result = self.heatmap_execution.run(request, live=True)
+        except (UnavailableError, ValueError):
+            return None
+        return max((tile.metric_value for tile in result.tiles), default=None)
+
+
+def _best_time_result(
+    request: TripAnalysisRequest,
+    heatmap: HeatmapResult,
+    environment: EnvironmentSeriesResult | None,
+    *,
+    environment_failure: str | None,
+    exceedance_hours: float | None,
+    persistence_hours: float | None,
+) -> BestTimeResult:
+    tcm_by_hour = {
+        hour: max(
+            tile.value_celsius
+            for tile in heatmap.tiles
+            if tile.valid_time.hour == hour and tile.value_celsius is not None
+        )
+        for hour in request.window.hours
+        if any(
+            tile.valid_time.hour == hour and tile.value_celsius is not None
+            for tile in heatmap.tiles
+        )
+    }
+    if not tcm_by_hour:
+        raise ValueError("no TCM values are available in the traveler window")
+    parameters_by_hour = (
+        {entry.valid_time.hour: entry.parameters for entry in environment.entries}
+        if environment is not None
+        else {}
+    )
+    profiles = tuple(
+        assess_hour(
+            hour,
+            tcm_celsius=tcm,
+            parameters=parameters_by_hour.get(hour, {}),
+        )
+        for hour, tcm in sorted(tcm_by_hour.items())
+    )
+    decision = select_best_time(profiles, cautious=request.cautious)
+    hourly = tuple(
+        HourlyEntry(
+            hour=profile.hour,
+            metric=Metric(
+                value=profile.primary_thermal_value,
+                unit="C",
+                label=(
+                    MetricLabel.NOAA_HEAT_INDEX
+                    if profile.primary_thermal_metric is HeatMetricName.HEAT_INDEX_CELSIUS
+                    else MetricLabel.PROVIDER_TCM
+                ),
+                is_actual_heat_index=(
+                    profile.primary_thermal_metric is HeatMetricName.HEAT_INDEX_CELSIUS
+                ),
+            ),
+        )
+        for profile in profiles
+    )
+    provenance = (
+        environment.provenance
+        if environment is not None
+        else _heatmap_product_provenance(request, heatmap)
+    )
+    provenance = _best_time_provenance(
+        provenance,
+        profiles,
+        heatmap=heatmap,
+        exceedance_hours=exceedance_hours,
+        persistence_hours=persistence_hours,
+    )
+    reason = decision.reason
+    if environment_failure is not None:
+        reason = f"TCM-only fallback because environmental parameters are unavailable; {reason}"
+    selected_label = next(entry.metric.label for entry in hourly if entry.hour == decision.hour)
+    return BestTimeResult(
+        hourly=hourly,
+        recommendation_hour=decision.hour,
+        recommendation_reason=reason,
+        metric_label=selected_label,
+        provenance=provenance,
+        hourly_coverage=len(hourly) / 24,
+        heat_interpretation=classify_heat(
+            decision.profile.primary_thermal_value,
+            metric=decision.profile.primary_thermal_metric,
+            cautious=request.cautious,
+        ),
+        environmental_concerns=profiles,
+        recommended_hour_tcm_celsius=tcm_by_hour[decision.hour],
+        exceedance_hours=exceedance_hours,
+        persistence_hours=persistence_hours,
+        framing_threshold_celsius=FRAMING_THRESHOLD_CELSIUS,
+        framing_direction=FRAMING_DIRECTION,
+    )
+
+
+def _best_time_provenance(
+    provenance: Provenance,
+    profiles: tuple[HourlyConcernProfile, ...],
+    *,
+    heatmap: HeatmapResult,
+    exceedance_hours: float | None,
+    persistence_hours: float | None,
+) -> Provenance:
+    configuration = dict(provenance.request_configuration)
+    configuration.update(
+        {
+            "framing_threshold_celsius": FRAMING_THRESHOLD_CELSIUS,
+            "framing_direction": FRAMING_DIRECTION,
+            "exceedance_available": exceedance_hours is not None,
+            "persistence_available": persistence_hours is not None,
+            "environment_parameter_count": len(profiles[0].concerns),
+            "reported_parameter_observations": sum(
+                len(profile.concerns) - profile.not_reported_count for profile in profiles
+            ),
+            "not_reported_parameter_observations": sum(
+                profile.not_reported_count for profile in profiles
+            ),
+            "tcm_source": heatmap.provenance.source,
+            "environment_source": provenance.source,
+        }
+    )
+    return Provenance(
+        source=(
+            heatmap.provenance.source
+            if heatmap.provenance.source != "provider"
+            else provenance.source
+        ),
+        data_date=provenance.data_date,
+        confidence=provenance.confidence,
+        retrieved_at=provenance.retrieved_at,
+        transformation_version="best-time-decision-v1",
+        provider=provenance.provider,
+        response_status=provenance.response_status,
+        request_configuration=configuration,
+        fresh=provenance.fresh and not heatmap.provenance.stale,
+        coverage=provenance.coverage,
+        note=provenance.note,
+        activity_id=provenance.activity_id,
+    )
+
+
+def _heatmap_product_provenance(request: TripAnalysisRequest, heatmap: HeatmapResult) -> Provenance:
+    provider_provenance = heatmap.provenance
+    retrieved_at = provider_provenance.retrieved_at
+    if not isinstance(retrieved_at, datetime):
+        raise ValueError("heatmap provenance retrieval time is incomplete")
+    return Provenance(
+        source=provider_provenance.source,
+        data_date=provider_provenance.data_date,
+        confidence=Confidence.SUFFICIENT,
+        retrieved_at=retrieved_at.isoformat(),
+        transformation_version="best-time-decision-v1",
+        provider="fortyguard",
+        response_status="completed",
+        request_configuration={
+            "latitude": request.destination.latitude,
+            "longitude": request.destination.longitude,
+            "start_date": request.date,
+            "start_hour": request.start_hour,
+            "end_hour": request.end_hour,
+            "anchor_policy": "maximum_in_window_temperature_celsius",
+            "forecast": provider_provenance.forecast,
+            "heatmap_transformations": [
+                {"name": transformation.name, "version": transformation.version}
+                for transformation in provider_provenance.transformations
+            ],
+        },
+        fresh=not provider_provenance.stale,
+        activity_id=provider_provenance.activity_id,
+    )
 
 
 def _environment_result(
@@ -205,6 +423,15 @@ def _environment_result(
             "anchor_policy": "maximum_in_window_temperature_celsius",
             "heatmap_source": heatmap.provenance.source,
             "heatmap_activity_id": heatmap.provenance.activity_id,
+            "forecast": heatmap.provenance.forecast,
+            "heatmap_transformations": [
+                {"name": transformation.name, "version": transformation.version}
+                for transformation in heatmap.provenance.transformations
+            ],
+            "environment_transformations": [
+                {"name": transformation.name, "version": transformation.version}
+                for transformation in outcome.transformations
+            ],
         },
         fresh=not heatmap.provenance.stale and not outcome.stale,
         activity_id=outcome.activity_id,

--- a/docs/adr/0001-live-provider-adapter-boundary.md
+++ b/docs/adr/0001-live-provider-adapter-boundary.md
@@ -88,6 +88,10 @@ properties.
    behavior. Hotel, route, best-time, and comfort decisions remain outside
    this preparation stage.
 
+   **Superseded in part by ADR 0005:** issue #14 extends this adapter into the
+   best-time decision and adds optional exceedance/persistence calls. The
+   window, anchor, cache, and submit-once rules above remain current.
+
 ## Consequences
 
 - Issue #7's "resolve the transport/payload mismatch explicitly" lock is

--- a/docs/adr/0005-best-time-decision-orchestration.md
+++ b/docs/adr/0005-best-time-decision-orchestration.md
@@ -1,0 +1,43 @@
+# ADR 0005: Best-time decision orchestration
+
+Date: 2026-08-29
+Status: Accepted
+
+## Context
+
+ADR 0001 established a series-only temporal preparation stage for issue #44.
+Issue #14 consumes that foundation to make the traveler-facing best-time
+decision. The decision needs the reusable TCM and environmental series plus two
+optional daily-burden measures: exceedance and persistence above a declared
+35°C product threshold.
+
+## Decision
+
+`TemporalTripAnalysisAdapter` now owns the complete live best-time stage. It
+runs one ranged TCM request and one identically ranged environmental-parameters
+request, then assesses all 17 requested parameters per available TCM hour. It
+also runs one exceedance and one persistence request at 35°C in the `above`
+direction. Framing failures are non-blocking. Environmental-series failure
+produces an explicit TCM-only fallback whose concern profile marks all provider
+parameters `not_reported`.
+
+The adapter returns a degraded trip analysis with `best_time` populated while
+hotel and route decisions remain absent. `BestTimeResult` retains hourly
+evidence, environmental concern profiles, the selected hour's raw TCM value,
+optional framing metrics, and provenance so route gating can reuse the evidence
+without another landmark request.
+
+This decision supersedes ADR 0001 section 8 only where that section limits the
+temporal adapter to `series_ready` preparation and excludes the best-time
+decision. Its request-window, anchor, cache, and submit-once rules remain in
+force.
+
+## Consequences
+
+- The live best-time stage uses four provider activities when all data is
+  available; exceedance and persistence are independently optional.
+- Missing environmental data is visible rather than assumed safe.
+- The API and frontend expose recommendation reason, metric, date, source,
+  freshness, concerns, and framing context.
+- Hotel and route work can consume `recommended_hour_tcm_celsius` and the
+  retained concern profile without another landmark heatmap call.

--- a/frontend/src/screens/TripSetupScreen.tsx
+++ b/frontend/src/screens/TripSetupScreen.tsx
@@ -2,8 +2,12 @@ import { AlertTriangle, CheckCircle2, Database, Radio } from "lucide-react";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useAppState } from "../app/AppState";
 import { dataClient } from "../services/dataClient";
-import type { ExecutionMode, TripAnalysisRequest } from "../types";
-import type { HeatInterpretation } from "../types";
+import type {
+  BestTimeResult,
+  ExecutionMode,
+  HeatInterpretation,
+  TripAnalysisRequest,
+} from "../types";
 
 const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
 
@@ -44,6 +48,103 @@ function parameterUnit(name: string) {
   if (name.includes("elevation")) return "m";
   if (name.includes("index") || name.includes("temperature")) return "C";
   return "";
+}
+
+function BestTimeSummary({ result }: { result: BestTimeResult }) {
+  const configuration = result.provenance.request_configuration;
+  const dataMode = configuration.forecast === true ? "forecast" : "historical";
+  const source =
+    result.provenance.source === "fixture"
+      ? "Fixture replay"
+      : result.provenance.source === "cache"
+        ? "Cached data"
+        : "Provider data";
+  const freshness = result.provenance.fresh ? "fresh" : "stale";
+  const selected = result.environmental_concerns?.find(
+    (profile) => profile.hour === result.recommendation_hour
+  );
+
+  return (
+    <section aria-label="Best visit time">
+      <h3>
+        Recommended visit: {String(result.recommendation_hour).padStart(2, "0")}
+        :00
+      </h3>
+      <p>{result.recommendation_reason}</p>
+      <p>
+        {source}, {dataMode}, {freshness}. Data date:{" "}
+        {result.provenance.data_date}.
+      </p>
+      {result.exceedance_hours !== null &&
+        result.framing_threshold_celsius !== null && (
+          <p>
+            {result.exceedance_hours.toFixed(1)} hours{" "}
+            {result.framing_direction}{" "}
+            {result.framing_threshold_celsius.toFixed(1)} °C.
+          </p>
+        )}
+      {result.persistence_hours !== null &&
+        result.framing_threshold_celsius !== null && (
+          <p>
+            Longest stretch {result.framing_direction}{" "}
+            {result.framing_threshold_celsius.toFixed(1)} °C:{" "}
+            {result.persistence_hours.toFixed(1)} hours.
+          </p>
+        )}
+      {selected && (
+        <p>
+          Environmental profile: {selected.high_count} high,{" "}
+          {selected.elevated_count} elevated, {selected.not_reported_count} not
+          reported.
+        </p>
+      )}
+      {result.environmental_concerns && (
+        <div className="series-table-wrap">
+          <table className="series-table">
+            <caption>Hourly best-time evidence</caption>
+            <thead>
+              <tr>
+                <th scope="col">Time</th>
+                <th scope="col">Thermal metric</th>
+                <th scope="col">Environmental concerns</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.environmental_concerns.map((profile) => (
+                <tr key={profile.hour}>
+                  <th scope="row">
+                    {String(profile.hour).padStart(2, "0")}:00
+                  </th>
+                  <td>
+                    {profile.primary_thermal_value.toFixed(1)} °C{" "}
+                    {profile.primary_thermal_metric === "tcm"
+                      ? "provider TCM"
+                      : "NOAA Heat Index"}
+                  </td>
+                  <td>
+                    {profile.concerns
+                      .filter((concern) => concern.concern_level !== "none")
+                      .map(
+                        (concern) =>
+                          `${formatParameterName(concern.parameter)}: ${
+                            concern.available
+                              ? `${concern.concern_level} (${formatMetric(
+                                  concern.value,
+                                  concern.unit
+                                )})`
+                              : "not reported by provider"
+                          }`
+                      )
+                      .join("; ") || "None"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
 }
 
 export function TripSetupScreen() {
@@ -459,12 +560,12 @@ export function TripSetupScreen() {
             {(tripAnalysis.state === "success" ||
               tripAnalysis.state === "degraded") &&
               tripAnalysis.best_time && (
-                <HeatPolicySummary
-                  value={
-                    tripAnalysis.best_time.heat_interpretation as
-                      HeatInterpretation | undefined
-                  }
-                />
+                <>
+                  <BestTimeSummary result={tripAnalysis.best_time} />
+                  <HeatPolicySummary
+                    value={tripAnalysis.best_time.heat_interpretation}
+                  />
+                </>
               )}
             <button
               type="button"

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -202,9 +202,44 @@ function validRoutes(value: unknown) {
 }
 
 function validBestTime(value: unknown) {
-  return (
-    value === null ||
-    (isObject(value) && validHeatInterpretation(value.heat_interpretation))
+  if (value === null) return true;
+  if (
+    !isObject(value) ||
+    !validHeatInterpretation(value.heat_interpretation) ||
+    !Array.isArray(value.hourly) ||
+    typeof value.hourly_coverage !== "number" ||
+    typeof value.recommendation_hour !== "number" ||
+    typeof value.recommendation_reason !== "string" ||
+    !(
+      value.recommended_hour_tcm_celsius === null ||
+      typeof value.recommended_hour_tcm_celsius === "number"
+    ) ||
+    !isObject(value.provenance) ||
+    !(
+      value.environmental_concerns === null ||
+      Array.isArray(value.environmental_concerns)
+    )
+  ) {
+    return false;
+  }
+  return (value.environmental_concerns ?? []).every(
+    (profile) =>
+      isObject(profile) &&
+      typeof profile.hour === "number" &&
+      typeof profile.primary_thermal_value === "number" &&
+      ["tcm", "heat_index_celsius"].includes(
+        String(profile.primary_thermal_metric)
+      ) &&
+      Array.isArray(profile.concerns) &&
+      profile.concerns.every(
+        (concern) =>
+          isObject(concern) &&
+          typeof concern.parameter === "string" &&
+          typeof concern.available === "boolean" &&
+          ["none", "elevated", "high", "not_reported"].includes(
+            String(concern.concern_level)
+          )
+      )
   );
 }
 

--- a/frontend/src/test/tripSetup.test.tsx
+++ b/frontend/src/test/tripSetup.test.tsx
@@ -17,6 +17,30 @@ const successResponse = {
   environment: null,
   best_time: {
     hourly: [],
+    hourly_coverage: 1,
+    recommendation_hour: 9,
+    recommendation_reason: "coolest period with no environmental concerns",
+    metric_label: "provider_tcm",
+    recommended_hour_tcm_celsius: 29,
+    exceedance_hours: 4,
+    persistence_hours: 2,
+    framing_threshold_celsius: 35,
+    framing_direction: "above",
+    environmental_concerns: [],
+    provenance: {
+      source: "fixture",
+      data_date: "2026-08-23",
+      confidence: "sufficient",
+      retrieved_at: "2026-08-24T00:00:00Z",
+      transformation_version: "best-time-decision-v1",
+      provider: "fortyguard",
+      response_status: "completed",
+      request_configuration: { forecast: false },
+      fresh: true,
+      coverage: 1,
+      note: null,
+      activity_id: null,
+    },
     heat_interpretation: {
       metric: "tcm",
       value_celsius: 29,
@@ -102,6 +126,14 @@ describe("curated Trip Setup", () => {
       screen.getByText(/29.0 °C provider temperature metric/)
     ).toBeInTheDocument();
     expect(screen.getByText(/NOAA Heat Index unavailable/)).toBeInTheDocument();
+    expect(screen.getByText("Recommended visit: 09:00")).toBeInTheDocument();
+    expect(
+      screen.getByText("coolest period with no environmental concerns")
+    ).toBeInTheDocument();
+    expect(screen.getByText(/4.0 hours above 35.0 °C/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Fixture replay.*historical.*fresh/i)
+    ).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(1, "/health", expect.any(Object));
     expect(fetchMock).toHaveBeenNthCalledWith(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -146,6 +146,50 @@ export type EnvironmentSeriesResult = {
   provenance: ApiProvenance;
 };
 
+export type ParameterConcern = {
+  parameter: string;
+  value: number | null;
+  unit: string;
+  available: boolean;
+  concern_level: "none" | "elevated" | "high" | "not_reported";
+  threshold: number | null;
+  threshold_source: string | null;
+};
+
+export type HourlyConcernProfile = {
+  hour: number;
+  concerns: ParameterConcern[];
+  elevated_count: number;
+  high_count: number;
+  not_reported_count: number;
+  primary_thermal_value: number;
+  primary_thermal_metric: "tcm" | "heat_index_celsius";
+};
+
+export type BestTimeResult = {
+  hourly: Array<{
+    hour: number;
+    metric: {
+      value: number;
+      unit: string;
+      label: "provider_tcm" | "noaa_heat_index";
+      is_actual_heat_index: boolean;
+    };
+  }>;
+  hourly_coverage: number;
+  recommendation_hour: number;
+  recommendation_reason: string;
+  metric_label: "provider_tcm" | "noaa_heat_index";
+  provenance: ApiProvenance;
+  heat_interpretation?: HeatInterpretation;
+  environmental_concerns: HourlyConcernProfile[] | null;
+  recommended_hour_tcm_celsius: number | null;
+  exceedance_hours: number | null;
+  persistence_hours: number | null;
+  framing_threshold_celsius: number | null;
+  framing_direction: "above" | "below" | null;
+};
+
 export type TripAnalysisRequest = {
   mode: "curated";
   origin_latitude: number;
@@ -167,9 +211,7 @@ export type TripAnalysisResponse = {
   execution_mode: ExecutionMode;
   state: "series_ready" | "success" | "degraded" | "unavailable" | "error";
   environment: EnvironmentSeriesResult | null;
-  best_time:
-    | ({ heat_interpretation?: HeatInterpretation } & Record<string, unknown>)
-    | null;
+  best_time: BestTimeResult | null;
   hotels: Record<string, unknown> | null;
   routes: Record<string, unknown> | null;
   unavailable: { reason: string; recoverable: boolean } | null;

--- a/tests/test_best_time.py
+++ b/tests/test_best_time.py
@@ -1,0 +1,81 @@
+from app.domain.best_time import assess_hour, select_best_time
+from app.domain.contracts import HeatMetricName
+
+
+def test_selects_coolest_when_no_concerns() -> None:
+    profiles = (
+        assess_hour(8, tcm_celsius=31.0, parameters={}),
+        assess_hour(9, tcm_celsius=29.0, parameters={}),
+    )
+
+    decision = select_best_time(profiles, cautious=False)
+
+    assert decision.hour == 9
+    assert decision.reason == "coolest period with no environmental concerns"
+    assert decision.profile.primary_thermal_metric is HeatMetricName.TCM
+
+
+def test_bad_aqi_penalizes_cool_hour() -> None:
+    profiles = (
+        assess_hour(8, tcm_celsius=28.0, parameters={"air_quality:idx": 125.0}),
+        assess_hour(9, tcm_celsius=30.0, parameters={"air_quality:idx": 25.0}),
+    )
+
+    decision = select_best_time(profiles, cautious=False)
+
+    assert decision.hour == 9
+    aqi = next(
+        concern for concern in profiles[0].concerns if concern.parameter == "air_quality:idx"
+    )
+    assert (aqi.concern_level, aqi.threshold, aqi.threshold_source) == (
+        "high",
+        101.0,
+        "epa_aqi",
+    )
+
+
+def test_concern_profile_is_complete_and_missing_values_are_not_penalized() -> None:
+    missing = assess_hour(8, tcm_celsius=29.0, parameters={})
+    available = assess_hour(
+        9,
+        tcm_celsius=29.0,
+        parameters={"precipitation_mm": 0.2, "wet_bulb_temperature_celsius": 32.0},
+    )
+
+    decision = select_best_time((available, missing), cautious=False)
+
+    assert len(missing.concerns) == 17
+    assert missing.not_reported_count == 17
+    assert missing.elevated_count == missing.high_count == 0
+    assert decision.hour == 8
+    wet_bulb = next(
+        concern
+        for concern in available.concerns
+        if concern.parameter == "wet_bulb_temperature_celsius"
+    )
+    assert (wet_bulb.concern_level, wet_bulb.threshold_source) == (
+        "high",
+        "published_physiology",
+    )
+
+
+def test_cautious_guidance_prefers_below_action_threshold_before_temperature() -> None:
+    profiles = (
+        assess_hour(8, tcm_celsius=33.0, parameters={}),
+        assess_hour(9, tcm_celsius=29.0, parameters={"relative_humidity_percent": 65.0}),
+    )
+
+    assert select_best_time(profiles, cautious=False).hour == 8
+    assert select_best_time(profiles, cautious=True).hour == 9
+
+
+def test_equal_temperature_with_different_concerns_is_not_described_as_flat() -> None:
+    profiles = (
+        assess_hour(8, tcm_celsius=29.0, parameters={}),
+        assess_hour(9, tcm_celsius=29.0, parameters={"air_quality:idx": 75.0}),
+    )
+
+    decision = select_best_time(profiles, cautious=False)
+
+    assert decision.hour == 8
+    assert "flat environmental profile" not in decision.reason

--- a/tests/test_temporal_trip_orchestration.py
+++ b/tests/test_temporal_trip_orchestration.py
@@ -73,6 +73,23 @@ def _heatmap_payload() -> dict[str, object]:
     }
 
 
+def _framing_payload(value: float) -> dict[str, object]:
+    return {
+        "mode": "historical",
+        "features": [
+            {
+                "geometry": {"type": "Point", "coordinates": [-98.485833, 29.425833]},
+                "properties": {
+                    "id": "framing",
+                    "value": value,
+                    "unit": "hours",
+                    "valid_time": "2026-08-23T08:00:00-05:00",
+                },
+            }
+        ],
+    }
+
+
 def _env_payload() -> dict[str, object]:
     return {
         "metadata": {
@@ -101,6 +118,10 @@ def test_temporal_adapter_chains_one_heatmap_call_into_one_env_params_call(
 
     def load_heatmap(request: HeatmapRequest) -> Mapping[str, object]:
         heatmap_requests.append(request)
+        if request.analytic_type.value == "exceedance":
+            return _framing_payload(4.0)
+        if request.analytic_type.value == "persistence":
+            return _framing_payload(2.0)
         return _heatmap_payload()
 
     def load_environment(request: EnvParamsRequest) -> Mapping[str, object]:
@@ -114,7 +135,7 @@ def test_temporal_adapter_chains_one_heatmap_call_into_one_env_params_call(
 
     response = adapter.analyze(_request(), ExecutionMode.LIVE)
 
-    assert len(heatmap_requests) == 1
+    assert len(heatmap_requests) == 3
     assert len(env_requests) == 1
     heatmap_request = heatmap_requests[0]
     env_request = env_requests[0]
@@ -132,17 +153,26 @@ def test_temporal_adapter_chains_one_heatmap_call_into_one_env_params_call(
         env_request.end_hour,
     )
     assert env_request.temperature_anchor_celsius == 39.4
-    assert response.state is ResultState.SERIES_READY
-    assert response.environment is not None
-    assert response.environment.temperature_anchor_celsius == 39.4
-    assert response.environment.entries[0].heat_index_celsius is None
-    assert response.environment.entries[1].humidity_percent is None
-    assert response.best_time is None
+    assert response.state is ResultState.DEGRADED
+    assert response.environment is None
+    assert response.best_time is not None
+    assert response.best_time.recommendation_hour == 15
+    assert response.best_time.recommended_hour_tcm_celsius == 39.4
+    assert response.best_time.exceedance_hours == 4.0
+    assert response.best_time.persistence_hours == 2.0
+    assert response.best_time.framing_threshold_celsius == 35.0
+    assert response.best_time.framing_direction == "above"
+    assert response.best_time.environmental_concerns is not None
+    assert response.best_time.environmental_concerns[0].not_reported_count == 16
     assert response.hotels is None
     assert response.routes is None
-    assert response.environment.provenance.request_configuration["anchor_policy"] == (
+    assert response.best_time.provenance.request_configuration["anchor_policy"] == (
         "maximum_in_window_temperature_celsius"
     )
+    assert response.best_time.provenance.request_configuration["forecast"] is False
+    assert response.best_time.metric_label.value == "provider_tcm"
+    assert response.best_time.hourly[0].metric.label.value == "noaa_heat_index"
+    assert response.best_time.hourly[1].metric.label.value == "provider_tcm"
 
 
 def test_heatmap_unavailable_stops_before_env_params_call(tmp_path: Path) -> None:
@@ -192,11 +222,39 @@ def test_env_params_unavailable_returns_explicit_unavailable_after_one_call(
 
     response = adapter.analyze(_request(), ExecutionMode.LIVE)
 
-    assert heatmap_calls == 1
+    assert heatmap_calls == 3
     assert env_calls == 1
-    assert response.state is ResultState.UNAVAILABLE
-    assert response.unavailable is not None
-    assert "environmental-parameters" in response.unavailable.reason
+    assert response.state is ResultState.DEGRADED
+    assert response.best_time is not None
+    assert response.best_time.recommendation_hour == 9
+    assert "TCM-only fallback" in response.best_time.recommendation_reason
+    assert response.best_time.environmental_concerns is not None
+    assert all(
+        profile.not_reported_count == 17 for profile in response.best_time.environmental_concerns
+    )
+
+
+def test_framing_metrics_are_optional_when_their_calls_fail(tmp_path: Path) -> None:
+    def load_heatmap(request: HeatmapRequest) -> Mapping[str, object]:
+        if request.analytic_type.value != "tcm":
+            raise ConnectionError("framing unavailable")
+        return _heatmap_payload()
+
+    adapter = TemporalTripAnalysisAdapter(
+        HeatmapExecution(fixture_path=tmp_path / "heatmap.json", live_loader=load_heatmap),
+        EnvParamsExecution(
+            fixture_path=tmp_path / "env.json",
+            live_loader=lambda request: _env_payload(),
+        ),
+    )
+
+    response = adapter.analyze(_request(), ExecutionMode.LIVE)
+
+    assert response.state is ResultState.DEGRADED
+    assert response.best_time is not None
+    assert response.best_time.exceedance_hours is None
+    assert response.best_time.persistence_hours is None
+    assert response.best_time.recommendation_hour == 15
 
 
 def test_production_wiring_uses_temporal_adapter_for_live_trip_requests(
@@ -253,9 +311,10 @@ def test_production_wiring_uses_temporal_adapter_for_live_trip_requests(
 
     assert response.status_code == 200
     body: dict[str, Any] = response.json()
-    assert body["state"] == "series_ready"
-    assert body["environment"]["temperature_anchor_celsius"] == 39.4
-    assert body["best_time"] is None
+    assert body["state"] == "degraded"
+    assert body["environment"] is None
+    assert body["best_time"]["recommendation_hour"] == 15
+    assert body["best_time"]["recommended_hour_tcm_celsius"] == 39.4
 
 
 def test_trip_endpoint_maps_orchestration_budget_failure_to_503(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- assess all 17 requested environmental parameters per available hour and select the least-concerning visit period
- retain reusable hourly TCM, environmental concern profiles, recommended-hour TCM, and conservative provenance for route gating
- add optional 35 C exceedance and persistence framing with an explicit TCM-only fallback when environmental data is unavailable
- display the recommendation, reason, source, freshness, framing metrics, and hourly concern evidence in the trip UI
- record the orchestration decision in ADR 0005 and update the shared domain glossary

## Verification

- `538` backend unit tests passed
- `10` backend integration tests passed
- `21` frontend tests passed
- Python and frontend typechecks passed
- Ruff and ESLint passed
- final code review reported no blocking findings

Closes #14