### PR TITLE
Feature/osm building shade 19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,7 @@
+## Python environment
+
+Always use the repository's `.venv` directly for Python commands and tooling, for example `.venv/bin/python` and `.venv/bin/pytest`. Do not use `uv`.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -142,6 +142,28 @@ directly.
   elevated heat defers the final recommendation until modeled shade is
   available. Cautious guidance uses the same one-band-earlier policy as other
   heat decisions.
+- **Modeled building shade** — A deterministic OSM-based estimate of the
+  fraction of a returned route's length intersecting projected building-shadow
+  geometry at the exact recommended local timestamp while the sun is above the
+  horizon. It is not measured real-world shade and does not include trees,
+  awnings, clouds, or temporary obstructions.
+- **Building height quality** — The origin of a usable OSM building height:
+  `explicit` from a valid `height` tag, `inferred_levels` from valid
+  `building:levels` multiplied by the product approximation of 3 m per level,
+  or `unknown`. A valid explicit height takes precedence.
+- **Building-height coverage** — The area-weighted fraction of relevant OSM
+  building and `building:part` footprints in a returned route's analysis
+  corridor that have explicit or inferred heights. A route with no mapped
+  building footprints has zero coverage. The configurable 0.70 sufficiency
+  default is product policy, not an OSM or scientific standard.
+- **Nighttime route decision** — The final elevated-heat decision when solar
+  elevation is at or below the horizon. Building shade is zero and not
+  applicable; the coolest returned route by retained route TCM is recommended,
+  with distance used only to break equal-temperature ties.
+- **Insufficient shade comparison** — The explicit daytime state when modeled
+  building-shade evidence is weak or uncomputable. All returned alternatives
+  and available metrics remain visible, but the product makes no route
+  recommendation; the traveler compares the trade-offs.
 - **No suitable returned route** — The explicit state when the routing provider
   returns no valid pedestrian routes, or when every returned route lacks enough
   evidence for a recommendation. A single valid route is instead shown as the
@@ -160,6 +182,8 @@ directly.
 - ADR 0005 — best-time decision orchestration and retained route-gating evidence.
 - ADR 0006 — returned-route heat AOI, conservative per-route aggregation, and
   recommendation staging.
+- ADR 0007 — exact-time modeled shade, nighttime route decisions, and weak
+  shade-evidence behavior.
 - `docs/design/fortyguard-extraction.md` — extraction contract from issue #6.
 - Layout: `app/domain/` (pure contracts), `app/services/` (cache, execution,
   acquisition, sidecars, ledger store), `app/integrations/fortyguard/`

--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -14,6 +14,7 @@ from datetime import date as calendar_date, datetime
 from typing import TYPE_CHECKING, Mapping, Protocol
 
 from app.domain.environment import TimeWindow
+from app.domain.route_shade import ShadeConfidence
 
 if TYPE_CHECKING:
     from app.domain.best_time import HourlyConcernProfile
@@ -56,8 +57,18 @@ class RouteSetState(str, Enum):
 class RouteDecisionState(str, Enum):
     MILD_SHORTEST_RECOMMENDED = "mild_shortest_recommended"
     SHADE_REQUIRED = "shade_required"
+    SHADE_SHADIEST_RECOMMENDED = "shade_shadiest_recommended"
+    SHADE_ONLY_ROUTE_RECOMMENDED = "shade_only_route_recommended"
+    NIGHTTIME_COOLEST_RECOMMENDED = "nighttime_coolest_recommended"
+    INSUFFICIENT_SHADE_COMPARISON_REQUIRED = "insufficient_shade_comparison_required"
     HEAT_UNAVAILABLE = "heat_unavailable"
     NO_SUITABLE_RETURNED_ROUTE = "no_suitable_returned_route"
+
+
+class TemporalEvidenceState(str, Enum):
+    EXACT = "exact"
+    INCONSISTENT = "inconsistent"
+    UNAVAILABLE = "unavailable"
 
 
 class RouteHeatSource(str, Enum):
@@ -559,6 +570,9 @@ class BestTimeResult:
     persistence_hours: float | None = None
     framing_threshold_celsius: float | None = None
     framing_direction: str | None = None
+    recommendation_time: datetime | None = None
+    recommendation_timezone: str | None = None
+    temporal_evidence: TemporalEvidenceState = TemporalEvidenceState.UNAVAILABLE
 
     def __post_init__(self) -> None:
         if not isinstance(self.metric_label, MetricLabel):
@@ -608,6 +622,18 @@ class BestTimeResult:
             self.framing_threshold_celsius
         ):
             raise ValueError("framing_threshold_celsius must be finite")
+        if not isinstance(self.temporal_evidence, TemporalEvidenceState):
+            raise ValueError("temporal_evidence must be a TemporalEvidenceState value")
+        if self.recommendation_time is not None and (
+            self.recommendation_time.tzinfo is None or self.recommendation_time.utcoffset() is None
+        ):
+            raise ValueError("recommendation_time must include a timezone")
+        if self.temporal_evidence is TemporalEvidenceState.EXACT:
+            if self.recommendation_time is None or not self.recommendation_timezone:
+                raise ValueError("exact temporal evidence requires time and timezone")
+        else:
+            if self.recommendation_time is not None or self.recommendation_timezone is not None:
+                raise ValueError("non-exact temporal evidence must not carry a recommendation time")
         if self.framing_direction not in (None, "above", "below"):
             raise ValueError("framing_direction must be above or below")
         if framing_present and self.framing_direction is None:
@@ -741,7 +767,7 @@ class RouteOption:
     heat_metric: HeatMetricName
     heat_status: HeatStatus | None
     modeled_shade_percent: float | None
-    shade_confidence: Confidence | None
+    shade_confidence: ShadeConfidence | None
     building_coverage: float
     recommended: bool
     recommendation_reason: str | None
@@ -750,14 +776,24 @@ class RouteOption:
     geometry: tuple[tuple[float, float], ...] | None = None
     heat_coverage: float | None = None
     heat_source: RouteHeatSource | None = None
+    building_explicit_fraction: float = 0.0
+    building_inferred_levels_fraction: float = 0.0
+    building_unknown_fraction: float = 0.0
+    building_explicit_count: int = 0
+    building_inferred_levels_count: int = 0
+    building_unknown_count: int = 0
+    dropped_building_geometry_count: int = 0
+    shade_limitations: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not isinstance(self.heat_metric, HeatMetricName):
             raise ValueError("heat_metric must be a HeatMetricName value")
         if self.heat_status is not None and not isinstance(self.heat_status, HeatStatus):
             raise ValueError("heat_status must be a HeatStatus value or None")
-        if self.shade_confidence is not None and not isinstance(self.shade_confidence, Confidence):
-            raise ValueError("shade_confidence must be a Confidence value")
+        if self.shade_confidence is not None and not isinstance(
+            self.shade_confidence, ShadeConfidence
+        ):
+            raise ValueError("shade_confidence must be a ShadeConfidence value")
         if not isinstance(self.recommended, bool):
             raise ValueError("recommended must be a boolean")
         if not self.identity:
@@ -777,6 +813,28 @@ class RouteOption:
             raise ValueError("temperature route metrics must use C")
         if not 0 <= self.building_coverage <= 1:
             raise ValueError("building_coverage must be between 0 and 1")
+        quality_fractions = (
+            self.building_explicit_fraction,
+            self.building_inferred_levels_fraction,
+            self.building_unknown_fraction,
+        )
+        if any(not math.isfinite(value) or not 0 <= value <= 1 for value in quality_fractions):
+            raise ValueError("building quality fractions must be between 0 and 1")
+        if any(quality_fractions) and not math.isclose(sum(quality_fractions), 1.0, abs_tol=1e-6):
+            raise ValueError("nonzero building quality fractions must sum to 1")
+        quality_counts = (
+            self.building_explicit_count,
+            self.building_inferred_levels_count,
+            self.building_unknown_count,
+            self.dropped_building_geometry_count,
+        )
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in quality_counts
+        ):
+            raise ValueError("building quality counts must be non-negative integers")
+        if any(not limitation.strip() for limitation in self.shade_limitations):
+            raise ValueError("shade limitations must be non-empty strings")
         if self.heat_coverage is not None and not 0 <= self.heat_coverage <= 1:
             raise ValueError("route heat coverage must be between 0 and 1")
         if self.heat_source is not None and not isinstance(self.heat_source, RouteHeatSource):
@@ -915,6 +973,19 @@ class RouteComparisonResult:
                 raise ValueError("mild heat must recommend the shortest returned route")
             if len(recommended) != 1 or recommended[0].identity != self.recommended_id:
                 raise ValueError("exactly one recommended route must match recommended_id")
+            if recommended[0].recommendation_reason is None:
+                raise ValueError("recommended route requires recommendation_reason")
+        elif self.decision_state in {
+            RouteDecisionState.SHADE_SHADIEST_RECOMMENDED,
+            RouteDecisionState.SHADE_ONLY_ROUTE_RECOMMENDED,
+            RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED,
+        }:
+            if (
+                self.recommended_id is None
+                or len(recommended) != 1
+                or recommended[0].identity != self.recommended_id
+            ):
+                raise ValueError("final route decisions require exactly one recommendation")
             if recommended[0].recommendation_reason is None:
                 raise ValueError("recommended route requires recommendation_reason")
         else:
@@ -1070,6 +1141,10 @@ class TripAnalysisResponse:
                     or self.routes.decision_state
                     in {
                         RouteDecisionState.SHADE_REQUIRED,
+                        RouteDecisionState.SHADE_SHADIEST_RECOMMENDED,
+                        RouteDecisionState.SHADE_ONLY_ROUTE_RECOMMENDED,
+                        RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED,
+                        RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED,
                         RouteDecisionState.HEAT_UNAVAILABLE,
                         RouteDecisionState.NO_SUITABLE_RETURNED_ROUTE,
                     }

--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -881,6 +881,8 @@ class RouteComparisonResult:
     lowest_heat_route_id: str | None = None
     routing_provenance: Provenance | None = None
     heat_provenance: Provenance | None = None
+    building_provenance: Provenance | None = None
+    solar_provenance: Provenance | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.heat_metric, HeatMetricName):
@@ -913,6 +915,8 @@ class RouteComparisonResult:
             or self.heat_interpretation.value_celsius != self.corridor_heat_value
         ):
             raise ValueError("route comparison heat interpretation must match its metric and value")
+        if self.building_provenance is not None and self.solar_provenance is None:
+            raise ValueError("building provenance requires the solar position it was modeled at")
         if self.route_set_state is None and self.decision_state is None:
             self._validate_legacy_recommendation()
             return

--- a/app/domain/route_decision.py
+++ b/app/domain/route_decision.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence, cast
+from typing import Mapping, Sequence, cast
 
 from app.domain.contracts import (
     Confidence,
@@ -16,6 +16,7 @@ from app.domain.contracts import (
     RouteOption,
     RouteSetState,
 )
+from app.domain.route_shade import RouteShadeEvidence, ShadeConfidence
 from app.domain.heat_policy import classify_heat
 from app.domain.route_heat import RouteHeatEvidence
 from app.domain.routing import ReturnedRoute, RouteSet
@@ -29,6 +30,8 @@ class RouteDecisionInput:
     landmark_tcm_celsius: float | None
     heat_evidence: tuple[RouteHeatEvidence, ...] | None = None
     shared_heat_unavailable: bool = False
+    nighttime: bool = False
+    shade_evidence: Mapping[str, RouteShadeEvidence] | None = None
 
 
 def decide_route_comparison(
@@ -114,6 +117,110 @@ def decide_route_comparison(
     elevated = any(item.action_required for item in interpretations)
     lowest = routes[numeric_values.index(min(numeric_values))].identity
     if elevated:
+        if decision.nighttime:
+            heat_by_id = dict(
+                zip((route.identity for route in routes), numeric_values, strict=True)
+            )
+            coolest = min(
+                routes,
+                key=lambda route: (
+                    heat_by_id[route.identity],
+                    route.distance_m,
+                    route.identity,
+                ),
+            )
+            nighttime_evidence = {
+                route.identity: RouteShadeEvidence(
+                    modeled_shade_percent=0.0,
+                    building_coverage=0.0,
+                    confidence=ShadeConfidence.NOT_APPLICABLE,
+                    explicit_area_fraction=0.0,
+                    inferred_levels_area_fraction=0.0,
+                    unknown_area_fraction=0.0,
+                    explicit_count=0,
+                    inferred_levels_count=0,
+                    unknown_count=0,
+                    dropped_geometry_count=0,
+                )
+                for route in routes
+            }
+            options = _options(
+                routes,
+                values=numeric_values,
+                cautious=cautious,
+                source=source,
+                coverages=coverages,
+                recommended_id=coolest.identity,
+                recommendation_reason="coolest returned route at night",
+                shade_evidence=nighttime_evidence,
+            )
+            return _result(
+                options, route_set_state=route_set_state,
+                decision_state=RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED,
+                reason="sun is below the horizon; the coolest returned route is recommended",
+                confidence=Confidence.SUFFICIENT, provenance=provenance,
+                routing_provenance=routing_provenance, heat_provenance=heat_provenance,
+                heat_status=HeatStatus.ELEVATED, corridor_heat_value=max(numeric_values),
+                lowest_heat_route_id=lowest, cautious=cautious, recommended_id=coolest.identity,
+            )
+        shade_evidence = decision.shade_evidence
+        if shade_evidence is not None:
+            valid = all(
+                route.identity in shade_evidence
+                and shade_evidence[route.identity].confidence is ShadeConfidence.SUFFICIENT
+                for route in routes
+            )
+            if valid:
+                best = min(
+                    routes,
+                    key=lambda route: (
+                        -shade_evidence[route.identity].modeled_shade_percent,
+                        route.distance_m,
+                        route.identity,
+                    ),
+                )
+                options = _options(
+                    routes,
+                    values=numeric_values,
+                    cautious=cautious,
+                    source=source,
+                    coverages=coverages,
+                    recommended_id=best.identity,
+                    recommendation_reason=(
+                        "only returned route with sufficient modeled shade evidence"
+                        if len(routes) == 1
+                        else "highest modeled shade among returned routes"
+                    ),
+                    shade_evidence=shade_evidence,
+                )
+                state = (RouteDecisionState.SHADE_ONLY_ROUTE_RECOMMENDED
+                         if len(routes) == 1 else RouteDecisionState.SHADE_SHADIEST_RECOMMENDED)
+                return _result(
+                    options, route_set_state=route_set_state, decision_state=state,
+                    reason="highest modeled OSM building shade among returned routes is recommended",
+                    confidence=Confidence.SUFFICIENT, provenance=provenance,
+                    routing_provenance=routing_provenance, heat_provenance=heat_provenance,
+                    heat_status=HeatStatus.ELEVATED, corridor_heat_value=max(numeric_values),
+                    lowest_heat_route_id=lowest, cautious=cautious, recommended_id=best.identity,
+                )
+            options = _options(
+                routes,
+                values=numeric_values,
+                cautious=cautious,
+                source=source,
+                coverages=coverages,
+                shade_evidence=shade_evidence,
+            )
+            return _result(
+                options, route_set_state=route_set_state,
+                decision_state=RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED,
+                reason="daytime building-shade evidence is insufficient; compare returned route trade-offs",
+                confidence=Confidence.INSUFFICIENT, provenance=provenance,
+                routing_provenance=routing_provenance, heat_provenance=heat_provenance,
+                heat_status=HeatStatus.ELEVATED, corridor_heat_value=max(numeric_values),
+                fallback_reason="building-height coverage or solar evidence was insufficient",
+                lowest_heat_route_id=lowest, cautious=cautious,
+            )
         options = _options(
             routes,
             values=numeric_values,
@@ -170,6 +277,8 @@ def _options(
     source: RouteHeatSource | None = None,
     coverages: Sequence[float | None] | None = None,
     recommended_id: str | None = None,
+    recommendation_reason: str = "shortest returned route under mild heat",
+    shade_evidence: Mapping[str, RouteShadeEvidence] | None = None,
 ) -> tuple[RouteOption, ...]:
     result: list[RouteOption] = []
     for index, (route, value) in enumerate(zip(routes, values, strict=True)):
@@ -181,6 +290,7 @@ def _options(
             if value is not None
             else None
         )
+        shade = (shade_evidence or {}).get(route_identity)
         result.append(
             RouteOption(
                 identity=route_identity,
@@ -196,20 +306,31 @@ def _options(
                 )
                 if interpretation
                 else None,
-                modeled_shade_percent=None,
-                shade_confidence=None,
-                building_coverage=0.0,
+                modeled_shade_percent=shade.modeled_shade_percent if shade else None,
+                shade_confidence=shade.confidence if shade else None,
+                building_coverage=shade.building_coverage if shade else 0.0,
                 recommended=route_identity == recommended_id,
                 recommendation_reason=(
-                    "shortest returned route under mild heat"
-                    if route_identity == recommended_id
-                    else None
+                    recommendation_reason if route_identity == recommended_id else None
                 ),
-                shade_model_label=None,
+                shade_model_label=(
+                    "modeled OSM building-shade estimate, not measured real-world shade"
+                    if shade else None
+                ),
                 heat_interpretation=interpretation,
                 geometry=route.geometry.coordinates,
                 heat_coverage=coverages[index] if coverages is not None else None,
                 heat_source=source,
+                building_explicit_fraction=shade.explicit_area_fraction if shade else 0.0,
+                building_inferred_levels_fraction=(
+                    shade.inferred_levels_area_fraction if shade else 0.0
+                ),
+                building_unknown_fraction=shade.unknown_area_fraction if shade else 0.0,
+                building_explicit_count=shade.explicit_count if shade else 0,
+                building_inferred_levels_count=shade.inferred_levels_count if shade else 0,
+                building_unknown_count=shade.unknown_count if shade else 0,
+                dropped_building_geometry_count=(shade.dropped_geometry_count if shade else 0),
+                shade_limitations=shade.limitations if shade else (),
             )
         )
     return tuple(result)

--- a/app/domain/route_decision.py
+++ b/app/domain/route_decision.py
@@ -155,13 +155,19 @@ def decide_route_comparison(
                 shade_evidence=nighttime_evidence,
             )
             return _result(
-                options, route_set_state=route_set_state,
+                options,
+                route_set_state=route_set_state,
                 decision_state=RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED,
                 reason="sun is below the horizon; the coolest returned route is recommended",
-                confidence=Confidence.SUFFICIENT, provenance=provenance,
-                routing_provenance=routing_provenance, heat_provenance=heat_provenance,
-                heat_status=HeatStatus.ELEVATED, corridor_heat_value=max(numeric_values),
-                lowest_heat_route_id=lowest, cautious=cautious, recommended_id=coolest.identity,
+                confidence=Confidence.SUFFICIENT,
+                provenance=provenance,
+                routing_provenance=routing_provenance,
+                heat_provenance=heat_provenance,
+                heat_status=HeatStatus.ELEVATED,
+                corridor_heat_value=max(numeric_values),
+                lowest_heat_route_id=lowest,
+                cautious=cautious,
+                recommended_id=coolest.identity,
             )
         shade_evidence = decision.shade_evidence
         if shade_evidence is not None:
@@ -193,15 +199,25 @@ def decide_route_comparison(
                     ),
                     shade_evidence=shade_evidence,
                 )
-                state = (RouteDecisionState.SHADE_ONLY_ROUTE_RECOMMENDED
-                         if len(routes) == 1 else RouteDecisionState.SHADE_SHADIEST_RECOMMENDED)
+                state = (
+                    RouteDecisionState.SHADE_ONLY_ROUTE_RECOMMENDED
+                    if len(routes) == 1
+                    else RouteDecisionState.SHADE_SHADIEST_RECOMMENDED
+                )
                 return _result(
-                    options, route_set_state=route_set_state, decision_state=state,
+                    options,
+                    route_set_state=route_set_state,
+                    decision_state=state,
                     reason="highest modeled OSM building shade among returned routes is recommended",
-                    confidence=Confidence.SUFFICIENT, provenance=provenance,
-                    routing_provenance=routing_provenance, heat_provenance=heat_provenance,
-                    heat_status=HeatStatus.ELEVATED, corridor_heat_value=max(numeric_values),
-                    lowest_heat_route_id=lowest, cautious=cautious, recommended_id=best.identity,
+                    confidence=Confidence.SUFFICIENT,
+                    provenance=provenance,
+                    routing_provenance=routing_provenance,
+                    heat_provenance=heat_provenance,
+                    heat_status=HeatStatus.ELEVATED,
+                    corridor_heat_value=max(numeric_values),
+                    lowest_heat_route_id=lowest,
+                    cautious=cautious,
+                    recommended_id=best.identity,
                 )
             options = _options(
                 routes,
@@ -212,14 +228,19 @@ def decide_route_comparison(
                 shade_evidence=shade_evidence,
             )
             return _result(
-                options, route_set_state=route_set_state,
+                options,
+                route_set_state=route_set_state,
                 decision_state=RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED,
                 reason="daytime building-shade evidence is insufficient; compare returned route trade-offs",
-                confidence=Confidence.INSUFFICIENT, provenance=provenance,
-                routing_provenance=routing_provenance, heat_provenance=heat_provenance,
-                heat_status=HeatStatus.ELEVATED, corridor_heat_value=max(numeric_values),
+                confidence=Confidence.INSUFFICIENT,
+                provenance=provenance,
+                routing_provenance=routing_provenance,
+                heat_provenance=heat_provenance,
+                heat_status=HeatStatus.ELEVATED,
+                corridor_heat_value=max(numeric_values),
                 fallback_reason="building-height coverage or solar evidence was insufficient",
-                lowest_heat_route_id=lowest, cautious=cautious,
+                lowest_heat_route_id=lowest,
+                cautious=cautious,
             )
         options = _options(
             routes,
@@ -315,7 +336,8 @@ def _options(
                 ),
                 shade_model_label=(
                     "modeled OSM building-shade estimate, not measured real-world shade"
-                    if shade else None
+                    if shade
+                    else None
                 ),
                 heat_interpretation=interpretation,
                 geometry=route.geometry.coordinates,

--- a/app/domain/route_decision.py
+++ b/app/domain/route_decision.py
@@ -41,6 +41,8 @@ def decide_route_comparison(
     provenance: Provenance,
     routing_provenance: Provenance,
     heat_provenance: Provenance | None,
+    building_provenance: Provenance | None = None,
+    solar_provenance: Provenance | None = None,
 ) -> RouteComparisonResult:
     """Apply the route heat gate without fabricating routes or recommendations."""
     routes = () if decision.route_set is None else decision.route_set.routes
@@ -50,6 +52,8 @@ def decide_route_comparison(
             provenance=provenance,
             routing_provenance=routing_provenance,
             heat_provenance=heat_provenance,
+            building_provenance=building_provenance,
+            solar_provenance=solar_provenance,
             reason="OSRM returned no suitable pedestrian route",
         )
 
@@ -67,6 +71,8 @@ def decide_route_comparison(
             provenance=provenance,
             routing_provenance=routing_provenance,
             heat_provenance=None,
+            building_provenance=building_provenance,
+            solar_provenance=solar_provenance,
             heat_status=None,
             corridor_heat_value=None,
             fallback_reason="shared corridor heat activity was unavailable",
@@ -103,6 +109,8 @@ def decide_route_comparison(
             provenance=provenance,
             routing_provenance=routing_provenance,
             heat_provenance=heat_provenance,
+            building_provenance=building_provenance,
+            solar_provenance=solar_provenance,
             heat_status=None,
             corridor_heat_value=None,
             fallback_reason="route heat coverage was insufficient",
@@ -163,6 +171,8 @@ def decide_route_comparison(
                 provenance=provenance,
                 routing_provenance=routing_provenance,
                 heat_provenance=heat_provenance,
+                building_provenance=building_provenance,
+                solar_provenance=solar_provenance,
                 heat_status=HeatStatus.ELEVATED,
                 corridor_heat_value=max(numeric_values),
                 lowest_heat_route_id=lowest,
@@ -213,6 +223,8 @@ def decide_route_comparison(
                     provenance=provenance,
                     routing_provenance=routing_provenance,
                     heat_provenance=heat_provenance,
+                    building_provenance=building_provenance,
+                    solar_provenance=solar_provenance,
                     heat_status=HeatStatus.ELEVATED,
                     corridor_heat_value=max(numeric_values),
                     lowest_heat_route_id=lowest,
@@ -236,6 +248,8 @@ def decide_route_comparison(
                 provenance=provenance,
                 routing_provenance=routing_provenance,
                 heat_provenance=heat_provenance,
+                building_provenance=building_provenance,
+                solar_provenance=solar_provenance,
                 heat_status=HeatStatus.ELEVATED,
                 corridor_heat_value=max(numeric_values),
                 fallback_reason="building-height coverage or solar evidence was insufficient",
@@ -258,6 +272,8 @@ def decide_route_comparison(
             provenance=provenance,
             routing_provenance=routing_provenance,
             heat_provenance=heat_provenance,
+            building_provenance=building_provenance,
+            solar_provenance=solar_provenance,
             heat_status=HeatStatus.ELEVATED,
             corridor_heat_value=max(numeric_values),
             lowest_heat_route_id=lowest,
@@ -282,6 +298,8 @@ def decide_route_comparison(
         provenance=provenance,
         routing_provenance=routing_provenance,
         heat_provenance=heat_provenance,
+        building_provenance=building_provenance,
+        solar_provenance=solar_provenance,
         heat_status=HeatStatus.NOT_ELEVATED,
         corridor_heat_value=max(numeric_values),
         lowest_heat_route_id=lowest,
@@ -368,6 +386,8 @@ def _result(
     provenance: Provenance,
     routing_provenance: Provenance,
     heat_provenance: Provenance | None,
+    building_provenance: Provenance | None = None,
+    solar_provenance: Provenance | None = None,
     heat_status: HeatStatus | None,
     corridor_heat_value: float | None,
     fallback_reason: str | None = None,
@@ -406,6 +426,8 @@ def _result(
         lowest_heat_route_id=lowest_heat_route_id,
         routing_provenance=routing_provenance,
         heat_provenance=heat_provenance,
+        building_provenance=building_provenance,
+        solar_provenance=solar_provenance,
     )
 
 
@@ -415,6 +437,8 @@ def _empty_result(
     provenance: Provenance,
     routing_provenance: Provenance,
     heat_provenance: Provenance | None,
+    building_provenance: Provenance | None,
+    solar_provenance: Provenance | None,
     reason: str,
 ) -> RouteComparisonResult:
     return _result(
@@ -426,6 +450,8 @@ def _empty_result(
         provenance=provenance,
         routing_provenance=routing_provenance,
         heat_provenance=heat_provenance,
+        building_provenance=building_provenance,
+        solar_provenance=solar_provenance,
         heat_status=None,
         corridor_heat_value=None,
         fallback_reason="OSRM returned no valid routes",

--- a/app/domain/route_shade.py
+++ b/app/domain/route_shade.py
@@ -1,0 +1,229 @@
+"""Provider-neutral OSM building-height and deterministic route-shade geometry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+import math
+import re
+from typing import Iterable, Mapping, cast
+
+from pyproj import Transformer
+from shapely.geometry import LineString, shape
+from shapely.geometry.base import BaseGeometry
+from shapely.ops import transform, unary_union
+
+
+class BuildingHeightQuality(str, Enum):
+    EXPLICIT = "explicit"
+    INFERRED_LEVELS = "inferred_levels"
+    UNKNOWN = "unknown"
+
+
+class ShadeConfidence(str, Enum):
+    SUFFICIENT = "sufficient"
+    INSUFFICIENT = "insufficient"
+    NOT_APPLICABLE = "not_applicable"
+
+
+SHADE_MODEL_LIMITATIONS = (
+    "modeled OSM building shade excludes trees, awnings, clouds, temporary obstructions, "
+    "and buildings beyond the configured search boundary"
+)
+
+
+@dataclass(frozen=True)
+class RouteShadeEvidence:
+    modeled_shade_percent: float
+    building_coverage: float
+    confidence: ShadeConfidence
+    explicit_area_fraction: float
+    inferred_levels_area_fraction: float
+    unknown_area_fraction: float
+    explicit_count: int
+    inferred_levels_count: int
+    unknown_count: int
+    dropped_geometry_count: int
+    limitations: tuple[str, ...] = (SHADE_MODEL_LIMITATIONS,)
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.modeled_shade_percent) or not 0 <= self.modeled_shade_percent <= 100:
+            raise ValueError("modeled shade percent must be finite and between 0 and 100")
+        fractions = (
+            self.explicit_area_fraction,
+            self.inferred_levels_area_fraction,
+            self.unknown_area_fraction,
+        )
+        if any(not math.isfinite(value) or not 0 <= value <= 1 for value in fractions):
+            raise ValueError("building quality fractions must be finite and between 0 and 1")
+        if not math.isclose(sum(fractions), 1.0, abs_tol=1e-6) and any(fractions):
+            raise ValueError("nonzero building quality fractions must sum to 1")
+        if not math.isclose(
+            self.building_coverage,
+            self.explicit_area_fraction + self.inferred_levels_area_fraction,
+            abs_tol=1e-6,
+        ):
+            raise ValueError("building coverage must equal known-height quality fractions")
+        counts = (
+            self.explicit_count,
+            self.inferred_levels_count,
+            self.unknown_count,
+            self.dropped_geometry_count,
+        )
+        if any(isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in counts):
+            raise ValueError("building quality and dropped geometry counts must be non-negative")
+        if not isinstance(self.confidence, ShadeConfidence):
+            raise ValueError("shade confidence must be a ShadeConfidence value")
+        if not self.limitations or any(not item.strip() for item in self.limitations):
+            raise ValueError("modeled shade limitations are required")
+
+
+@dataclass(frozen=True)
+class BuildingFootprint:
+    identity: str
+    geometry: BaseGeometry
+    height_m: float | None
+    height_quality: BuildingHeightQuality
+
+    def __post_init__(self) -> None:
+        if not self.identity or self.geometry.is_empty or not self.geometry.is_valid:
+            raise ValueError("building identity and valid geometry are required")
+        if self.geometry.geom_type not in {"Polygon", "MultiPolygon"}:
+            raise ValueError("building geometry must be polygonal")
+        if self.height_m is not None and (not math.isfinite(self.height_m) or self.height_m <= 0):
+            raise ValueError("building height must be positive and finite")
+        if self.height_quality is BuildingHeightQuality.UNKNOWN and self.height_m is not None:
+            raise ValueError("unknown building height cannot have a numeric value")
+        if self.height_quality is not BuildingHeightQuality.UNKNOWN and self.height_m is None:
+            raise ValueError("known building height requires a quality")
+
+
+@dataclass(frozen=True)
+class SolarPosition:
+    azimuth_degrees: float
+    elevation_degrees: float
+
+    def __post_init__(self) -> None:
+        if not all(math.isfinite(value) for value in (self.azimuth_degrees, self.elevation_degrees)):
+            raise ValueError("solar position must be finite")
+        if not 0 <= self.azimuth_degrees < 360:
+            raise ValueError("solar azimuth must be in [0, 360)")
+
+
+def parse_height(value: object) -> float | None:
+    """Parse one positive OSM height value in metres; reject ambiguous syntax."""
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    if not text or ";" in text or "-" in text or " to " in text or ".." in text:
+        return None
+    match = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)\s*(m|meters?|ft|feet)?", text)
+    if match:
+        number = float(match.group(1))
+        unit = match.group(2) or "m"
+        metres = number * 0.3048 if unit in {"ft", "feet"} else number
+    else:
+        feet_inches = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)\s*'\s*([0-9]+(?:\.[0-9]+)?)?\s*\"", text)
+        if not feet_inches:
+            return None
+        metres = (float(feet_inches.group(1)) + float(feet_inches.group(2) or 0) / 12) * 0.3048
+    return metres if math.isfinite(metres) and metres > 0 else None
+
+
+def classify_building_height(
+    tags: Mapping[str, object], *, metres_per_level: float = 3.0
+) -> tuple[float | None, BuildingHeightQuality]:
+    if not math.isfinite(metres_per_level) or metres_per_level <= 0:
+        raise ValueError("metres_per_level must be positive and finite")
+    explicit = parse_height(tags.get("height"))
+    if explicit is not None:
+        return explicit, BuildingHeightQuality.EXPLICIT
+    levels = tags.get("building:levels")
+    if isinstance(levels, str) and re.fullmatch(r"[0-9]+(?:\.[0-9]+)?", levels.strip()):
+        count = float(levels)
+        if math.isfinite(count) and count > 0:
+            return count * metres_per_level, BuildingHeightQuality.INFERRED_LEVELS
+    return None, BuildingHeightQuality.UNKNOWN
+
+
+def solar_position(instant: datetime, latitude: float, longitude: float) -> SolarPosition:
+    """Return an approximate true-north solar position for deterministic modelling."""
+    if instant.tzinfo is None or instant.utcoffset() is None:
+        raise ValueError("solar instant must be timezone-aware")
+    if not -90 <= latitude <= 90 or not -180 <= longitude <= 180:
+        raise ValueError("solar coordinates are out of range")
+    utc = instant.astimezone(timezone.utc)
+    day = utc.timetuple().tm_yday
+    hour = utc.hour + utc.minute / 60 + utc.second / 3600
+    gamma = 2 * math.pi / 365 * (day - 1 + (hour - 12) / 24)
+    declination = (0.006918 - 0.399912 * math.cos(gamma) + 0.070257 * math.sin(gamma)
+                   - 0.006758 * math.cos(2 * gamma) + 0.000907 * math.sin(2 * gamma))
+    equation = 229.18 * (0.000075 + 0.001868 * math.cos(gamma) - 0.032077 * math.sin(gamma)
+                         - 0.014615 * math.cos(2 * gamma) - 0.040849 * math.sin(2 * gamma))
+    minutes = utc.hour * 60 + utc.minute + utc.second / 60
+    true_solar_minutes = minutes + equation + 4 * longitude
+    hour_angle = math.radians((true_solar_minutes / 4) - 180)
+    lat = math.radians(latitude)
+    elevation = math.degrees(math.asin(math.sin(lat) * math.sin(declination)
+                                       + math.cos(lat) * math.cos(declination) * math.cos(hour_angle)))
+    azimuth = math.degrees(math.atan2(math.sin(hour_angle), math.cos(hour_angle) * math.sin(lat)
+                                      - math.tan(declination) * math.cos(lat))) + 180
+    return SolarPosition(azimuth % 360, elevation)
+
+
+def route_shade_percent(
+    route: LineString, buildings: Iterable[BuildingFootprint], solar: SolarPosition
+) -> float:
+    """Calculate route length covered by unioned projected building shadows."""
+    if route.is_empty or route.length <= 0:
+        raise ValueError("route must have positive length")
+    if solar.elevation_degrees <= 0:
+        return 0.0
+    crs = _utm(route)
+    projected_route = _project(route, crs)
+    sweeps: list[BaseGeometry] = []
+    occupied: list[BaseGeometry] = []
+    for building in buildings:
+        footprint = _project(building.geometry, crs)
+        occupied.append(footprint)
+        if building.height_m is None:
+            continue
+        length = building.height_m / math.tan(math.radians(solar.elevation_degrees))
+        radians = math.radians(solar.azimuth_degrees + 180)
+        dx, dy = length * math.sin(radians), length * math.cos(radians)
+        shifted = transform(lambda x, y, z=None: (x + dx, y + dy), footprint)
+        sweeps.append(footprint.union(shifted).convex_hull)
+    if not sweeps:
+        return 0.0
+    shadow = cast(BaseGeometry, unary_union(sweeps)).difference(
+        cast(BaseGeometry, unary_union(occupied))
+    )
+    covered = projected_route.intersection(shadow).length
+    percentage = float(covered) / float(projected_route.length) * 100
+    return max(0.0, min(100.0, percentage))
+
+
+def _utm(geometry: BaseGeometry) -> int:
+    centroid = geometry.centroid
+    zone = int((centroid.x + 180) // 6) + 1
+    return 32600 + zone if centroid.y >= 0 else 32700 + zone
+
+
+def _project(geometry: BaseGeometry, epsg: int) -> BaseGeometry:
+    transformer = Transformer.from_crs("EPSG:4326", f"EPSG:{epsg}", always_xy=True)
+    return transform(transformer.transform, geometry)
+
+
+def building_from_geojson(
+    identity: str,
+    geometry: Mapping[str, object],
+    tags: Mapping[str, object],
+    *,
+    metres_per_level: float = 3.0,
+) -> BuildingFootprint:
+    polygon = cast(BaseGeometry, shape(dict(geometry)))
+    if polygon.geom_type not in {"Polygon", "MultiPolygon"}:
+        raise ValueError("building geometry must be polygonal")
+    height, quality = classify_building_height(tags, metres_per_level=metres_per_level)
+    return BuildingFootprint(identity, polygon, height, quality)

--- a/app/domain/route_shade.py
+++ b/app/domain/route_shade.py
@@ -13,7 +13,7 @@ from astral import Observer
 from astral.sun import azimuth as astral_azimuth
 from astral.sun import elevation as astral_elevation
 from pyproj import Transformer
-from shapely.geometry import LineString, shape
+from shapely.geometry import LineString, Polygon, shape
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform, unary_union
 
@@ -224,9 +224,7 @@ def route_shade_percent(
             continue
         length = building.height_m / math.tan(math.radians(solar.elevation_degrees))
         radians = math.radians(solar.azimuth_degrees + 180)
-        dx, dy = length * math.sin(radians), length * math.cos(radians)
-        shifted = transform(lambda x, y, z=None: (x + dx, y + dy), footprint)
-        sweeps.append(footprint.union(shifted).convex_hull)
+        sweeps.append(_swept(footprint, length * math.sin(radians), length * math.cos(radians)))
     if not sweeps:
         return 0.0
     shadow = cast(BaseGeometry, unary_union(sweeps)).difference(
@@ -235,6 +233,26 @@ def route_shade_percent(
     covered = projected_route.intersection(shadow).length
     percentage = float(covered) / float(projected_route.length) * 100
     return max(0.0, min(100.0, percentage))
+
+
+def _swept(footprint: BaseGeometry, dx: float, dy: float) -> BaseGeometry:
+    """The exact region a footprint covers as it is translated by (dx, dy).
+
+    This is the Minkowski sum of the footprint with the translation segment: the
+    footprint, its translated copy, and one parallelogram per boundary edge. A
+    convex hull would be simpler but would wrongly fill courtyards and the
+    concave notches of L-shaped buildings with shadow.
+    """
+    shifted = transform(lambda x, y, z=None: (x + dx, y + dy), footprint)
+    walls: list[BaseGeometry] = []
+    for polygon in getattr(footprint, "geoms", (footprint,)):
+        for ring in (polygon.exterior, *polygon.interiors):
+            points = list(ring.coords)
+            walls.extend(
+                Polygon([start, end, (end[0] + dx, end[1] + dy), (start[0] + dx, start[1] + dy)])
+                for start, end in zip(points, points[1:])
+            )
+    return cast(BaseGeometry, unary_union([footprint, shifted, *walls]))
 
 
 def _utm(geometry: BaseGeometry) -> int:

--- a/app/domain/route_shade.py
+++ b/app/domain/route_shade.py
@@ -38,6 +38,11 @@ SHADE_MODEL_LIMITATIONS = (
 SOLAR_MODEL_IDENTITY = "astral-3.2-apparent"
 """Solar-position provider identity recorded in shade provenance."""
 
+SHADE_UNAVAILABLE_LIMITATION = (
+    "no OSM building geometry was available from the provider, cache, or committed fixture, "
+    "so no modeled building shade could be calculated"
+)
+
 
 @dataclass(frozen=True)
 class RouteShadeEvidence:
@@ -88,6 +93,31 @@ class RouteShadeEvidence:
             raise ValueError("shade confidence must be a ShadeConfidence value")
         if not self.limitations or any(not item.strip() for item in self.limitations):
             raise ValueError("modeled shade limitations are required")
+
+
+def unavailable_shade_evidence(
+    reason: str = SHADE_UNAVAILABLE_LIMITATION,
+) -> RouteShadeEvidence:
+    """Explicit zero-evidence shade result naming why no building shade exists.
+
+    Insufficient rather than not-applicable: shade is physically relevant here,
+    the evidence for it is simply missing.
+    """
+    if not reason.strip():
+        raise ValueError("unavailable shade evidence requires a reason")
+    return RouteShadeEvidence(
+        modeled_shade_percent=0.0,
+        building_coverage=0.0,
+        confidence=ShadeConfidence.INSUFFICIENT,
+        explicit_area_fraction=0.0,
+        inferred_levels_area_fraction=0.0,
+        unknown_area_fraction=0.0,
+        explicit_count=0,
+        inferred_levels_count=0,
+        unknown_count=0,
+        dropped_geometry_count=0,
+        limitations=(SHADE_MODEL_LIMITATIONS, reason),
+    )
 
 
 @dataclass(frozen=True)

--- a/app/domain/route_shade.py
+++ b/app/domain/route_shade.py
@@ -9,6 +9,9 @@ import math
 import re
 from typing import Iterable, Mapping, cast
 
+from astral import Observer
+from astral.sun import azimuth as astral_azimuth
+from astral.sun import elevation as astral_elevation
 from pyproj import Transformer
 from shapely.geometry import LineString, shape
 from shapely.geometry.base import BaseGeometry
@@ -32,6 +35,9 @@ SHADE_MODEL_LIMITATIONS = (
     "and buildings beyond the configured search boundary"
 )
 
+SOLAR_MODEL_IDENTITY = "astral-3.2-apparent"
+"""Solar-position provider identity recorded in shade provenance."""
+
 
 @dataclass(frozen=True)
 class RouteShadeEvidence:
@@ -48,7 +54,10 @@ class RouteShadeEvidence:
     limitations: tuple[str, ...] = (SHADE_MODEL_LIMITATIONS,)
 
     def __post_init__(self) -> None:
-        if not math.isfinite(self.modeled_shade_percent) or not 0 <= self.modeled_shade_percent <= 100:
+        if (
+            not math.isfinite(self.modeled_shade_percent)
+            or not 0 <= self.modeled_shade_percent <= 100
+        ):
             raise ValueError("modeled shade percent must be finite and between 0 and 100")
         fractions = (
             self.explicit_area_fraction,
@@ -71,7 +80,9 @@ class RouteShadeEvidence:
             self.unknown_count,
             self.dropped_geometry_count,
         )
-        if any(isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in counts):
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in counts
+        ):
             raise ValueError("building quality and dropped geometry counts must be non-negative")
         if not isinstance(self.confidence, ShadeConfidence):
             raise ValueError("shade confidence must be a ShadeConfidence value")
@@ -105,7 +116,9 @@ class SolarPosition:
     elevation_degrees: float
 
     def __post_init__(self) -> None:
-        if not all(math.isfinite(value) for value in (self.azimuth_degrees, self.elevation_degrees)):
+        if not all(
+            math.isfinite(value) for value in (self.azimuth_degrees, self.elevation_degrees)
+        ):
             raise ValueError("solar position must be finite")
         if not 0 <= self.azimuth_degrees < 360:
             raise ValueError("solar azimuth must be in [0, 360)")
@@ -148,27 +161,17 @@ def classify_building_height(
 
 
 def solar_position(instant: datetime, latitude: float, longitude: float) -> SolarPosition:
-    """Return an approximate true-north solar position for deterministic modelling."""
+    """Return the apparent true-north solar position for one exact timezone-aware instant."""
     if instant.tzinfo is None or instant.utcoffset() is None:
         raise ValueError("solar instant must be timezone-aware")
     if not -90 <= latitude <= 90 or not -180 <= longitude <= 180:
         raise ValueError("solar coordinates are out of range")
+    observer = Observer(latitude=latitude, longitude=longitude)
     utc = instant.astimezone(timezone.utc)
-    day = utc.timetuple().tm_yday
-    hour = utc.hour + utc.minute / 60 + utc.second / 3600
-    gamma = 2 * math.pi / 365 * (day - 1 + (hour - 12) / 24)
-    declination = (0.006918 - 0.399912 * math.cos(gamma) + 0.070257 * math.sin(gamma)
-                   - 0.006758 * math.cos(2 * gamma) + 0.000907 * math.sin(2 * gamma))
-    equation = 229.18 * (0.000075 + 0.001868 * math.cos(gamma) - 0.032077 * math.sin(gamma)
-                         - 0.014615 * math.cos(2 * gamma) - 0.040849 * math.sin(2 * gamma))
-    minutes = utc.hour * 60 + utc.minute + utc.second / 60
-    true_solar_minutes = minutes + equation + 4 * longitude
-    hour_angle = math.radians((true_solar_minutes / 4) - 180)
-    lat = math.radians(latitude)
-    elevation = math.degrees(math.asin(math.sin(lat) * math.sin(declination)
-                                       + math.cos(lat) * math.cos(declination) * math.cos(hour_angle)))
-    azimuth = math.degrees(math.atan2(math.sin(hour_angle), math.cos(hour_angle) * math.sin(lat)
-                                      - math.tan(declination) * math.cos(lat))) + 180
+    azimuth = float(astral_azimuth(observer, utc))
+    elevation = float(astral_elevation(observer, utc))
+    if not math.isfinite(azimuth) or not math.isfinite(elevation):
+        raise ValueError("solar provider returned a non-finite position")
     return SolarPosition(azimuth % 360, elevation)
 
 

--- a/app/domain/trip.py
+++ b/app/domain/trip.py
@@ -111,7 +111,10 @@ class RouteComparator:
         shade_values = {route.identity: shade(route) for route in routes}
         if building_coverage < 0.7:
             return RouteComparison(
-                None, "insufficient shade coverage; traveler comparison required", corridor_heat, True
+                None,
+                "insufficient shade coverage; traveler comparison required",
+                corridor_heat,
+                True,
             )
         best = max(routes, key=lambda route: (shade_values[route.identity], -route.distance_m))
         return RouteComparison(

--- a/app/domain/trip.py
+++ b/app/domain/trip.py
@@ -76,7 +76,7 @@ class RouteCandidate:
 
 @dataclass(frozen=True)
 class RouteComparison:
-    recommended_id: str
+    recommended_id: str | None
     reason: str
     corridor_heat_value: float
     shade_was_computed: bool
@@ -111,7 +111,7 @@ class RouteComparator:
         shade_values = {route.identity: shade(route) for route in routes}
         if building_coverage < 0.7:
             return RouteComparison(
-                shortest.identity, "insufficient shade coverage", corridor_heat, True
+                None, "insufficient shade coverage; traveler comparison required", corridor_heat, True
             )
         best = max(routes, key=lambda route: (shade_values[route.identity], -route.distance_m))
         return RouteComparison(

--- a/app/integrations/overpass/buildings.py
+++ b/app/integrations/overpass/buildings.py
@@ -1,0 +1,81 @@
+"""Bounded Overpass building query, its cache identity, and its OSM data date.
+
+The query options and selected tags that shape a building response are part of
+the cache and fixture identity (ADR 0004), so they live here beside the query
+they build rather than being restated at each call site.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from app.domain.hotels import BoundingBox
+from app.integrations.overpass.errors import OverpassError
+
+BUILDING_TAGS: tuple[str, ...] = ("building", "building:part")
+BUILDING_OBJECT_TYPES: tuple[str, ...] = ("way", "relation")
+BUILDING_RESPONSE_FORMAT = "json"
+BUILDING_TIMEOUT_SECONDS = 60
+BUILDING_OUTPUT = "body geom"
+
+
+def build_building_query(aoi: BoundingBox) -> str:
+    """One deterministic bounded query for building and building-part geometry."""
+    bounds = ",".join(format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east))
+    selectors = "".join(
+        f'{object_type}["{tag}"]({bounds});'
+        for tag in BUILDING_TAGS
+        for object_type in BUILDING_OBJECT_TYPES
+    )
+    return (
+        f"[out:{BUILDING_RESPONSE_FORMAT}][timeout:{BUILDING_TIMEOUT_SECONDS}];\n"
+        f"({selectors});\n"
+        f"out {BUILDING_OUTPUT};"
+    )
+
+
+def building_query_options() -> dict[str, Any]:
+    """The complete query options and selected tags that shape a building response."""
+    return {
+        "response_format": BUILDING_RESPONSE_FORMAT,
+        "timeout_seconds": BUILDING_TIMEOUT_SECONDS,
+        "output": BUILDING_OUTPUT,
+        "object_types": list(BUILDING_OBJECT_TYPES),
+        "selected_tags": list(BUILDING_TAGS),
+    }
+
+
+def building_request_payload(
+    aoi: BoundingBox,
+    *,
+    search_distance_m: float,
+    model_version: str,
+) -> dict[str, Any]:
+    """Complete building cache and fixture identity (ADR 0004).
+
+    Two building responses only share an identity when the canonical shared AOI,
+    the search distance that produced it, the complete query options and
+    selected tags, and the route-shade model version all agree.
+    """
+    return {
+        "aoi": aoi.to_payload(),
+        "search_distance_m": search_distance_m,
+        "query_options": building_query_options(),
+        "model_version": model_version,
+    }
+
+
+def osm_source_timestamp(response: Mapping[str, object]) -> datetime:
+    """Read the authoritative OSM data timestamp from one Overpass response."""
+    osm3s = response.get("osm3s")
+    raw = osm3s.get("timestamp_osm_base") if isinstance(osm3s, Mapping) else None
+    if not isinstance(raw, str) or not raw.strip():
+        raise OverpassError("Overpass response is missing its OSM source timestamp")
+    try:
+        timestamp = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        raise OverpassError("Overpass OSM source timestamp is invalid") from None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp

--- a/app/integrations/overpass/client.py
+++ b/app/integrations/overpass/client.py
@@ -1,4 +1,4 @@
-"""Bounded Overpass client for hotel queries."""
+"""Bounded Overpass client for hotel and route-building queries."""
 
 from __future__ import annotations
 
@@ -32,7 +32,13 @@ class OverpassClient:
         self._sleep = sleep
 
     def query(self, aoi: BoundingBox) -> dict[str, object]:
-        query = build_hotel_query(aoi)
+        return self._execute(build_hotel_query(aoi))
+
+    def query_buildings(self, aoi: BoundingBox) -> dict[str, object]:
+        """Fetch polygon geometry and height tags for one bounded route AOI."""
+        return self._execute(build_building_query(aoi))
+
+    def _execute(self, query: str) -> dict[str, object]:
         for attempt in range(1, self._max_attempts + 1):
             try:
                 return self._transport.execute(query)
@@ -46,3 +52,15 @@ class OverpassClient:
 def build_hotel_query(aoi: BoundingBox) -> str:
     bounds = ",".join(format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east))
     return f'[out:json][timeout:60];\nnwr["tourism"="hotel"]({bounds});\nout center;'
+
+
+def build_building_query(aoi: BoundingBox) -> str:
+    bounds = ",".join(
+        format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east)
+    )
+    return (
+        '[out:json][timeout:60];\n('
+        f'way["building"]({bounds});relation["building"]({bounds});'
+        f'way["building:part"]({bounds});relation["building:part"]({bounds});'
+        ');\nout body geom;'
+    )

--- a/app/integrations/overpass/client.py
+++ b/app/integrations/overpass/client.py
@@ -55,12 +55,10 @@ def build_hotel_query(aoi: BoundingBox) -> str:
 
 
 def build_building_query(aoi: BoundingBox) -> str:
-    bounds = ",".join(
-        format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east)
-    )
+    bounds = ",".join(format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east))
     return (
-        '[out:json][timeout:60];\n('
+        "[out:json][timeout:60];\n("
         f'way["building"]({bounds});relation["building"]({bounds});'
         f'way["building:part"]({bounds});relation["building:part"]({bounds});'
-        ');\nout body geom;'
+        ");\nout body geom;"
     )

--- a/app/integrations/overpass/client.py
+++ b/app/integrations/overpass/client.py
@@ -6,7 +6,10 @@ from time import sleep as default_sleep
 from typing import Callable, Protocol
 
 from app.domain.hotels import BoundingBox
+from app.integrations.overpass.buildings import build_building_query
 from app.integrations.overpass.errors import OverpassRateLimited
+
+__all__ = ["OverpassClient", "OverpassTransport", "build_building_query", "build_hotel_query"]
 
 
 class OverpassTransport(Protocol):
@@ -52,13 +55,3 @@ class OverpassClient:
 def build_hotel_query(aoi: BoundingBox) -> str:
     bounds = ",".join(format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east))
     return f'[out:json][timeout:60];\nnwr["tourism"="hotel"]({bounds});\nout center;'
-
-
-def build_building_query(aoi: BoundingBox) -> str:
-    bounds = ",".join(format(value, ".12g") for value in (aoi.south, aoi.west, aoi.north, aoi.east))
-    return (
-        "[out:json][timeout:60];\n("
-        f'way["building"]({bounds});relation["building"]({bounds});'
-        f'way["building:part"]({bounds});relation["building:part"]({bounds});'
-        ");\nout body geom;"
-    )

--- a/app/services/building_execution.py
+++ b/app/services/building_execution.py
@@ -1,0 +1,172 @@
+"""Exact-cache and sidecar-fixture execution for shared OSM building acquisition.
+
+One returned route set means one provider execution. When the provider fails,
+replay falls back to an exact cache entry, then to a fixture whose sidecar
+identity matches this request exactly, and finally to explicit unavailability —
+never to a silently substituted building set (ADR 0004, ADR 0007).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from app.domain.hotels import BoundingBox
+from app.domain.provenance import CacheKey
+from app.integrations.overpass.buildings import building_request_payload, osm_source_timestamp
+from app.integrations.overpass.errors import OverpassError
+from app.services.cache import CacheService
+from app.services.sidecars import load_acquisition_record
+
+DEFAULT_SCHEMA_VERSION = "building-v1"
+DEFAULT_PROVIDER_CONFIG_VERSION = "overpass-building-config-v1"
+DEFAULT_MODEL_VERSION = "route-shade-v1"
+
+
+class BuildingsUnavailable(RuntimeError):
+    """No provider, exact cache entry, or matching fixture can supply buildings."""
+
+
+@dataclass(frozen=True)
+class BuildingOutcome:
+    """One shared building response and where it actually came from.
+
+    ``retrieved_at`` is ``None`` only for a synthesized fixture, which has no
+    provider retrieval time to report; ``data_date`` is always the true OSM
+    source date, including on stale replay.
+    """
+
+    payload: Mapping[str, Any]
+    source: str
+    stale: bool
+    retrieved_at: datetime | None
+    data_date: str
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.source not in {"provider", "cache", "fixture"}:
+            raise ValueError("building source must be provider, cache, or fixture")
+        if not self.data_date.strip():
+            raise ValueError("building outcome requires the OSM data date")
+
+
+class BuildingExecution:
+    """Acquire one shared building set: live, then exact cache, then exact fixture."""
+
+    def __init__(
+        self,
+        *,
+        live_loader: Callable[[BoundingBox], Mapping[str, Any]] | None = None,
+        cache: CacheService | None = None,
+        fixture_path: Path | None = None,
+        endpoint: str,
+        schema_version: str = DEFAULT_SCHEMA_VERSION,
+        provider_config_version: str = DEFAULT_PROVIDER_CONFIG_VERSION,
+        model_version: str = DEFAULT_MODEL_VERSION,
+        search_distance_m: float,
+        clock: Callable[[], datetime] = lambda: datetime.now().astimezone(),
+    ) -> None:
+        if not endpoint.strip():
+            raise ValueError("building execution requires an Overpass endpoint")
+        self.live_loader = live_loader
+        self.cache = cache
+        self.fixture_path = fixture_path
+        self.endpoint = endpoint
+        self.schema_version = schema_version
+        self.provider_config_version = provider_config_version
+        self.model_version = model_version
+        self.search_distance_m = search_distance_m
+        self.clock = clock
+
+    def identity(self, aoi: BoundingBox) -> dict[str, Any]:
+        """The complete request identity this AOI caches and replays under."""
+        return building_request_payload(
+            aoi,
+            search_distance_m=self.search_distance_m,
+            model_version=self.model_version,
+        )
+
+    def run(self, aoi: BoundingBox) -> BuildingOutcome:
+        identity = self.identity(aoi)
+        if self.live_loader is None:
+            fallback = self._fallback(identity)
+            if fallback is not None:
+                return fallback
+            raise BuildingsUnavailable("live building acquisition is not configured")
+        try:
+            payload = self.live_loader(aoi)
+            data_date = osm_source_timestamp(payload).date().isoformat()
+        except (OverpassError, ConnectionError, OSError, TimeoutError, ValueError):
+            fallback = self._fallback(identity)
+            if fallback is not None:
+                return fallback
+            raise BuildingsUnavailable(
+                "the building request failed and no matching cache entry or fixture is available"
+            ) from None
+        retrieved_at = self.clock()
+        if self.cache is not None:
+            self.cache.put(
+                self.endpoint,
+                self.schema_version,
+                identity,
+                payload,
+                retrieved_at=retrieved_at,
+                data_date=data_date,
+                provider_config_version=self.provider_config_version,
+            )
+        return BuildingOutcome(payload, "provider", False, retrieved_at, data_date)
+
+    def _fallback(self, identity: dict[str, Any]) -> BuildingOutcome | None:
+        if self.cache is not None:
+            cached = self.cache.get(
+                CacheKey.create(
+                    self.endpoint,
+                    self.schema_version,
+                    identity,
+                    self.provider_config_version,
+                )
+            )
+            if cached is not None:
+                return BuildingOutcome(
+                    cached.payload,
+                    "cache",
+                    True,
+                    cached.provenance.retrieved_at,
+                    cached.provenance.data_date,
+                    reason="replayed the exact cached building response; stale",
+                )
+        return self._fixture(identity)
+
+    def _fixture(self, identity: dict[str, Any]) -> BuildingOutcome | None:
+        """Replay the committed fixture only when its sidecar identity matches exactly."""
+        if self.fixture_path is None:
+            return None
+        try:
+            record = load_acquisition_record(self.fixture_path)
+            if (
+                record is None
+                or not record.replayable
+                or record.endpoint != self.endpoint
+                or record.schema_version != self.schema_version
+                or record.provider_config_version != self.provider_config_version
+                or record.request_configuration != identity
+                or record.data_date is None
+            ):
+                return None
+            payload = json.loads(self.fixture_path.read_text(encoding="utf-8"))
+            if not isinstance(payload, Mapping):
+                return None
+        except (OSError, ValueError, KeyError):
+            return None
+        return BuildingOutcome(
+            payload,
+            "fixture",
+            True,
+            record.retrieved_at,
+            record.data_date,
+            reason="replayed the matching committed building fixture; stale",
+        )

--- a/app/services/hotel_discovery.py
+++ b/app/services/hotel_discovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 import math
 from typing import Callable, Mapping
 from urllib.parse import urlsplit, urlunsplit
@@ -16,6 +16,7 @@ from app.domain.hotels import (
     OsmIdentity,
 )
 from app.domain.provenance import CacheKey
+from app.integrations.overpass.buildings import osm_source_timestamp as _source_timestamp
 from app.integrations.overpass.client import OverpassClient
 from app.integrations.overpass.errors import OverpassError
 from app.services.cache import CacheService
@@ -127,20 +128,6 @@ class HotelDiscoveryService:
             stale,
             None if state is DiscoveryState.AVAILABLE else "insufficient_usable_hotels",
         )
-
-
-def _source_timestamp(response: Mapping[str, object]) -> datetime:
-    osm3s = response.get("osm3s")
-    raw = osm3s.get("timestamp_osm_base") if isinstance(osm3s, Mapping) else None
-    if not isinstance(raw, str) or not raw.strip():
-        raise OverpassError("Overpass response is missing its OSM source timestamp")
-    try:
-        timestamp = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
-        raise OverpassError("Overpass OSM source timestamp is invalid") from None
-    if timestamp.tzinfo is None:
-        timestamp = timestamp.replace(tzinfo=timezone.utc)
-    return timestamp
 
 
 def _normalize(response: Mapping[str, object]) -> tuple[list[_HotelObject], int]:

--- a/app/services/route_analysis.py
+++ b/app/services/route_analysis.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
+from typing import cast
 
 from shapely.geometry import MultiLineString, shape
 
@@ -16,13 +17,19 @@ from app.domain.contracts import (
     TemporalEvidenceState,
     TripAnalysisRequest,
 )
+from app.domain.provenance import Transformation
 from app.domain.route_decision import RouteDecisionInput, decide_route_comparison
 from app.domain.route_heat import (
     SharedRouteHeatRequest,
     aggregate_shared_route_heat,
     build_shared_route_aoi,
 )
-from app.domain.route_shade import RouteShadeEvidence, SolarPosition, solar_position
+from app.domain.route_shade import (
+    SOLAR_MODEL_IDENTITY,
+    RouteShadeEvidence,
+    SolarPosition,
+    solar_position,
+)
 from app.domain.routing import RouteRequest, RouteSet
 from app.integrations.fortyguard.contracts import (
     AnalyticType,
@@ -32,6 +39,7 @@ from app.integrations.fortyguard.contracts import (
 )
 from app.integrations.fortyguard.errors import ProviderError
 from app.integrations.fortyguard.live import LiveHeatmapPayload
+from app.services.route_shade import RouteShadeOutcome
 from app.services.routing import (
     RouteExecution,
     RouteOutcome,
@@ -45,8 +53,17 @@ class SharedRouteHeatUnavailable(RuntimeError):
 
 
 ShadeEvidence = Mapping[str, RouteShadeEvidence]
-ShadeEvidenceLoader = Callable[[RouteSet, SolarPosition, datetime], ShadeEvidence]
+ShadeEvidenceLoader = Callable[[RouteSet, SolarPosition, datetime], RouteShadeOutcome]
 SolarLocator = Callable[[datetime, float, float], SolarPosition]
+
+BUILDING_TRANSFORMATION_VERSION = "route-shade-building-normalization-v1"
+"""Overpass building normalization: geometry parsing, height classification, part merging."""
+
+SOLAR_TRANSFORMATIONS: tuple[Transformation, ...] = (
+    Transformation(name="local_instant_to_utc", version=1),
+    Transformation(name="apparent_solar_position", version=1),
+)
+"""The named steps between the local recommendation time and the modeled sun position."""
 
 
 class RouteAnalysisService:
@@ -211,50 +228,62 @@ class RouteAnalysisService:
             best_time.temporal_evidence is not TemporalEvidenceState.EXACT
             or best_time.recommendation_time is None
         ):
-            shade_decision = RouteDecisionInput(
-                decision.route_set,
-                decision.landmark_tcm_celsius,
-                decision.heat_evidence,
-                shade_evidence={},
+            return decide_route_comparison(
+                RouteDecisionInput(
+                    decision.route_set,
+                    decision.landmark_tcm_celsius,
+                    decision.heat_evidence,
+                    shade_evidence={},
+                ),
+                cautious=request.cautious,
+                provenance=provenance,
+                routing_provenance=routing_provenance,
+                heat_provenance=heat_provenance,
             )
-        else:
-            route_geometry = MultiLineString(
-                [route.geometry.coordinates for route in decision.route_set.routes]
-            )
-            centroid = route_geometry.centroid
-            solar = self.solar_locator(
-                best_time.recommendation_time,
-                centroid.y,
-                centroid.x,
-            )
-            if solar.elevation_degrees <= 0:
-                shade_decision = RouteDecisionInput(
+
+        instant = best_time.recommendation_time
+        route_geometry = MultiLineString(
+            [route.geometry.coordinates for route in decision.route_set.routes]
+        )
+        centroid = route_geometry.centroid
+        solar = self.solar_locator(instant, centroid.y, centroid.x)
+        solar_provenance = _solar_provenance(
+            solar, instant, centroid.y, centroid.x, clock=self.clock
+        )
+        if solar.elevation_degrees <= 0:
+            return decide_route_comparison(
+                RouteDecisionInput(
                     decision.route_set,
                     decision.landmark_tcm_celsius,
                     decision.heat_evidence,
                     nighttime=True,
-                )
-            else:
-                try:
-                    shade_evidence = self.shade_evidence_loader(
-                        decision.route_set,
-                        solar,
-                        best_time.recommendation_time,
-                    )
-                except (ConnectionError, OSError, RuntimeError, TimeoutError, ValueError):
-                    shade_evidence = {}
-                shade_decision = RouteDecisionInput(
-                    decision.route_set,
-                    decision.landmark_tcm_celsius,
-                    decision.heat_evidence,
-                    shade_evidence=shade_evidence,
-                )
+                ),
+                cautious=request.cautious,
+                provenance=provenance,
+                routing_provenance=routing_provenance,
+                heat_provenance=heat_provenance,
+                solar_provenance=solar_provenance,
+            )
+
+        try:
+            shade = self.shade_evidence_loader(decision.route_set, solar, instant)
+        except (ConnectionError, OSError, RuntimeError, TimeoutError, ValueError):
+            shade = None
         return decide_route_comparison(
-            shade_decision,
+            RouteDecisionInput(
+                decision.route_set,
+                decision.landmark_tcm_celsius,
+                decision.heat_evidence,
+                shade_evidence={} if shade is None else shade.evidence,
+            ),
             cautious=request.cautious,
             provenance=provenance,
             routing_provenance=routing_provenance,
             heat_provenance=heat_provenance,
+            building_provenance=(
+                None if shade is None else _building_provenance(shade, clock=self.clock)
+            ),
+            solar_provenance=solar_provenance,
         )
 
     def _load_shared_heat(
@@ -380,6 +409,95 @@ def _shared_heat_provenance(heatmap: HeatmapResult) -> Provenance:
         fresh=not provider.stale,
         activity_id=provider.activity_id,
     )
+
+
+def _building_provenance(shade: RouteShadeOutcome, *, clock: Callable[[], datetime]) -> Provenance:
+    """Where the shared OSM building geometry came from, under the identity requested."""
+    coverage = min(
+        (item.building_coverage for item in shade.evidence.values()),
+        default=0.0,
+    )
+    configuration: dict[str, object] = dict(shade.request_identity)
+    configuration["metres_per_level"] = shade.metres_per_level
+    configuration["minimum_building_coverage"] = shade.minimum_building_coverage
+    configuration["dropped_geometry_count"] = shade.dropped_geometry_count
+    if shade.building is None:
+        return Provenance(
+            source="unavailable",
+            data_date=clock().date().isoformat(),
+            confidence=Confidence.INSUFFICIENT,
+            retrieved_at=clock().isoformat(),
+            transformation_version=BUILDING_TRANSFORMATION_VERSION,
+            provider="overpass",
+            response_status="unavailable",
+            request_configuration=configuration,
+            fresh=False,
+            coverage=coverage,
+            note=shade.unavailable_reason,
+        )
+    building = shade.building
+    replayed_without_retrieval_time = building.retrieved_at is None
+    return Provenance(
+        source=building.source,
+        data_date=building.data_date,
+        confidence=Confidence.SUFFICIENT,
+        retrieved_at=(
+            clock() if building.retrieved_at is None else building.retrieved_at
+        ).isoformat(),
+        transformation_version=BUILDING_TRANSFORMATION_VERSION,
+        provider="overpass",
+        response_status="completed",
+        request_configuration=configuration,
+        fresh=not building.stale,
+        coverage=coverage,
+        note=(
+            "replay time; the committed fixture records no provider retrieval time"
+            if replayed_without_retrieval_time
+            else building.reason
+        ),
+    )
+
+
+def _solar_provenance(
+    solar: SolarPosition,
+    instant: datetime,
+    latitude: float,
+    longitude: float,
+    *,
+    clock: Callable[[], datetime],
+) -> Provenance:
+    """The exact instant, place, and model behind one solar position (ADR 0007)."""
+    return Provenance(
+        source="computed",
+        data_date=instant.date().isoformat(),
+        confidence=Confidence.SUFFICIENT,
+        retrieved_at=clock().isoformat(),
+        transformation_version="route-solar-position-v1",
+        provider="astral",
+        response_status="completed",
+        request_configuration={
+            "instant": instant.isoformat(),
+            "timezone": _timezone_name(instant),
+            "utc_offset_seconds": int(cast(timedelta, instant.utcoffset()).total_seconds()),
+            "latitude": latitude,
+            "longitude": longitude,
+            "azimuth_degrees": solar.azimuth_degrees,
+            "elevation_degrees": solar.elevation_degrees,
+            "model_version": SOLAR_MODEL_IDENTITY,
+            "transformations": [
+                {"name": item.name, "version": item.version} for item in SOLAR_TRANSFORMATIONS
+            ],
+        },
+        fresh=True,
+    )
+
+
+def _timezone_name(instant: datetime) -> str:
+    """The named zone the instant carries, never a guess derived from its offset."""
+    key = getattr(instant.tzinfo, "key", None)
+    if isinstance(key, str) and key:
+        return key
+    return instant.tzname() or instant.strftime("%z")
 
 
 def _decision_provenance(routing: Provenance, heat: Provenance | None) -> Provenance:

--- a/app/services/route_analysis.py
+++ b/app/services/route_analysis.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from datetime import date, datetime
 
-from shapely.geometry import shape
+from shapely.geometry import MultiLineString, shape
 
 from app.domain.contracts import (
     BestTimeResult,
     Confidence,
     Provenance,
     RouteComparisonResult,
+    RouteDecisionState,
+    TemporalEvidenceState,
     TripAnalysisRequest,
 )
 from app.domain.route_decision import RouteDecisionInput, decide_route_comparison
@@ -20,7 +22,8 @@ from app.domain.route_heat import (
     aggregate_shared_route_heat,
     build_shared_route_aoi,
 )
-from app.domain.routing import RouteRequest
+from app.domain.route_shade import RouteShadeEvidence, SolarPosition, solar_position
+from app.domain.routing import RouteRequest, RouteSet
 from app.integrations.fortyguard.contracts import (
     AnalyticType,
     HeatmapRequest,
@@ -39,6 +42,11 @@ from app.services.routing import (
 
 class SharedRouteHeatUnavailable(RuntimeError):
     """The shared corridor activity could not provide normalized heat evidence."""
+
+
+ShadeEvidence = Mapping[str, RouteShadeEvidence]
+ShadeEvidenceLoader = Callable[[RouteSet, SolarPosition, datetime], ShadeEvidence]
+SolarLocator = Callable[[datetime, float, float], SolarPosition]
 
 
 class RouteAnalysisService:
@@ -63,6 +71,8 @@ class RouteAnalysisService:
             [SharedRouteHeatRequest], Mapping[str, object] | LiveHeatmapPayload
         ]
         | None = None,
+        shade_evidence_loader: ShadeEvidenceLoader | None = None,
+        solar_locator: SolarLocator = solar_position,
         clock: Callable[[], datetime] = lambda: datetime.now().astimezone(),
     ) -> None:
         self.route_execution = route_execution
@@ -78,6 +88,8 @@ class RouteAnalysisService:
         self.corridor_buffer_m = corridor_buffer_m
         self.corridor_granularity = corridor_granularity
         self.shared_heat_loader = shared_heat_loader
+        self.shade_evidence_loader = shade_evidence_loader
+        self.solar_locator = solar_locator
         self.clock = clock
 
     def analyze(
@@ -113,13 +125,13 @@ class RouteAnalysisService:
 
         if not outcome.routes.any_longer_than(self.representative_distance_m):
             heat_provenance = _landmark_heat_provenance(best_time.provenance)
-            return decide_route_comparison(
+            return self._decide(
                 RouteDecisionInput(
                     route_set=outcome.routes,
                     landmark_tcm_celsius=best_time.recommended_hour_tcm_celsius,
                 ),
-                cautious=request.cautious,
-                provenance=_decision_provenance(routing_provenance, heat_provenance),
+                request=request,
+                best_time=best_time,
                 routing_provenance=routing_provenance,
                 heat_provenance=heat_provenance,
             )
@@ -160,14 +172,87 @@ class RouteAnalysisService:
                 heat_provenance=None,
             )
         heat_provenance = _shared_heat_provenance(heatmap)
-        return decide_route_comparison(
+        return self._decide(
             RouteDecisionInput(
                 route_set=outcome.routes,
                 landmark_tcm_celsius=None,
                 heat_evidence=evidence,
             ),
+            request=request,
+            best_time=best_time,
+            routing_provenance=routing_provenance,
+            heat_provenance=heat_provenance,
+        )
+
+    def _decide(
+        self,
+        decision: RouteDecisionInput,
+        *,
+        request: TripAnalysisRequest,
+        best_time: BestTimeResult,
+        routing_provenance: Provenance,
+        heat_provenance: Provenance,
+    ) -> RouteComparisonResult:
+        provenance = _decision_provenance(routing_provenance, heat_provenance)
+        preliminary = decide_route_comparison(
+            decision,
             cautious=request.cautious,
-            provenance=_decision_provenance(routing_provenance, heat_provenance),
+            provenance=provenance,
+            routing_provenance=routing_provenance,
+            heat_provenance=heat_provenance,
+        )
+        if (
+            preliminary.decision_state is not RouteDecisionState.SHADE_REQUIRED
+            or self.shade_evidence_loader is None
+            or decision.route_set is None
+        ):
+            return preliminary
+        if (
+            best_time.temporal_evidence is not TemporalEvidenceState.EXACT
+            or best_time.recommendation_time is None
+        ):
+            shade_decision = RouteDecisionInput(
+                decision.route_set,
+                decision.landmark_tcm_celsius,
+                decision.heat_evidence,
+                shade_evidence={},
+            )
+        else:
+            route_geometry = MultiLineString(
+                [route.geometry.coordinates for route in decision.route_set.routes]
+            )
+            centroid = route_geometry.centroid
+            solar = self.solar_locator(
+                best_time.recommendation_time,
+                centroid.y,
+                centroid.x,
+            )
+            if solar.elevation_degrees <= 0:
+                shade_decision = RouteDecisionInput(
+                    decision.route_set,
+                    decision.landmark_tcm_celsius,
+                    decision.heat_evidence,
+                    nighttime=True,
+                )
+            else:
+                try:
+                    shade_evidence = self.shade_evidence_loader(
+                        decision.route_set,
+                        solar,
+                        best_time.recommendation_time,
+                    )
+                except (ConnectionError, OSError, RuntimeError, TimeoutError, ValueError):
+                    shade_evidence = {}
+                shade_decision = RouteDecisionInput(
+                    decision.route_set,
+                    decision.landmark_tcm_celsius,
+                    decision.heat_evidence,
+                    shade_evidence=shade_evidence,
+                )
+        return decide_route_comparison(
+            shade_decision,
+            cautious=request.cautious,
+            provenance=provenance,
             routing_provenance=routing_provenance,
             heat_provenance=heat_provenance,
         )

--- a/app/services/route_shade.py
+++ b/app/services/route_shade.py
@@ -8,7 +8,7 @@ import math
 from typing import Any, Mapping, cast
 
 from pyproj import Transformer
-from shapely.geometry import GeometryCollection, LineString, MultiPolygon, Polygon
+from shapely.geometry import GeometryCollection, LineString, Polygon, mapping
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform, unary_union
 
@@ -210,14 +210,15 @@ def _normalize_buildings(
             or ("building" not in tags and "building:part" not in tags)
         ):
             continue
-        geometry = _element_geometry(element)
-        if geometry is None:
+        result = _element_geometry(element)
+        if result.geometry is None:
             dropped += 1
             continue
+        dropped += result.dropped_members
         try:
             footprint = building_from_geojson(
                 f"{object_type}/{object_id}",
-                geometry,
+                result.geometry,
                 tags,
                 metres_per_level=metres_per_level,
             )
@@ -228,38 +229,92 @@ def _normalize_buildings(
     return _effective_footprints(raw), dropped
 
 
-def _element_geometry(element: Mapping[str, object]) -> Mapping[str, object] | None:
+@dataclass(frozen=True)
+class _ElementGeometry:
+    """One element's polygonal geometry and the member ways it could not use."""
+
+    geometry: Mapping[str, object] | None
+    dropped_members: int = 0
+
+
+def _element_geometry(element: Mapping[str, object]) -> _ElementGeometry:
     if element.get("type") == "way":
         ring = _ring(element.get("geometry"))
-        return {"type": "Polygon", "coordinates": [ring]} if ring is not None else None
+        return _ElementGeometry(
+            {"type": "Polygon", "coordinates": [ring]} if ring is not None else None
+        )
     members = element.get("members")
     if not isinstance(members, list):
-        return None
-    rings = [
-        ring
-        for member in members
-        if isinstance(member, Mapping)
-        for ring in [_ring(member.get("geometry"))]
-        if ring is not None and member.get("role") != "inner"
-    ]
-    if not rings:
-        return None
-    merged = cast(BaseGeometry, unary_union([Polygon(ring) for ring in rings]))
-    if merged.geom_type == "Polygon":
-        polygon = cast(Polygon, merged)
-        return {"type": "Polygon", "coordinates": [list(polygon.exterior.coords)]}
-    if merged.geom_type == "MultiPolygon":
-        return {
-            "type": "MultiPolygon",
-            "coordinates": [
-                [list(polygon.exterior.coords)] for polygon in cast(MultiPolygon, merged).geoms
-            ],
-        }
+        return _ElementGeometry(None)
+    outer: list[list[list[float]]] = []
+    inner: list[list[list[float]]] = []
+    dropped = 0
+    for member in members:
+        if not isinstance(member, Mapping):
+            dropped += 1
+            continue
+        if member.get("type") != "way":
+            # Node and sub-relation members carry no ring; they discard no area.
+            continue
+        points = _points(member.get("geometry"))
+        if points is None:
+            dropped += 1
+            continue
+        (inner if member.get("role") == "inner" else outer).append(points)
+    outer_rings, unclosed_outer = _assemble_rings(outer)
+    inner_rings, unclosed_inner = _assemble_rings(inner)
+    dropped += unclosed_outer + unclosed_inner
+    if not outer_rings:
+        return _ElementGeometry(None, dropped)
+    shell = cast(BaseGeometry, unary_union([Polygon(ring) for ring in outer_rings]))
+    holes = [Polygon(ring) for ring in inner_rings]
+    solid = shell.difference(cast(BaseGeometry, unary_union(holes))) if holes else shell
+    if solid.is_empty or solid.geom_type not in {"Polygon", "MultiPolygon"}:
+        return _ElementGeometry(None, dropped)
+    return _ElementGeometry(cast(Mapping[str, object], mapping(solid)), dropped)
+
+
+def _assemble_rings(ways: list[list[list[float]]]) -> tuple[list[list[list[float]]], int]:
+    """Stitch fragmented member ways into closed rings; count the members left over."""
+    pending = [list(way) for way in ways]
+    rings: list[list[list[float]]] = []
+    dropped_members = 0
+    while pending:
+        chain = pending.pop(0)
+        consumed = 1
+        while chain[0] != chain[-1]:
+            extended = _join(chain, pending)
+            if extended is None:
+                break
+            chain, consumed = extended, consumed + 1
+        if chain[0] == chain[-1] and len(chain) >= 4:
+            rings.append(chain)
+        else:
+            dropped_members += consumed
+    return rings, dropped_members
+
+
+def _join(chain: list[list[float]], pending: list[list[list[float]]]) -> list[list[float]] | None:
+    """Extend the chain with the first pending way sharing an endpoint, in either direction."""
+    for index, candidate in enumerate(pending):
+        if candidate[0] == chain[-1]:
+            extended = chain + candidate[1:]
+        elif candidate[-1] == chain[-1]:
+            extended = chain + candidate[-2::-1]
+        elif candidate[-1] == chain[0]:
+            extended = candidate[:-1] + chain
+        elif candidate[0] == chain[0]:
+            extended = candidate[:0:-1] + chain
+        else:
+            continue
+        pending.pop(index)
+        return extended
     return None
 
 
-def _ring(value: object) -> list[list[float]] | None:
-    if not isinstance(value, list):
+def _points(value: object) -> list[list[float]] | None:
+    """Validated lon/lat points from one Overpass geometry array, open or closed."""
+    if not isinstance(value, list) or len(value) < 2:
         return None
     coordinates: list[list[float]] = []
     for point in value:
@@ -278,9 +333,15 @@ def _ring(value: object) -> list[list[float]] | None:
         ):
             return None
         coordinates.append([float(longitude), float(latitude)])
-    if len(coordinates) < 4 or coordinates[0] != coordinates[-1]:
-        return None
     return coordinates
+
+
+def _ring(value: object) -> list[list[float]] | None:
+    """One already-closed ring of at least four validated points."""
+    points = _points(value)
+    if points is None or len(points) < 4 or points[0] != points[-1]:
+        return None
+    return points
 
 
 def _effective_footprints(raw: list[_RawBuilding]) -> tuple[BuildingFootprint, ...]:

--- a/app/services/route_shade.py
+++ b/app/services/route_shade.py
@@ -1,0 +1,285 @@
+"""One-request OSM building acquisition and per-route modeled shade evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import math
+from typing import Mapping, cast
+
+from pyproj import Transformer
+from shapely.geometry import GeometryCollection, LineString, MultiPolygon, Polygon
+from shapely.geometry.base import BaseGeometry
+from shapely.ops import transform, unary_union
+
+from app.domain.hotels import BoundingBox
+from app.domain.route_heat import build_shared_route_aoi
+from app.domain.route_shade import (
+    BuildingFootprint,
+    BuildingHeightQuality,
+    RouteShadeEvidence,
+    ShadeConfidence,
+    SolarPosition,
+    building_from_geojson,
+    route_shade_percent,
+)
+from app.domain.routing import RouteSet
+from app.integrations.overpass.client import OverpassClient
+from app.integrations.overpass.errors import OverpassError
+
+
+class RouteShadeService:
+    """Acquire one shared building set and derive detailed evidence for each route."""
+
+    def __init__(
+        self,
+        client: OverpassClient,
+        *,
+        corridor_buffer_m: float = 250.0,
+        minimum_building_coverage: float = 0.70,
+        metres_per_level: float = 3.0,
+    ) -> None:
+        if not math.isfinite(corridor_buffer_m) or corridor_buffer_m <= 0:
+            raise ValueError("shade corridor buffer must be positive and finite")
+        if (
+            not math.isfinite(minimum_building_coverage)
+            or not 0 <= minimum_building_coverage <= 1
+        ):
+            raise ValueError("minimum building coverage must be between zero and one")
+        if not math.isfinite(metres_per_level) or metres_per_level <= 0:
+            raise ValueError("metres per building level must be positive and finite")
+        self._client = client
+        self._corridor_buffer_m = corridor_buffer_m
+        self._minimum_building_coverage = minimum_building_coverage
+        self._metres_per_level = metres_per_level
+
+    def load(
+        self,
+        routes: RouteSet,
+        solar: SolarPosition,
+        instant: datetime,
+    ) -> Mapping[str, RouteShadeEvidence]:
+        if instant.tzinfo is None or instant.utcoffset() is None:
+            raise ValueError("shade instant must be timezone-aware")
+        response = self._client.query_buildings(
+            _shared_bbox(routes, self._corridor_buffer_m)
+        )
+        buildings, dropped_geometry_count = _normalize_buildings(
+            response, metres_per_level=self._metres_per_level
+        )
+        return {
+            route.identity: self._route_evidence(
+                LineString(route.geometry.coordinates),
+                buildings,
+                solar,
+                dropped_geometry_count,
+            )
+            for route in routes.routes
+        }
+
+    def _route_evidence(
+        self,
+        route: LineString,
+        buildings: tuple[BuildingFootprint, ...],
+        solar: SolarPosition,
+        dropped_geometry_count: int,
+    ) -> RouteShadeEvidence:
+        epsg = _local_epsg(route)
+        corridor = _project(route, epsg).buffer(self._corridor_buffer_m)
+        projected = tuple(
+            (building, _project(building.geometry, epsg)) for building in buildings
+        )
+        relevant = tuple(
+            (building, geometry)
+            for building, geometry in projected
+            if geometry.intersects(corridor)
+        )
+        areas: dict[BuildingHeightQuality, float] = {}
+        counts: dict[BuildingHeightQuality, int] = {}
+        for quality in BuildingHeightQuality:
+            geometries = [
+                geometry.intersection(corridor)
+                for building, geometry in relevant
+                if building.height_quality is quality
+            ]
+            usable = [geometry for geometry in geometries if geometry.area > 0]
+            areas[quality] = float(unary_union(usable).area) if usable else 0.0
+            counts[quality] = sum(
+                1 for building, _ in relevant if building.height_quality is quality
+            )
+        total = sum(areas.values())
+        fractions = {
+            quality: (areas[quality] / total if total > 0 else 0.0)
+            for quality in BuildingHeightQuality
+        }
+        coverage = (
+            fractions[BuildingHeightQuality.EXPLICIT]
+            + fractions[BuildingHeightQuality.INFERRED_LEVELS]
+        )
+        confidence = (
+            ShadeConfidence.SUFFICIENT
+            if coverage >= self._minimum_building_coverage and dropped_geometry_count == 0
+            else ShadeConfidence.INSUFFICIENT
+        )
+        relevant_buildings = tuple(building for building, _ in relevant)
+        return RouteShadeEvidence(
+            modeled_shade_percent=route_shade_percent(route, relevant_buildings, solar),
+            building_coverage=coverage,
+            confidence=confidence,
+            explicit_area_fraction=fractions[BuildingHeightQuality.EXPLICIT],
+            inferred_levels_area_fraction=fractions[BuildingHeightQuality.INFERRED_LEVELS],
+            unknown_area_fraction=fractions[BuildingHeightQuality.UNKNOWN],
+            explicit_count=counts[BuildingHeightQuality.EXPLICIT],
+            inferred_levels_count=counts[BuildingHeightQuality.INFERRED_LEVELS],
+            unknown_count=counts[BuildingHeightQuality.UNKNOWN],
+            dropped_geometry_count=dropped_geometry_count,
+        )
+
+
+def _shared_bbox(routes: RouteSet, buffer_m: float) -> BoundingBox:
+    polygon = build_shared_route_aoi(routes, buffer_m=buffer_m)
+    rings = polygon.get("coordinates")
+    if not isinstance(rings, list) or not rings or not isinstance(rings[0], list):
+        raise ValueError("shared route AOI must be a GeoJSON polygon")
+    points = rings[0]
+    longitudes = [float(point[0]) for point in points]
+    latitudes = [float(point[1]) for point in points]
+    return BoundingBox(min(latitudes), min(longitudes), max(latitudes), max(longitudes))
+
+
+@dataclass(frozen=True)
+class _RawBuilding:
+    footprint: BuildingFootprint
+    is_part: bool
+
+
+def _normalize_buildings(
+    response: Mapping[str, object], *, metres_per_level: float = 3.0
+) -> tuple[tuple[BuildingFootprint, ...], int]:
+    elements = response.get("elements")
+    if not isinstance(elements, list):
+        raise OverpassError("Overpass building response elements must be a list")
+    raw: list[_RawBuilding] = []
+    dropped = 0
+    for element in elements:
+        if not isinstance(element, Mapping):
+            dropped += 1
+            continue
+        object_type = element.get("type")
+        object_id = element.get("id")
+        tags = element.get("tags")
+        if (
+            object_type not in {"way", "relation"}
+            or not isinstance(object_id, int)
+            or isinstance(object_id, bool)
+            or not isinstance(tags, Mapping)
+            or ("building" not in tags and "building:part" not in tags)
+        ):
+            continue
+        geometry = _element_geometry(element)
+        if geometry is None:
+            dropped += 1
+            continue
+        try:
+            footprint = building_from_geojson(
+                f"{object_type}/{object_id}",
+                geometry,
+                tags,
+                metres_per_level=metres_per_level,
+            )
+        except ValueError:
+            dropped += 1
+            continue
+        raw.append(_RawBuilding(footprint, "building:part" in tags))
+    return _effective_footprints(raw), dropped
+
+
+def _element_geometry(element: Mapping[str, object]) -> Mapping[str, object] | None:
+    if element.get("type") == "way":
+        ring = _ring(element.get("geometry"))
+        return {"type": "Polygon", "coordinates": [ring]} if ring is not None else None
+    members = element.get("members")
+    if not isinstance(members, list):
+        return None
+    rings = [
+        ring
+        for member in members
+        if isinstance(member, Mapping)
+        for ring in [_ring(member.get("geometry"))]
+        if ring is not None and member.get("role") != "inner"
+    ]
+    if not rings:
+        return None
+    merged = cast(BaseGeometry, unary_union([Polygon(ring) for ring in rings]))
+    if merged.geom_type == "Polygon":
+        polygon = cast(Polygon, merged)
+        return {"type": "Polygon", "coordinates": [list(polygon.exterior.coords)]}
+    if merged.geom_type == "MultiPolygon":
+        return {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [list(polygon.exterior.coords)] for polygon in cast(MultiPolygon, merged).geoms
+            ],
+        }
+    return None
+
+
+def _ring(value: object) -> list[list[float]] | None:
+    if not isinstance(value, list):
+        return None
+    coordinates: list[list[float]] = []
+    for point in value:
+        if not isinstance(point, Mapping):
+            return None
+        latitude, longitude = point.get("lat"), point.get("lon")
+        if (
+            not isinstance(latitude, (int, float))
+            or isinstance(latitude, bool)
+            or not math.isfinite(latitude)
+            or not -90 <= latitude <= 90
+            or not isinstance(longitude, (int, float))
+            or isinstance(longitude, bool)
+            or not math.isfinite(longitude)
+            or not -180 <= longitude <= 180
+        ):
+            return None
+        coordinates.append([float(longitude), float(latitude)])
+    if len(coordinates) < 4 or coordinates[0] != coordinates[-1]:
+        return None
+    return coordinates
+
+
+def _effective_footprints(raw: list[_RawBuilding]) -> tuple[BuildingFootprint, ...]:
+    parts = sorted((item.footprint for item in raw if item.is_part), key=lambda item: item.identity)
+    parents = sorted(
+        (item.footprint for item in raw if not item.is_part), key=lambda item: item.identity
+    )
+    effective: list[BuildingFootprint] = []
+    occupied_parts: BaseGeometry = GeometryCollection()
+    for part in parts:
+        geometry = part.geometry.difference(occupied_parts)
+        if not geometry.is_empty and geometry.geom_type in {"Polygon", "MultiPolygon"}:
+            effective.append(
+                BuildingFootprint(part.identity, geometry, part.height_m, part.height_quality)
+            )
+        occupied_parts = occupied_parts.union(part.geometry)
+    occupied_parents: BaseGeometry = GeometryCollection()
+    for parent in parents:
+        geometry = parent.geometry.difference(occupied_parts).difference(occupied_parents)
+        if not geometry.is_empty and geometry.geom_type in {"Polygon", "MultiPolygon"}:
+            effective.append(
+                BuildingFootprint(parent.identity, geometry, parent.height_m, parent.height_quality)
+            )
+        occupied_parents = occupied_parents.union(parent.geometry)
+    return tuple(effective)
+
+
+def _local_epsg(geometry: BaseGeometry) -> int:
+    centroid = geometry.centroid
+    zone = int((centroid.x + 180) // 6) + 1
+    return 32600 + zone if centroid.y >= 0 else 32700 + zone
+
+
+def _project(geometry: BaseGeometry, epsg: int) -> BaseGeometry:
+    transformer = Transformer.from_crs("EPSG:4326", f"EPSG:{epsg}", always_xy=True)
+    return transform(transformer.transform, geometry)

--- a/app/services/route_shade.py
+++ b/app/services/route_shade.py
@@ -22,10 +22,11 @@ from app.domain.route_shade import (
     SolarPosition,
     building_from_geojson,
     route_shade_percent,
+    unavailable_shade_evidence,
 )
 from app.domain.routing import RouteSet
-from app.integrations.overpass.client import OverpassClient
 from app.integrations.overpass.errors import OverpassError
+from app.services.building_execution import BuildingExecution, BuildingsUnavailable
 
 
 class RouteShadeService:
@@ -33,7 +34,7 @@ class RouteShadeService:
 
     def __init__(
         self,
-        client: OverpassClient,
+        execution: BuildingExecution,
         *,
         corridor_buffer_m: float = 250.0,
         minimum_building_coverage: float = 0.70,
@@ -45,7 +46,7 @@ class RouteShadeService:
             raise ValueError("minimum building coverage must be between zero and one")
         if not math.isfinite(metres_per_level) or metres_per_level <= 0:
             raise ValueError("metres per building level must be positive and finite")
-        self._client = client
+        self._execution = execution
         self._corridor_buffer_m = corridor_buffer_m
         self._minimum_building_coverage = minimum_building_coverage
         self._metres_per_level = metres_per_level
@@ -58,10 +59,13 @@ class RouteShadeService:
     ) -> Mapping[str, RouteShadeEvidence]:
         if instant.tzinfo is None or instant.utcoffset() is None:
             raise ValueError("shade instant must be timezone-aware")
-        response = self._client.query_buildings(_shared_bbox(routes, self._corridor_buffer_m))
-        buildings, dropped_geometry_count = _normalize_buildings(
-            response, metres_per_level=self._metres_per_level
-        )
+        try:
+            outcome = self._execution.run(_shared_bbox(routes, self._corridor_buffer_m))
+            buildings, dropped_geometry_count = _normalize_buildings(
+                outcome.payload, metres_per_level=self._metres_per_level
+            )
+        except (BuildingsUnavailable, OverpassError):
+            return {route.identity: unavailable_shade_evidence() for route in routes.routes}
         return {
             route.identity: self._route_evidence(
                 LineString(route.geometry.coordinates),

--- a/app/services/route_shade.py
+++ b/app/services/route_shade.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 import math
-from typing import Mapping, cast
+from typing import Any, Mapping, cast
 
 from pyproj import Transformer
 from shapely.geometry import GeometryCollection, LineString, MultiPolygon, Polygon
@@ -15,6 +15,7 @@ from shapely.ops import transform, unary_union
 from app.domain.hotels import BoundingBox
 from app.domain.route_heat import build_shared_route_aoi
 from app.domain.route_shade import (
+    SHADE_UNAVAILABLE_LIMITATION,
     BuildingFootprint,
     BuildingHeightQuality,
     RouteShadeEvidence,
@@ -26,7 +27,28 @@ from app.domain.route_shade import (
 )
 from app.domain.routing import RouteSet
 from app.integrations.overpass.errors import OverpassError
-from app.services.building_execution import BuildingExecution, BuildingsUnavailable
+from app.services.building_execution import (
+    BuildingExecution,
+    BuildingOutcome,
+    BuildingsUnavailable,
+)
+
+
+@dataclass(frozen=True)
+class RouteShadeOutcome:
+    """Per-route shade evidence and the building acquisition that produced it."""
+
+    evidence: Mapping[str, RouteShadeEvidence]
+    request_identity: Mapping[str, Any]
+    metres_per_level: float
+    minimum_building_coverage: float
+    dropped_geometry_count: int = 0
+    building: BuildingOutcome | None = None
+    unavailable_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if (self.building is None) != (self.unavailable_reason is not None):
+            raise ValueError("shade outcomes record either a building source or why none answered")
 
 
 class RouteShadeService:
@@ -56,25 +78,40 @@ class RouteShadeService:
         routes: RouteSet,
         solar: SolarPosition,
         instant: datetime,
-    ) -> Mapping[str, RouteShadeEvidence]:
+    ) -> RouteShadeOutcome:
         if instant.tzinfo is None or instant.utcoffset() is None:
             raise ValueError("shade instant must be timezone-aware")
+        aoi = _shared_bbox(routes, self._corridor_buffer_m)
+        identity = self._execution.identity(aoi)
         try:
-            outcome = self._execution.run(_shared_bbox(routes, self._corridor_buffer_m))
+            outcome = self._execution.run(aoi)
             buildings, dropped_geometry_count = _normalize_buildings(
                 outcome.payload, metres_per_level=self._metres_per_level
             )
-        except (BuildingsUnavailable, OverpassError):
-            return {route.identity: unavailable_shade_evidence() for route in routes.routes}
-        return {
-            route.identity: self._route_evidence(
-                LineString(route.geometry.coordinates),
-                buildings,
-                solar,
-                dropped_geometry_count,
+        except (BuildingsUnavailable, OverpassError) as error:
+            return RouteShadeOutcome(
+                evidence={route.identity: unavailable_shade_evidence() for route in routes.routes},
+                request_identity=identity,
+                metres_per_level=self._metres_per_level,
+                minimum_building_coverage=self._minimum_building_coverage,
+                unavailable_reason=str(error) or SHADE_UNAVAILABLE_LIMITATION,
             )
-            for route in routes.routes
-        }
+        return RouteShadeOutcome(
+            evidence={
+                route.identity: self._route_evidence(
+                    LineString(route.geometry.coordinates),
+                    buildings,
+                    solar,
+                    dropped_geometry_count,
+                )
+                for route in routes.routes
+            },
+            request_identity=identity,
+            metres_per_level=self._metres_per_level,
+            minimum_building_coverage=self._minimum_building_coverage,
+            dropped_geometry_count=dropped_geometry_count,
+            building=outcome,
+        )
 
     def _route_evidence(
         self,

--- a/app/services/route_shade.py
+++ b/app/services/route_shade.py
@@ -41,10 +41,7 @@ class RouteShadeService:
     ) -> None:
         if not math.isfinite(corridor_buffer_m) or corridor_buffer_m <= 0:
             raise ValueError("shade corridor buffer must be positive and finite")
-        if (
-            not math.isfinite(minimum_building_coverage)
-            or not 0 <= minimum_building_coverage <= 1
-        ):
+        if not math.isfinite(minimum_building_coverage) or not 0 <= minimum_building_coverage <= 1:
             raise ValueError("minimum building coverage must be between zero and one")
         if not math.isfinite(metres_per_level) or metres_per_level <= 0:
             raise ValueError("metres per building level must be positive and finite")
@@ -61,9 +58,7 @@ class RouteShadeService:
     ) -> Mapping[str, RouteShadeEvidence]:
         if instant.tzinfo is None or instant.utcoffset() is None:
             raise ValueError("shade instant must be timezone-aware")
-        response = self._client.query_buildings(
-            _shared_bbox(routes, self._corridor_buffer_m)
-        )
+        response = self._client.query_buildings(_shared_bbox(routes, self._corridor_buffer_m))
         buildings, dropped_geometry_count = _normalize_buildings(
             response, metres_per_level=self._metres_per_level
         )
@@ -86,9 +81,7 @@ class RouteShadeService:
     ) -> RouteShadeEvidence:
         epsg = _local_epsg(route)
         corridor = _project(route, epsg).buffer(self._corridor_buffer_m)
-        projected = tuple(
-            (building, _project(building.geometry, epsg)) for building in buildings
-        )
+        projected = tuple((building, _project(building.geometry, epsg)) for building in buildings)
         relevant = tuple(
             (building, geometry)
             for building, geometry in projected

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -687,11 +687,13 @@ def _best_time(
     )
     recommendation_time = (
         datetime.fromisoformat(_string(best_payload["recommendation_time"], "recommendation_time"))
-        if best_payload.get("recommendation_time") is not None else None
+        if best_payload.get("recommendation_time") is not None
+        else None
     )
     recommendation_timezone = (
         _string(best_payload["recommendation_timezone"], "recommendation_timezone")
-        if best_payload.get("recommendation_timezone") is not None else None
+        if best_payload.get("recommendation_timezone") is not None
+        else None
     )
     recommendation_reason = _string(best_payload["recommendation_reason"], "recommendation_reason")
     if cautious:

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import math
 from datetime import date, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from pathlib import Path
 from typing import Callable, Mapping
 
@@ -30,11 +31,13 @@ from app.domain.contracts import (
     RouteOption,
     RouteSetState,
     TripAnalysisAdapter,
+    TemporalEvidenceState,
     TripAnalysisRequest,
     TripAnalysisResponse,
     TripMode,
     UnavailableResult,
 )
+from app.domain.route_shade import ShadeConfidence
 from app.domain.environment import select_anchor_celsius
 from app.domain.best_time import HourlyConcernProfile, assess_hour, select_best_time
 from app.domain.heat_policy import classify_heat
@@ -240,6 +243,8 @@ class TemporalTripAnalysisAdapter:
 def _route_degradation_reason(routes: RouteComparisonResult) -> str | None:
     if routes.decision_state is RouteDecisionState.SHADE_REQUIRED:
         return "route heat is elevated; shade analysis is required before recommendation"
+    if routes.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED:
+        return "modeled building-shade evidence is insufficient for a recommendation"
     if routes.decision_state is RouteDecisionState.HEAT_UNAVAILABLE:
         return "shared corridor heat is unavailable"
     if routes.decision_state is RouteDecisionState.NO_SUITABLE_RETURNED_ROUTE:
@@ -319,6 +324,33 @@ def _best_time_result(
     reason = decision.reason
     if environment_failure is not None:
         reason = f"TCM-only fallback because environmental parameters are unavailable; {reason}"
+    selected_times = tuple(
+        {tile.valid_time for tile in heatmap.tiles if tile.valid_time.hour == decision.hour}
+    )
+    recommendation_time: datetime | None = None
+    recommendation_timezone: str | None = None
+    temporal_evidence = TemporalEvidenceState.UNAVAILABLE
+    if len(selected_times) == 1:
+        candidate = selected_times[0]
+        requested_zone = environment.timezone if environment is not None else "America/Chicago"
+        try:
+            zone = ZoneInfo(requested_zone)
+        except (ZoneInfoNotFoundError, ValueError):
+            requested_zone = "America/Chicago"
+            zone = ZoneInfo(requested_zone)
+        local = candidate.astimezone(zone)
+        if (
+            local.date() == date.fromisoformat(request.date)
+            and local.hour == decision.hour
+            and candidate.utcoffset() == local.utcoffset()
+        ):
+            recommendation_time = candidate
+            recommendation_timezone = requested_zone
+            temporal_evidence = TemporalEvidenceState.EXACT
+        else:
+            temporal_evidence = TemporalEvidenceState.INCONSISTENT
+    elif len(selected_times) > 1:
+        temporal_evidence = TemporalEvidenceState.INCONSISTENT
     selected_label = next(entry.metric.label for entry in hourly if entry.hour == decision.hour)
     return BestTimeResult(
         hourly=hourly,
@@ -338,6 +370,9 @@ def _best_time_result(
         persistence_hours=persistence_hours,
         framing_threshold_celsius=FRAMING_THRESHOLD_CELSIUS,
         framing_direction=FRAMING_DIRECTION,
+        recommendation_time=recommendation_time,
+        recommendation_timezone=recommendation_timezone,
+        temporal_evidence=temporal_evidence,
     )
 
 
@@ -647,6 +682,17 @@ def _best_time(
         cautious=cautious,
         noaa_heat_index_available=selected_heat_index is not None,
     )
+    temporal_evidence = TemporalEvidenceState(
+        _string(best_payload.get("temporal_evidence", "unavailable"), "temporal_evidence")
+    )
+    recommendation_time = (
+        datetime.fromisoformat(_string(best_payload["recommendation_time"], "recommendation_time"))
+        if best_payload.get("recommendation_time") is not None else None
+    )
+    recommendation_timezone = (
+        _string(best_payload["recommendation_timezone"], "recommendation_timezone")
+        if best_payload.get("recommendation_timezone") is not None else None
+    )
     recommendation_reason = _string(best_payload["recommendation_reason"], "recommendation_reason")
     if cautious:
         recommendation_reason = (
@@ -663,6 +709,9 @@ def _best_time(
         provenance=best_provenance,
         hourly_coverage=_number(best_payload["hourly_coverage"], "hourly_coverage"),
         heat_interpretation=interpretation,
+        recommendation_time=recommendation_time,
+        recommendation_timezone=recommendation_timezone,
+        temporal_evidence=temporal_evidence,
     )
 
 
@@ -796,7 +845,13 @@ def _route_option(
         modeled_shade_percent=_number(shade, "modeled_shade_percent")
         if shade is not None
         else None,
-        shade_confidence=confidence if shade is not None else None,
+        shade_confidence=(
+            ShadeConfidence.SUFFICIENT
+            if shade is not None and confidence is Confidence.SUFFICIENT
+            else ShadeConfidence.INSUFFICIENT
+            if shade is not None
+            else None
+        ),
         building_coverage=_number(item["building_coverage"], "building_coverage"),
         recommended=identity == recommended_id,
         recommendation_reason=_route_recommendation_reason(

--- a/app/settings.py
+++ b/app/settings.py
@@ -340,8 +340,7 @@ def _shade_from_env(merged: Mapping[str, str]) -> ShadeSettings:
         canonical_timezone=timezone_name,
         schema_version=merged.get("SHADE_BUILDING_SCHEMA_VERSION", "").strip() or "building-v1",
         provider_config_version=(
-            merged.get("SHADE_PROVIDER_CONFIG_VERSION", "").strip()
-            or "overpass-building-config-v1"
+            merged.get("SHADE_PROVIDER_CONFIG_VERSION", "").strip() or "overpass-building-config-v1"
         ),
         model_version=merged.get("SHADE_MODEL_VERSION", "").strip() or "route-shade-v1",
     )

--- a/app/settings.py
+++ b/app/settings.py
@@ -7,6 +7,7 @@ import math
 import os
 from pathlib import Path
 from typing import Mapping
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.domain.hotels import BoundingBox
 
@@ -77,6 +78,19 @@ class OverpassSettings:
 
 
 @dataclass(frozen=True)
+class ShadeSettings:
+    """Product and model policy for exact-time OSM building shade."""
+
+    building_search_distance_m: float = 250.0
+    minimum_building_height_coverage: float = 0.70
+    metres_per_level: float = 3.0
+    canonical_timezone: str = "America/Chicago"
+    schema_version: str = "building-v1"
+    provider_config_version: str = "overpass-building-config-v1"
+    model_version: str = "route-shade-v1"
+
+
+@dataclass(frozen=True)
 class AppSettings:
     allow_live: bool
     fortyguard_api_key: str | None
@@ -85,6 +99,7 @@ class AppSettings:
     area: FortyGuardAreaSettings = FortyGuardAreaSettings()
     overpass: OverpassSettings = OverpassSettings()
     osrm: OsrmSettings = OsrmSettings()
+    shade: ShadeSettings = ShadeSettings()
     call_budget: int | None = None
     ledger_path: Path | None = DEFAULT_LEDGER_PATH
 
@@ -217,6 +232,7 @@ def load_settings(
         area=area or _area_from_env(merged),
         overpass=_overpass_from_env(merged),
         osrm=_osrm_from_env(merged),
+        shade=_shade_from_env(merged),
         call_budget=_call_budget_from_env(merged),
         ledger_path=_ledger_path_from_env(process_env, file_values),
     )
@@ -293,6 +309,41 @@ def _overpass_from_env(merged: Mapping[str, str]) -> OverpassSettings:
         max_attempts=positive_int("OVERPASS_MAX_ATTEMPTS", 2),
         retry_delay_seconds=float_value("OVERPASS_RETRY_DELAY_SECONDS", 30.0, allow_zero=True),
         district_aoi=district_aoi,
+    )
+
+
+def _shade_from_env(merged: Mapping[str, str]) -> ShadeSettings:
+    def positive_float(name: str, default: float) -> float:
+        raw = merged.get(name, "").strip()
+        if not raw:
+            return default
+        try:
+            value = float(raw)
+        except ValueError:
+            raise SettingsError(f"{name} must be a number") from None
+        if not math.isfinite(value) or value <= 0:
+            raise SettingsError(f"{name} must be positive")
+        return value
+
+    coverage = positive_float("SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE", 0.70)
+    if coverage > 1:
+        raise SettingsError("SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE must be at most 1")
+    timezone_name = merged.get("TRIP_CANONICAL_TIMEZONE", "").strip() or "America/Chicago"
+    try:
+        ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        raise SettingsError("TRIP_CANONICAL_TIMEZONE must be a valid IANA timezone") from None
+    return ShadeSettings(
+        building_search_distance_m=positive_float("SHADE_BUILDING_SEARCH_DISTANCE_M", 250.0),
+        minimum_building_height_coverage=coverage,
+        metres_per_level=positive_float("SHADE_METRES_PER_LEVEL", 3.0),
+        canonical_timezone=timezone_name,
+        schema_version=merged.get("SHADE_BUILDING_SCHEMA_VERSION", "").strip() or "building-v1",
+        provider_config_version=(
+            merged.get("SHADE_PROVIDER_CONFIG_VERSION", "").strip()
+            or "overpass-building-config-v1"
+        ),
+        model_version=merged.get("SHADE_MODEL_VERSION", "").strip() or "route-shade-v1",
     )
 
 

--- a/app/wiring.py
+++ b/app/wiring.py
@@ -52,6 +52,7 @@ from app.services.hotel_heat_score import build_fixture_hotel_heat_analysis_serv
 from app.services.execution import EnvParamsExecution, HeatmapExecution
 from app.services.ledger_store import JsonlLedgerStore
 from app.services.route_analysis import RouteAnalysisService
+from app.services.route_shade import RouteShadeService
 from app.services.routing import RouteExecution
 from app.services.trip_adapters import (
     FixtureTripAnalysisAdapter,
@@ -435,6 +436,22 @@ def build_live_route_analysis_service(
         client,
         polling=settings.polling,
     )
+    overpass = settings.overpass
+    shade = settings.shade
+    shade_service = RouteShadeService(
+        OverpassClient(
+            HttpOverpassTransport(
+                overpass.endpoint,
+                user_agent=overpass.user_agent,
+                timeout_seconds=overpass.timeout_seconds,
+            ),
+            max_attempts=overpass.max_attempts,
+            retry_delay_seconds=overpass.retry_delay_seconds,
+        ),
+        corridor_buffer_m=shade.building_search_distance_m,
+        minimum_building_coverage=shade.minimum_building_height_coverage,
+        metres_per_level=shade.metres_per_level,
+    )
     return RouteAnalysisService(
         route_execution,
         profile=osrm.profile,
@@ -449,6 +466,7 @@ def build_live_route_analysis_service(
         corridor_buffer_m=settings.area.buffer_m,
         corridor_granularity=settings.area.granularity,
         shared_heat_loader=shared_heat.load,
+        shade_evidence_loader=shade_service.load,
     )
 
 

--- a/app/wiring.py
+++ b/app/wiring.py
@@ -46,6 +46,7 @@ from app.integrations.overpass.client import OverpassClient
 from app.integrations.overpass.errors import OverpassError
 from app.integrations.overpass.transport import HttpOverpassTransport
 from app.services.cache import CacheService
+from app.services.building_execution import BuildingExecution
 from app.services.hotel_discovery import HotelDiscoveryService
 from app.services.hotel_heat_score import HotelHeatAnalysisService
 from app.services.hotel_heat_score import build_fixture_hotel_heat_analysis_service
@@ -415,6 +416,7 @@ def build_live_route_analysis_service(
     client: FortyGuardClient,
     cache: CacheService | None = None,
     fixture_path: Path,
+    building_fixture_path: Path | None = None,
 ) -> RouteAnalysisService:
     """Compose one OSRM execution and one optional shared corridor activity."""
     osrm = settings.osrm
@@ -438,16 +440,27 @@ def build_live_route_analysis_service(
     )
     overpass = settings.overpass
     shade = settings.shade
-    shade_service = RouteShadeService(
-        OverpassClient(
-            HttpOverpassTransport(
-                overpass.endpoint,
-                user_agent=overpass.user_agent,
-                timeout_seconds=overpass.timeout_seconds,
-            ),
-            max_attempts=overpass.max_attempts,
-            retry_delay_seconds=overpass.retry_delay_seconds,
+    overpass_client = OverpassClient(
+        HttpOverpassTransport(
+            overpass.endpoint,
+            user_agent=overpass.user_agent,
+            timeout_seconds=overpass.timeout_seconds,
         ),
+        max_attempts=overpass.max_attempts,
+        retry_delay_seconds=overpass.retry_delay_seconds,
+    )
+    building_execution = BuildingExecution(
+        live_loader=overpass_client.query_buildings,
+        cache=cache if cache is not None else CacheService(),
+        fixture_path=building_fixture_path,
+        endpoint=overpass.endpoint,
+        schema_version=shade.schema_version,
+        provider_config_version=shade.provider_config_version,
+        model_version=shade.model_version,
+        search_distance_m=shade.building_search_distance_m,
+    )
+    shade_service = RouteShadeService(
+        building_execution,
         corridor_buffer_m=shade.building_search_distance_m,
         minimum_building_coverage=shade.minimum_building_height_coverage,
         metres_per_level=shade.metres_per_level,
@@ -535,6 +548,9 @@ def create_production_app(
             client=client,
             cache=cache,
             fixture_path=heatmap_fixture.parent / "osrm-route.json",
+            building_fixture_path=(
+                heatmap_fixture.parent / "acquired" / "overpass-buildings-canonical.json"
+            ),
         )
     if trip_adapter is None:
         fixture_trip_adapter = FixtureTripAnalysisAdapter(

--- a/docs/adr/0007-exact-time-modeled-shade-decisions.md
+++ b/docs/adr/0007-exact-time-modeled-shade-decisions.md
@@ -1,0 +1,53 @@
+# ADR 0007: Exact-time modeled shade and evidence-based route decisions
+
+Date: 2026-08-30
+Status: Accepted
+
+## Context
+
+Issue #19 completes ADR 0006's elevated-heat route stage with deterministic
+OSM building-shadow estimates. Solar geometry depends on an exact instant, but
+the current best-time contract reduces provider evidence to a whole-hour
+integer. Building data can also be incomplete, and building shade is physically
+irrelevant while the sun is below the horizon. A forced shortest-route fallback
+would hide these distinctions and prevent travelers from evaluating the route
+metrics that remain available.
+
+## Decision
+
+`BestTimeResult` retains the unique timezone-aware TCM `valid_time` for the
+recommended period as its exact recommendation timestamp and carries the named
+local timezone. Shade analysis never invents a timestamp when selected-hour
+TCM tiles disagree. The canonical trip uses `America/Chicago` only as an
+explicitly recorded fallback when environmental timezone metadata is
+unavailable.
+
+For positive solar elevation, the product may perform one shared OSM building
+acquisition and calculate modeled building shade for every returned route.
+Sufficient evidence recommends the returned route with the highest modeled
+building-shade percentage, breaking ties by distance and then stable route
+identity. A single sufficiently evidenced route is recommended as the only
+returned route with limited-comparison wording.
+
+For solar elevation at or below the horizon, building shade is zero and not
+applicable. The product performs no OSM building acquisition and recommends the
+coolest returned route from retained route TCM evidence, using distance and
+then stable identity only to break equal-temperature ties.
+
+Weak or uncomputable daytime shade evidence preserves every valid returned
+alternative and all available distance, TCM, coverage, and partial-shade
+metrics, but produces no recommendation. The traveler-facing UI owns the
+trade-off presentation. This deliberately replaces issue #19's original
+shortest-route fallback and the legacy `RouteComparator` prototype rule.
+
+## Consequences
+
+- Exact temporal evidence becomes part of the best-time and route contracts.
+- Shade confidence has `sufficient`, `insufficient`, and `not_applicable`
+  states; nighttime is not represented as missing data.
+- Final route states distinguish shadiest, only-route, nighttime-coolest, and
+  insufficient-comparison outcomes.
+- OSM acquisition, cache, fixtures, and building-height quality affect daytime
+  confidence without erasing partial evidence.
+- Issue #20 can present unresolved route trade-offs without reverse-engineering
+  them from missing recommendation fields.

--- a/docs/design/issue-19-implementation-plan.md
+++ b/docs/design/issue-19-implementation-plan.md
@@ -203,9 +203,12 @@ fixture to explicit unavailability. Identity includes:
 - route-shade model version where it affects requested data.
 
 Cache and fixture replay remain stale and retain the true OSM data date. Add a
-canonical provider-shape building fixture and acquisition sidecar. Synthesized
-geometry used for focused tests stays in test fixtures and is labelled
-synthesized.
+canonical provider-shape building fixture and acquisition sidecar. The committed
+canonical building fixture is synthesized to the provider's response shape, not
+captured from a live Overpass execution; its acquisition sidecar records
+`source: "synthesized"`, a null `retrieved_at`, and the exact request identity
+it stands in for. Synthesized geometry used for focused tests stays in test
+fixtures and is labelled synthesized.
 
 Shade provenance should report source, OSM timestamp, retrieval timestamp,
 staleness, AOI/search distance, metres-per-level policy, solar timestamp and

--- a/docs/design/issue-19-implementation-plan.md
+++ b/docs/design/issue-19-implementation-plan.md
@@ -1,0 +1,423 @@
+# Issue #19 Implementation Plan: OSM Building Quality And Modeled Route Shade
+
+## Goal
+
+Complete the elevated route-heat stage from ADR 0006 with deterministic,
+exact-time modeled building shade. Preserve all returned route evidence, make
+OSM limitations explicit, recommend only when the applicable evidence supports
+a decision, and avoid all building acquisition when shade is physically
+irrelevant at night.
+
+This plan implements ADR 0007. It does not build the route-comparison UI owned
+by issue #20.
+
+## Current Baseline
+
+Issue #18 already provides:
+
+- one normalized OSRM route set with full WGS84 geometry;
+- per-route distance, duration, TCM, heat coverage, and heat source;
+- `lowest_heat_route_id` when route heat is comparable;
+- `mild_shortest_recommended` and the elevated intermediate `shade_required`;
+- separate routing and heat provenance;
+- Shapely and pyproj geometry foundations;
+- a bounded Overpass transport, cache service, and acquisition-sidecar model.
+
+The remaining gaps are:
+
+- `BestTimeResult` discards exact TCM `valid_time` and retains only an hour;
+- the Overpass client is specialized for hotel queries;
+- modeled-shade response fields are placeholders without backend evidence;
+- explicit final shade/nighttime/insufficient-comparison states do not exist;
+- the legacy `RouteComparator` still encodes the rejected weak-coverage
+  shortest fallback.
+
+## Settled Behavior
+
+1. Preserve the exact timezone-aware TCM timestamp selected by best-time
+   analysis and the named local timezone. Never manufacture precision when
+   selected-hour timestamps disagree.
+2. At solar elevation `<= 0`, perform no Overpass request, report building shade
+   as `0%` and `not_applicable`, and recommend the coolest returned route.
+   Distance and stable identity are tie-breakers only among equal TCM values.
+3. At positive solar elevation, make one shared Overpass request for all
+   returned routes, requesting both `building` and `building:part` geometry.
+4. The shared building AOI uses a configurable 250 m route buffer. The boundary
+   and its omitted-beyond-boundary limitation are visible in provenance.
+5. Valid explicit OSM `height` wins over valid `building:levels * 3 m`; otherwise
+   height is unknown. Explicit, inferred, and unknown quality remain visible.
+6. Building parts replace overlapping parent geometry; uncovered parent area
+   retains the parent's own height quality.
+7. Each route's building-height coverage is the area-weighted known-height
+   fraction within its analysis corridor. No mapped footprints means zero
+   coverage. The configurable sufficiency default is `0.70`.
+8. A daytime comparison is sufficient only when every compared route meets the
+   threshold, solar/time evidence is valid, and no potentially relevant OSM
+   building geometry was dropped.
+9. Sufficient alternatives recommend the highest modeled building-shade
+   percentage, then shorter distance, then stable route identity.
+10. One sufficiently evidenced route is recommended as the only returned route
+    with limited-comparison wording.
+11. Weak or uncomputable daytime evidence retains every route and every
+    available metric, leaves `recommended_id` null, and explicitly delegates
+    comparison to the traveler.
+12. Modeled shade is always labelled as an OSM-based estimate, never measured
+    shade, and explicitly excludes trees, awnings, clouds, and temporary
+    obstructions.
+
+## Phase 1: Preserve Exact Recommendation Time
+
+### Contract changes
+
+Extend the best-time contract with typed temporal evidence rather than deriving
+an instant later from `date + hour`:
+
+- timezone-aware `recommendation_time`, serialized as ISO 8601;
+- `recommendation_timezone`, preserving the IANA zone name;
+- an explicit temporal-evidence state for exact, inconsistent, or unavailable
+  evidence so a best-time result can survive while shade becomes insufficient.
+
+The exact state requires a timestamp and named zone. Inconsistent/unavailable
+states carry no invented timestamp and include a limitation in provenance.
+
+### Temporal orchestration
+
+When selecting the best hour:
+
+1. Gather all TCM tiles contributing to that hour.
+2. Require one unique `valid_time` instant across those tiles.
+3. Prefer the env-params series timezone when available.
+4. Validate the timestamp's local date, hour, and UTC offset against that IANA
+   zone and the trip setup.
+5. For the curated TCM-only fallback, use `America/Chicago` as an explicit
+   timezone-resolution transformation and validate its offset against the TCM
+   timestamp.
+6. Preserve disagreement as temporal evidence failure; do not fail the complete
+   best-time or route-heat result.
+
+Update fixture normalization so fixture and live paths expose the same exact
+contract. Existing fixtures must gain truthful timestamps and timezone names.
+
+## Phase 2: Building And Shade Domain Model
+
+Create a provider-neutral shade module, likely `app/domain/route_shade.py`, with
+validated immutable types for:
+
+- `BuildingHeightQuality`: `explicit`, `inferred_levels`, `unknown`;
+- normalized building identity, footprint, effective geometry, height, and
+  height quality;
+- `ShadeConfidence`: `sufficient`, `insufficient`, `not_applicable`;
+- solar position with north-referenced clockwise azimuth and horizon-referenced
+  elevation;
+- per-route shade evidence, including modeled percentage, building-height
+  coverage, quality area fractions, footprint counts, and dropped geometry;
+- route-set shade evidence and limitations.
+
+### Height parsing
+
+Implement one strict parser for common OSM forms:
+
+- plain numeric values are metres;
+- metre suffixes such as `12 m`;
+- feet values such as `40 ft`;
+- feet/inches notation such as `10'6"`;
+- positive finite values only;
+- semicolon lists, ranges, malformed text, zero, and negatives are invalid.
+
+Use a valid explicit `height` first. If it is absent or invalid, use positive
+finite `building:levels * 3.0`. Otherwise classify the footprint as unknown.
+Keep the 3 m approximation in configuration/provenance and never label it as an
+explicit OSM height.
+
+### Parent and part geometry
+
+Normalize building and `building:part` objects independently, preserving OSM
+identity. For overlapping geometry:
+
+1. partition each parent by the union of its parts;
+2. use each part's own height classification over its footprint;
+3. retain the parent's classification only on uncovered parent geometry;
+4. do not inherit parent height into a part;
+5. avoid double-counting area, coverage, or shadows.
+
+Invalid or empty polygonal geometry is dropped and counted. If its bounds or
+membership make it potentially relevant to a route corridor, that route's
+confidence is forced insufficient. If relevance cannot be localized, apply the
+limitation to the whole returned route set.
+
+## Phase 3: Solar And Shadow Geometry
+
+Add and pin Astral as the solar-position implementation. Wrap it behind a small
+pure domain-facing adapter so provider conventions and test vectors remain
+owned by this repository.
+
+For the exact recommendation instant and route-set centroid:
+
+- calculate azimuth clockwise from true north;
+- calculate elevation from the horizon;
+- validate finite values and normalize azimuth to `[0, 360)`;
+- classify elevation `<= 0` as nighttime before any OSM acquisition.
+
+For positive elevation, project routes and footprints to the existing local UTM
+CRS. For each known-height effective footprint:
+
+1. compute shadow length as `height / tan(elevation)`;
+2. cast opposite the solar azimuth;
+3. construct the geometric sweep from the footprint to its translated copy;
+4. union all sweeps;
+5. subtract occupied building footprints;
+6. intersect the shadow union with each route LineString;
+7. divide covered route length by total projected route length and report a
+   percentage in `[0, 100]`.
+
+Use structured Shapely operations for the polygonal sweep; do not approximate
+coverage with point sampling. Union overlapping shadows before route
+intersection so route length is never counted twice.
+
+## Phase 4: Shared OSM Building Acquisition
+
+### Query boundary
+
+Generalize the Overpass client to execute bounded typed queries, or add a
+building-specific client over the existing transport. Keep hotel normalization
+separate.
+
+Build one deterministic query over the shared 250 m buffered route AOI:
+
+- select ways and relations tagged `building`;
+- select ways and relations tagged `building:part`;
+- request tags, identities, relation membership, and full geometry;
+- preserve `osm3s.timestamp_osm_base` as the OSM data date;
+- make exactly one provider execution for the complete returned route set.
+
+### Cache, fixture, and provenance
+
+Create a building execution service with live to exact cache to matching
+fixture to explicit unavailability. Identity includes:
+
+- Overpass endpoint/provider instance;
+- canonical shared AOI;
+- complete query options and selected tags;
+- schema version;
+- provider configuration version;
+- route-shade model version where it affects requested data.
+
+Cache and fixture replay remain stale and retain the true OSM data date. Add a
+canonical provider-shape building fixture and acquisition sidecar. Synthesized
+geometry used for focused tests stays in test fixtures and is labelled
+synthesized.
+
+Shade provenance should report source, OSM timestamp, retrieval timestamp,
+staleness, AOI/search distance, metres-per-level policy, solar timestamp and
+position, model version, counts by height quality, dropped geometry, coverage,
+and model limitations.
+
+## Phase 5: Coverage And Confidence
+
+For each route, intersect effective footprints with its projected 250 m
+analysis corridor. Calculate area by quality after parent/part partitioning:
+
+- `explicit_fraction = explicit_area / total_relevant_area`;
+- `inferred_levels_fraction = inferred_area / total_relevant_area`;
+- `unknown_fraction = unknown_area / total_relevant_area`;
+- `building_coverage = explicit_fraction + inferred_levels_fraction`.
+
+When total relevant area is zero, all known fractions and coverage are zero.
+Percentages and counts remain visible even when confidence is insufficient.
+
+`ShadeConfidence.SUFFICIENT` requires:
+
+- exact validated recommendation time and named timezone;
+- positive solar elevation;
+- successful provider/cache/fixture normalization;
+- no potentially relevant dropped building geometry;
+- every route's building-height coverage at or above the configured threshold;
+- finite modeled shade for every route.
+
+`INSUFFICIENT` applies to weak or uncomputable daytime evidence.
+`NOT_APPLICABLE` applies only to nighttime, with zero building shade and no
+building acquisition.
+
+## Phase 6: Route Decisions And Contracts
+
+Extend `RouteDecisionState` with:
+
+- `shade_shadiest_recommended`;
+- `shade_only_route_recommended`;
+- `nighttime_coolest_recommended`;
+- `insufficient_shade_comparison_required`.
+
+Extend route results with typed shade confidence, detailed height-quality
+coverage, building and solar provenance, and limitations. Keep distance, TCM,
+heat coverage, heat source, full geometry, and partial modeled shade available
+in insufficient states.
+
+Decision order after issue #18's route heat gate:
+
+1. Mild heat remains `mild_shortest_recommended`; do no solar or OSM work.
+2. Elevated heat with missing comparable TCM retains the existing heat
+   unavailable/no-suitable behavior; shade cannot repair missing heat evidence.
+3. Resolve exact solar position.
+4. At night, set every route to `0%`/`not_applicable`, recommend minimum TCM,
+   and break ties by distance then identity.
+5. In daytime, acquire and model all returned routes once.
+6. If every route is sufficient, recommend maximum shade, then distance, then
+   identity. Use the only-route state when applicable.
+7. Otherwise leave `recommended_id` null and use
+   `insufficient_shade_comparison_required`.
+
+Update contract invariants so final recommendation states require exactly one
+matching recommended option, while insufficient comparison requires none.
+Remove or rewrite the legacy `RouteComparator` shortest fallback so there is
+one authoritative decision policy.
+
+## Phase 7: Service Integration And Settings
+
+Add a `RouteShadeAnalysisService` between route heat evidence and final route
+decisioning. Keep pure solar, geometry, coverage, and recommendation functions
+outside provider orchestration.
+
+Extend settings with a focused shade configuration:
+
+- building search/analysis distance, default `250.0` m;
+- minimum building-height coverage, default `0.70`;
+- inferred metres per level, default `3.0`;
+- canonical trip timezone, `America/Chicago`;
+- building schema/provider configuration versions;
+- shade model version.
+
+Reuse Overpass endpoint, User-Agent, timeout, and bounded retry policy. Validate
+all numeric ranges and the IANA timezone at startup.
+
+Inject shade analysis into `RouteAnalysisService` after elevated heat is known.
+Nighttime must bypass the building loader entirely. Building failures become an
+insufficient shade comparison, not loss of the already valid route section.
+
+Update trip degradation rules:
+
+- sufficient shadiest and nighttime decisions are final route results;
+- a single-route recommendation remains degraded only for limited comparison;
+- insufficient shade comparison keeps the route section and adds a route
+  degradation reason;
+- no forced fallback recommendation is introduced.
+
+## Phase 8: Offline Test Strategy
+
+### Exact-time tests
+
+- preserve offset-aware selected TCM time;
+- preserve and validate `America/Chicago` across standard and daylight time;
+- reject inconsistent selected-hour tile instants without losing best-time;
+- reject local date/hour or zone-offset mismatch for shade purposes;
+- serialize fixture and live timestamps identically.
+
+### Height and geometry tests
+
+- explicit height precedence over levels;
+- valid metres, feet, and feet/inches parsing;
+- malformed explicit height falling back to valid levels;
+- invalid levels producing unknown quality;
+- exact `3 m/level` inference and provenance;
+- building parts replacing parent overlap;
+- no duplicated parent/part area or shadow;
+- malformed geometry retained as a confidence limitation.
+
+### Solar and shadow tests
+
+- representative San Antonio summer-noon and winter cases;
+- morning/evening azimuth direction;
+- positive, zero, and negative solar elevation boundaries;
+- a known-height footprint casting the expected cardinal-direction shadow;
+- route fully shaded, partially shaded, and unshaded cases;
+- overlapping shadows not double-counting route length;
+- building footprints excluded from shade length.
+
+### Coverage and decisions
+
+- explicit/inferred/unknown area fractions sum correctly;
+- no buildings produces zero coverage;
+- `0.70` boundary is sufficient and just below it is insufficient;
+- any route with weak coverage blocks a comparison recommendation;
+- partial evidence remains visible in insufficient results;
+- sufficient alternatives recommend shadiest with deterministic ties;
+- sufficient single route uses `shade_only_route_recommended`;
+- weak single route has no recommendation;
+- nighttime recommends coolest and uses distance only for equal-TCM ties;
+- nighttime makes zero Overpass calls;
+- mild heat makes zero solar and Overpass calls.
+
+### Acquisition and integration
+
+- exactly one shared Overpass request for elevated daytime alternatives;
+- query includes `building` and `building:part` full geometry;
+- every cache identity field changes the key;
+- live, cache, fixture, and exhausted degradation paths are truthful;
+- stale fixture/cache evidence remains visible;
+- dropped geometry and provider failure yield no forced recommendation;
+- route, heat, building, and solar provenance remain distinct;
+- frontend type checks and fixtures accept all new states for issue #20.
+
+## Phase 9: Documentation And Issue Alignment
+
+- Amend issue #19 to replace the weak-coverage shortest fallback with explicit
+  no-recommendation comparison behavior and add exact-time/nighttime criteria.
+- Keep `CONTEXT.md` synchronized with the accepted domain terms.
+- Add ADR 0007 for exact-time, nighttime, and insufficient-evidence decisions.
+- Document Astral, shade settings, Overpass building fixtures, and model
+  limitations in README/design documentation.
+- Update fixture inventory and acquisition records.
+- Point issue #20 at the four final shade decision states and the detailed
+  evidence it must present.
+
+## Planned File Map
+
+New files:
+
+- `app/domain/route_shade.py`
+- `app/integrations/overpass/buildings.py` or equivalent typed query module
+- `app/services/building_execution.py`
+- `app/services/route_shade_analysis.py`
+- `tests/test_building_heights.py`
+- `tests/test_route_shade.py`
+- `tests/test_building_execution.py`
+- canonical building fixture and acquisition sidecar under `fixtures/`
+
+Primary modified files:
+
+- `app/domain/contracts.py`
+- `app/domain/route_decision.py`
+- `app/domain/trip.py` to remove or align the legacy comparator
+- `app/services/route_analysis.py`
+- `app/services/trip_adapters.py`
+- `app/integrations/overpass/client.py`
+- `app/settings.py`
+- `app/wiring.py`
+- `pyproject.toml` and lock data
+- fixture/API/orchestration tests
+- `frontend/src/types.ts` and response guards
+- README and relevant design documentation
+
+## Implementation Order
+
+1. Add failing exact-time contract and temporal orchestration tests.
+2. Preserve exact recommendation time and timezone through live and fixture
+   paths.
+3. Add failing height normalization, parent/part, coverage, and shadow tests.
+4. Implement pure building-height, solar, shadow, and coverage domain logic.
+5. Add Overpass building query, normalization, exact degradation, and fixtures.
+6. Add final decision states and prove nighttime/weak/single-route behavior.
+7. Integrate shade analysis after the elevated heat gate and prove call counts.
+8. Update API fixtures and frontend compatibility types.
+9. Run focused tests, then the complete backend and frontend verification suite.
+10. Finish configuration, fixture, model-limitation, and issue documentation.
+
+## Completion Criteria
+
+Issue #19 is complete when exact temporal evidence reaches solar calculations;
+elevated daytime routes receive deterministic OSM building-shade estimates and
+height-quality coverage; sufficient evidence recommends the shadiest returned
+route; nighttime performs no building acquisition and recommends the coolest
+returned route; weak daytime evidence preserves every available route metric
+without a recommendation; all provider, geometry, confidence, provenance, and
+call-count behavior is proven offline; and no result presents modeled shade as
+measured real-world shade.

--- a/fixtures/acquired/overpass-buildings-canonical.acquisition.json
+++ b/fixtures/acquired/overpass-buildings-canonical.acquisition.json
@@ -1,0 +1,28 @@
+{
+  "source": "synthesized",
+  "endpoint": "https://overpass-api.de/api/interpreter",
+  "request_configuration": {
+    "aoi": {
+      "south": 29.422322896,
+      "west": -98.489017329,
+      "north": 29.428101444,
+      "east": -98.483244313
+    },
+    "search_distance_m": 250.0,
+    "query_options": {
+      "response_format": "json",
+      "timeout_seconds": 60,
+      "output": "body geom",
+      "object_types": ["way", "relation"],
+      "selected_tags": ["building", "building:part"]
+    },
+    "model_version": "route-shade-v1"
+  },
+  "retrieved_at": null,
+  "data_date": "2026-08-29",
+  "status": "ok",
+  "schema_version": "building-v1",
+  "provider_config_version": "overpass-building-config-v1",
+  "activity_id": null,
+  "transformations": []
+}

--- a/fixtures/acquired/overpass-buildings-canonical.json
+++ b/fixtures/acquired/overpass-buildings-canonical.json
@@ -1,0 +1,196 @@
+{
+  "version": 0.6,
+  "generator": "synthesized-overpass-building-shape",
+  "note": "Synthesized canonical Overpass building response shape for the canonical OSRM route AOI. Geometry, identities, and tags are invented, not real OpenStreetMap data.",
+  "osm3s": {
+    "timestamp_osm_base": "2026-08-29T20:14:03Z",
+    "copyright": "synthesized fixture; no OpenStreetMap data is reproduced"
+  },
+  "elements": [
+    {
+      "type": "way",
+      "id": 101,
+      "tags": {
+        "building": "office",
+        "height": "34",
+        "name": "Corridor Office Block"
+      },
+      "geometry": [
+        {
+          "lat": 29.4245639,
+          "lon": -98.4858495
+        },
+        {
+          "lat": 29.4249457,
+          "lon": -98.4856662
+        },
+        {
+          "lat": 29.4250778,
+          "lon": -98.4860277
+        },
+        {
+          "lat": 29.424696,
+          "lon": -98.486211
+        },
+        {
+          "lat": 29.4245639,
+          "lon": -98.4858495
+        }
+      ]
+    },
+    {
+      "type": "way",
+      "id": 102,
+      "tags": {
+        "building": "commercial",
+        "building:levels": "9"
+      },
+      "geometry": [
+        {
+          "lat": 29.4251373,
+          "lon": -98.4856078
+        },
+        {
+          "lat": 29.4254859,
+          "lon": -98.4854404
+        },
+        {
+          "lat": 29.4256041,
+          "lon": -98.4857639
+        },
+        {
+          "lat": 29.4252555,
+          "lon": -98.4859312
+        },
+        {
+          "lat": 29.4251373,
+          "lon": -98.4856078
+        }
+      ]
+    },
+    {
+      "type": "way",
+      "id": 103,
+      "tags": {
+        "building": "yes"
+      },
+      "geometry": [
+        {
+          "lat": 29.4249551,
+          "lon": -98.4864668
+        },
+        {
+          "lat": 29.4252041,
+          "lon": -98.4863473
+        },
+        {
+          "lat": 29.4252944,
+          "lon": -98.4865946
+        },
+        {
+          "lat": 29.4250455,
+          "lon": -98.4867141
+        },
+        {
+          "lat": 29.4249551,
+          "lon": -98.4864668
+        }
+      ]
+    },
+    {
+      "type": "relation",
+      "id": 104,
+      "tags": {
+        "type": "multipolygon",
+        "building": "hotel",
+        "height": "48"
+      },
+      "members": [
+        {
+          "type": "way",
+          "ref": 1041,
+          "role": "outer",
+          "geometry": [
+            {
+              "lat": 29.4253335,
+              "lon": -98.4862516
+            },
+            {
+              "lat": 29.4257982,
+              "lon": -98.4860285
+            },
+            {
+              "lat": 29.4259512,
+              "lon": -98.486447
+            },
+            {
+              "lat": 29.4254864,
+              "lon": -98.4866702
+            },
+            {
+              "lat": 29.4253335,
+              "lon": -98.4862516
+            }
+          ]
+        },
+        {
+          "type": "way",
+          "ref": 1042,
+          "role": "inner",
+          "geometry": [
+            {
+              "lat": 29.4255433,
+              "lon": -98.4863186
+            },
+            {
+              "lat": 29.4256927,
+              "lon": -98.4862469
+            },
+            {
+              "lat": 29.4257414,
+              "lon": -98.48638
+            },
+            {
+              "lat": 29.425592,
+              "lon": -98.4864518
+            },
+            {
+              "lat": 29.4255433,
+              "lon": -98.4863186
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "way",
+      "id": 105,
+      "tags": {
+        "building:part": "yes",
+        "height": "72"
+      },
+      "geometry": [
+        {
+          "lat": 29.4247065,
+          "lon": -98.4858928
+        },
+        {
+          "lat": 29.4248725,
+          "lon": -98.4858132
+        },
+        {
+          "lat": 29.4249351,
+          "lon": -98.4859844
+        },
+        {
+          "lat": 29.4247691,
+          "lon": -98.4860641
+        },
+        {
+          "lat": 29.4247065,
+          "lon": -98.4858928
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/src/screens/TripSetupScreen.tsx
+++ b/frontend/src/screens/TripSetupScreen.tsx
@@ -1,4 +1,11 @@
-import { AlertTriangle, CheckCircle2, Database, Radio } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Database,
+  MapPinned,
+  Radio,
+  Sun,
+} from "lucide-react";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useAppState } from "../app/AppState";
 import { dataClient } from "../services/dataClient";
@@ -6,6 +13,7 @@ import type {
   BestTimeResult,
   ExecutionMode,
   HeatInterpretation,
+  RouteComparisonResult,
   TripAnalysisRequest,
 } from "../types";
 
@@ -143,6 +151,143 @@ function BestTimeSummary({ result }: { result: BestTimeResult }) {
           </table>
         </div>
       )}
+    </section>
+  );
+}
+
+function formatPercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
+function routeDecisionHeading(result: RouteComparisonResult) {
+  switch (result.decision_state) {
+    case "shade_shadiest_recommended":
+      return "Shadiest route recommended";
+    case "shade_only_route_recommended":
+      return "Only route recommended";
+    case "nighttime_coolest_recommended":
+      return "Coolest nighttime route recommended";
+    case "mild_shortest_recommended":
+      return "Shortest route recommended";
+    case "insufficient_shade_comparison_required":
+      return "Compare route trade-offs";
+    case "shade_required":
+      return "Shade analysis required";
+    case "heat_unavailable":
+      return "Route heat unavailable";
+    default:
+      return "Walking routes";
+  }
+}
+
+function RouteComparison({ result }: { result: RouteComparisonResult }) {
+  if (result.route_set_state === "no_suitable_returned_route") {
+    return (
+      <section className="route-comparison" aria-label="Walking routes">
+        <h3>Walking routes unavailable</h3>
+        <p>{result.reason}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="route-comparison" aria-label="Walking routes">
+      <header className="route-comparison-heading">
+        <MapPinned size={22} />
+        <div>
+          <h3>{routeDecisionHeading(result)}</h3>
+          <p>{result.reason}</p>
+        </div>
+      </header>
+      {result.decision_state === "insufficient_shade_comparison_required" && (
+        <div className="route-evidence-warning">
+          <AlertTriangle size={18} />
+          <span>
+            No route is recommended because shade evidence is incomplete.
+          </span>
+        </div>
+      )}
+      <p className="shade-model-notice">
+        <Sun size={17} />
+        Modeled OSM building shade, not measured real-world shade. Trees,
+        awnings, clouds, and temporary obstructions are excluded.
+      </p>
+      <div className="route-evidence-list">
+        {result.alternatives.map((route, index) => (
+          <article
+            className={`route-evidence-row${route.recommended ? " recommended" : ""}`}
+            key={route.identity}
+          >
+            <div className="route-evidence-title">
+              <span>Route {index + 1}</span>
+              <h4>
+                {route.recommended ? "Recommended route" : "Alternative route"}
+              </h4>
+              <small>
+                {(route.distance_m / 1000).toFixed(2)} km ·{" "}
+                {Math.round(route.duration_s / 60)} min
+              </small>
+            </div>
+            <dl className="route-evidence-metrics">
+              <div>
+                <dt>Modeled shade</dt>
+                <dd>
+                  {route.modeled_shade_percent === null
+                    ? "Unavailable"
+                    : `${route.modeled_shade_percent.toFixed(0)}%`}
+                </dd>
+              </div>
+              <div>
+                <dt>Building height coverage</dt>
+                <dd>{formatPercent(route.building_coverage)}</dd>
+              </div>
+              <div>
+                <dt>Shade confidence</dt>
+                <dd>
+                  {route.shade_confidence?.replaceAll("_", " ") ??
+                    "Unavailable"}
+                </dd>
+              </div>
+              <div>
+                <dt>Route heat</dt>
+                <dd>
+                  {route.heat_value === null
+                    ? "Unavailable"
+                    : `${route.heat_value.toFixed(1)} °C`}
+                </dd>
+              </div>
+            </dl>
+            <div
+              className="building-quality"
+              aria-label="Building height quality"
+            >
+              <span>
+                Explicit {formatPercent(route.building_explicit_fraction)}
+              </span>
+              <span>
+                Inferred{" "}
+                {formatPercent(route.building_inferred_levels_fraction)}
+              </span>
+              <span>
+                Unknown {formatPercent(route.building_unknown_fraction)}
+              </span>
+            </div>
+            {route.recommendation_reason && (
+              <p>{route.recommendation_reason}</p>
+            )}
+            {route.shade_limitations.length > 0 && (
+              <ul
+                className="route-limitations"
+                aria-label="Shade model limitations"
+              >
+                {route.shade_limitations.map((limitation) => (
+                  <li key={limitation}>{limitation}</li>
+                ))}
+              </ul>
+            )}
+          </article>
+        ))}
+      </div>
     </section>
   );
 }
@@ -566,6 +711,11 @@ export function TripSetupScreen() {
                     value={tripAnalysis.best_time.heat_interpretation}
                   />
                 </>
+              )}
+            {(tripAnalysis.state === "success" ||
+              tripAnalysis.state === "degraded") &&
+              tripAnalysis.routes && (
+                <RouteComparison result={tripAnalysis.routes} />
               )}
             <button
               type="button"

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -179,6 +179,19 @@ function validHeatInterpretation(value: unknown) {
   );
 }
 
+function isNonNegativeInteger(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isUnitFraction(value: unknown) {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= 1
+  );
+}
+
 function validRouteGeometry(value: unknown) {
   return (
     Array.isArray(value) &&
@@ -208,6 +221,10 @@ function validExplicitRoutes(value: Record<string, unknown>) {
   const decisionStates = [
     "mild_shortest_recommended",
     "shade_required",
+    "shade_shadiest_recommended",
+    "shade_only_route_recommended",
+    "nighttime_coolest_recommended",
+    "insufficient_shade_comparison_required",
     "heat_unavailable",
     "no_suitable_returned_route",
   ];
@@ -242,6 +259,18 @@ function validExplicitRoutes(value: Record<string, unknown>) {
       typeof route.identity === "string" &&
       typeof route.distance_m === "number" &&
       typeof route.duration_s === "number" &&
+      isUnitFraction(route.building_coverage) &&
+      isUnitFraction(route.building_explicit_fraction) &&
+      isUnitFraction(route.building_inferred_levels_fraction) &&
+      isUnitFraction(route.building_unknown_fraction) &&
+      isNonNegativeInteger(route.building_explicit_count) &&
+      isNonNegativeInteger(route.building_inferred_levels_count) &&
+      isNonNegativeInteger(route.building_unknown_count) &&
+      isNonNegativeInteger(route.dropped_building_geometry_count) &&
+      Array.isArray(route.shade_limitations) &&
+      route.shade_limitations.every(
+        (limitation) => typeof limitation === "string" && limitation.length > 0
+      ) &&
       typeof route.recommended === "boolean" &&
       (heatUnavailable
         ? route.heat_value === null && route.heat_interpretation === null
@@ -254,11 +283,25 @@ function validExplicitRoutes(value: Record<string, unknown>) {
   const recommended = value.alternatives.filter(
     (route) => isObject(route) && route.recommended === true
   );
+  const finalDecisionStates = [
+    "shade_shadiest_recommended",
+    "shade_only_route_recommended",
+    "nighttime_coolest_recommended",
+  ];
+  const noRecommendationStates = [
+    "shade_required",
+    "insufficient_shade_comparison_required",
+    "heat_unavailable",
+    "no_suitable_returned_route",
+  ];
   return (
     alternativesValid &&
-    (value.decision_state === "mild_shortest_recommended"
+    (value.decision_state === "mild_shortest_recommended" ||
+    finalDecisionStates.includes(String(value.decision_state))
       ? typeof value.recommended_id === "string" && recommended.length === 1
-      : value.recommended_id === null && recommended.length === 0)
+      : noRecommendationStates.includes(String(value.decision_state))
+        ? value.recommended_id === null && recommended.length === 0
+        : false)
   );
 }
 
@@ -296,6 +339,19 @@ function validBestTime(value: unknown) {
     typeof value.hourly_coverage !== "number" ||
     typeof value.recommendation_hour !== "number" ||
     typeof value.recommendation_reason !== "string" ||
+    !["exact", "inconsistent", "unavailable"].includes(
+      String(value.temporal_evidence)
+    ) ||
+    !(
+      value.recommendation_time === null ||
+      (typeof value.recommendation_time === "string" &&
+        !Number.isNaN(Date.parse(value.recommendation_time)))
+    ) ||
+    !(
+      value.recommendation_timezone === null ||
+      (typeof value.recommendation_timezone === "string" &&
+        value.recommendation_timezone.length > 0)
+    ) ||
     !(
       value.recommended_hour_tcm_celsius === null ||
       typeof value.recommended_hour_tcm_celsius === "number"
@@ -379,6 +435,7 @@ function isTripAnalysisResponse(
       (value.routes.confidence === "insufficient" ||
         [
           "shade_required",
+          "insufficient_shade_comparison_required",
           "heat_unavailable",
           "no_suitable_returned_route",
         ].includes(String(value.routes.decision_state)) ||

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -212,6 +212,27 @@ function validRouteGeometry(value: unknown) {
   );
 }
 
+function validShadeProvenance(value: Record<string, unknown>) {
+  const building = value.building_provenance ?? null;
+  const solar = value.solar_provenance ?? null;
+  if (building !== null && !isObject(building)) return false;
+  if (solar !== null && !isObject(solar)) return false;
+  // Buildings are only ever acquired against a resolved solar position.
+  if (building !== null && solar === null) return false;
+  const modeledShadeStates = [
+    "shade_shadiest_recommended",
+    "shade_only_route_recommended",
+  ];
+  if (modeledShadeStates.includes(String(value.decision_state))) {
+    return building !== null;
+  }
+  // Night needs the sun's position to justify itself, and acquires no buildings.
+  if (value.decision_state === "nighttime_coolest_recommended") {
+    return solar !== null && building === null;
+  }
+  return true;
+}
+
 function validExplicitRoutes(value: Record<string, unknown>) {
   const routeSetStates = [
     "alternatives_returned",
@@ -232,7 +253,8 @@ function validExplicitRoutes(value: Record<string, unknown>) {
     !routeSetStates.includes(String(value.route_set_state)) ||
     !decisionStates.includes(String(value.decision_state)) ||
     !Array.isArray(value.alternatives) ||
-    !isObject(value.routing_provenance)
+    !isObject(value.routing_provenance) ||
+    !validShadeProvenance(value)
   ) {
     return false;
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -938,6 +938,130 @@ dd {
 .setup-outcome button {
   min-height: 44px;
 }
+.route-comparison {
+  display: grid;
+  gap: 14px;
+  margin-top: 26px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
+}
+.route-comparison h3 {
+  margin: 0;
+}
+.route-comparison-heading {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.route-comparison-heading svg {
+  flex: none;
+  color: var(--accent);
+  margin-top: 3px;
+}
+.route-comparison-heading p {
+  margin: 4px 0 0;
+}
+.route-evidence-warning {
+  display: flex;
+  gap: 9px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 700;
+}
+.shade-model-notice {
+  display: flex;
+  gap: 9px;
+  align-items: flex-start;
+  margin: 0;
+  padding: 12px 14px;
+  background: #fff3d9;
+  color: #684c1b;
+  font-size: 13px;
+}
+.shade-model-notice svg {
+  flex: none;
+  margin-top: 2px;
+}
+.route-evidence-list {
+  display: grid;
+  gap: 11px;
+}
+.route-evidence-row {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  background: #f8faf7;
+}
+.route-evidence-row.recommended {
+  border: 2px solid #287158;
+  background: #eef5f0;
+}
+.route-evidence-title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  align-items: baseline;
+}
+.route-evidence-title span {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.route-evidence-title h4 {
+  margin: 0;
+  font-size: 16px;
+}
+.route-evidence-title small {
+  color: var(--muted);
+}
+.route-evidence-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+.route-evidence-metrics div {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+  padding: 11px 12px;
+  background: #fffdf8;
+}
+.route-evidence-metrics dt {
+  font-size: 10px;
+}
+.route-evidence-metrics dd {
+  margin: 0;
+}
+.building-quality {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.building-quality span {
+  padding: 5px 9px;
+  background: #edf2eb;
+  color: var(--ink);
+  font-size: 12px;
+}
+.route-evidence-row p {
+  margin: 0;
+  font-size: 13px;
+}
+.route-limitations {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 12px;
+}
 .dev-panel {
   position: fixed;
   right: 14px;
@@ -1034,6 +1158,9 @@ dd {
   }
   .series-summary {
     grid-template-columns: minmax(0, 1fr);
+  }
+  .route-evidence-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
   .setup-card > button,
   .setup-outcome button,

--- a/frontend/src/test/tripSetup.test.tsx
+++ b/frontend/src/test/tripSetup.test.tsx
@@ -26,6 +26,9 @@ const successResponse = {
     persistence_hours: 2,
     framing_threshold_celsius: 35,
     framing_direction: "above",
+    recommendation_time: "2026-08-23T09:00:00-05:00",
+    recommendation_timezone: "America/Chicago",
+    temporal_evidence: "exact",
     environmental_concerns: [],
     provenance: {
       source: "fixture",

--- a/frontend/src/test/tripSetup.test.tsx
+++ b/frontend/src/test/tripSetup.test.tsx
@@ -79,6 +79,200 @@ const successResponse = {
   degraded_reasons: null,
 };
 
+const routesProvenance = {
+  source: "fixture",
+  data_date: "2026-08-23",
+  confidence: "sufficient",
+  retrieved_at: "2026-08-24T00:00:00Z",
+  transformation_version: "osrm-route-normalization-v1",
+  provider: "osrm",
+  response_status: "completed",
+  request_configuration: {},
+  fresh: true,
+  coverage: 1,
+  note: null,
+  activity_id: null,
+};
+
+const solarProvenance = {
+  source: "astral",
+  data_date: "2026-08-23",
+  confidence: "sufficient",
+  retrieved_at: "2026-08-24T00:00:00Z",
+  transformation_version: "solar-position-v1",
+  provider: "astral",
+  response_status: "completed",
+  request_configuration: {},
+  fresh: true,
+  coverage: null,
+  note: null,
+  activity_id: null,
+};
+
+const buildingProvenance = {
+  source: "fixture",
+  data_date: "2026-08-29",
+  confidence: "sufficient",
+  retrieved_at: "2026-08-24T00:00:00Z",
+  transformation_version: "building-v1",
+  provider: "overpass",
+  response_status: "completed",
+  request_configuration: {},
+  fresh: false,
+  coverage: 1,
+  note: null,
+  activity_id: null,
+};
+
+const routeOption = (
+  identity: string,
+  {
+    distance = 900,
+    duration = 720,
+    heatValue = 38,
+    shadePercent = 60,
+    shadeConfidence = "sufficient",
+    buildingCoverage = 0.8,
+    explicitFraction = 0.6,
+    inferredFraction = 0.2,
+    unknownFraction = 0.2,
+    recommended = false,
+    recommendationReason = null,
+    limitations = [],
+  }: {
+    distance?: number;
+    duration?: number;
+    heatValue?: number;
+    shadePercent?: number;
+    shadeConfidence?: "sufficient" | "insufficient" | "not_applicable";
+    buildingCoverage?: number;
+    explicitFraction?: number;
+    inferredFraction?: number;
+    unknownFraction?: number;
+    recommended?: boolean;
+    recommendationReason?: string | null;
+    limitations?: string[];
+  } = {}
+) => ({
+  identity,
+  distance_m: distance,
+  duration_s: duration,
+  geometry: [
+    [-98.49, 29.42],
+    [-98.48, 29.43],
+  ],
+  heat_value: heatValue,
+  heat_unit: "C",
+  heat_metric: "tcm",
+  heat_status: "elevated",
+  heat_coverage: 1,
+  heat_source: "shared_corridor",
+  heat_interpretation: {
+    metric: "tcm",
+    value_celsius: heatValue,
+    band: "provider_higher",
+    band_label: "Higher provider temperature",
+    action_threshold_band: "provider_higher",
+    guidance_policy: "standard",
+    is_actual_heat_index: false,
+    noaa_heat_index_available: false,
+    action_required: true,
+    policy_applied: "standard_heat_guidance",
+  },
+  modeled_shade_percent: shadePercent,
+  shade_confidence: shadeConfidence,
+  building_coverage: buildingCoverage,
+  building_explicit_fraction: explicitFraction,
+  building_inferred_levels_fraction: inferredFraction,
+  building_unknown_fraction: unknownFraction,
+  building_explicit_count: 3,
+  building_inferred_levels_count: 1,
+  building_unknown_count: 1,
+  dropped_building_geometry_count: 0,
+  shade_limitations: limitations,
+  recommended,
+  recommendation_reason: recommendationReason,
+  shade_model_label:
+    "modeled OSM building-shade estimate, not measured real-world shade",
+});
+
+const shadiestRoutes = {
+  alternatives: [
+    routeOption("route-1", {
+      distance: 900,
+      shadePercent: 40,
+      recommended: false,
+    }),
+    routeOption("route-2", {
+      distance: 1200,
+      shadePercent: 75,
+      recommended: true,
+      recommendationReason: "highest modeled shade among returned routes",
+    }),
+  ],
+  recommended_id: "route-2",
+  lowest_heat_route_id: "route-1",
+  reason:
+    "highest modeled OSM building shade among returned routes is recommended",
+  heat_status: "elevated",
+  corridor_heat_value: 38,
+  heat_metric: "tcm",
+  heat_unit: "C",
+  coverage: 1,
+  confidence: "sufficient",
+  comparison_scope: "returned alternatives",
+  route_set_state: "alternatives_returned",
+  decision_state: "shade_shadiest_recommended",
+  provenance: routesProvenance,
+  routing_provenance: routesProvenance,
+  heat_provenance: routesProvenance,
+  building_provenance: buildingProvenance,
+  solar_provenance: solarProvenance,
+  fallback_reason: null,
+  heat_interpretation: {
+    metric: "tcm",
+    value_celsius: 38,
+    band: "provider_higher",
+    band_label: "Higher provider temperature",
+    action_threshold_band: "provider_higher",
+    guidance_policy: "standard",
+    is_actual_heat_index: false,
+    noaa_heat_index_available: false,
+    action_required: true,
+    policy_applied: "standard_heat_guidance",
+  },
+};
+
+const insufficientRoutes = {
+  ...shadiestRoutes,
+  recommended_id: null,
+  decision_state: "insufficient_shade_comparison_required",
+  confidence: "insufficient",
+  reason:
+    "daytime building-shade evidence is insufficient; compare returned route trade-offs",
+  fallback_reason:
+    "building-height coverage or solar evidence was insufficient",
+  alternatives: [
+    routeOption("route-1", {
+      shadePercent: 70,
+      shadeConfidence: "sufficient",
+      buildingCoverage: 0.8,
+      explicitFraction: 0.7,
+      inferredFraction: 0.1,
+      unknownFraction: 0.2,
+      limitations: ["building search is limited to 250 m around the route"],
+    }),
+    routeOption("route-2", {
+      shadePercent: 45,
+      shadeConfidence: "insufficient",
+      buildingCoverage: 0.5,
+      explicitFraction: 0.4,
+      inferredFraction: 0.1,
+      unknownFraction: 0.5,
+    }),
+  ],
+};
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -305,6 +499,90 @@ describe("curated Trip Setup", () => {
       screen.getByText("fixed temperature anchor; not a real 24-hour forecast")
     ).toBeInTheDocument();
     expect(screen.queryByText(/best time/i)).not.toBeInTheDocument();
+  });
+
+  it("presents recommended modeled route shade with quality evidence", async () => {
+    mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse({ ...successResponse, routes: shadiestRoutes })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    const comparison = await screen.findByRole("region", {
+      name: "Walking routes",
+    });
+    expect(
+      within(comparison).getByRole("heading", {
+        name: "Shadiest route recommended",
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(comparison).getByText(/highest modeled OSM building shade/)
+    ).toBeInTheDocument();
+    expect(within(comparison).getAllByText("Recommended route")).toHaveLength(
+      1
+    );
+    expect(within(comparison).getAllByText("Alternative route")).toHaveLength(
+      1
+    );
+    expect(within(comparison).getByText("75%")).toBeInTheDocument();
+    expect(within(comparison).getByText("40%")).toBeInTheDocument();
+    expect(within(comparison).getAllByText("80%")).toHaveLength(2);
+    expect(within(comparison).getAllByText("sufficient")).toHaveLength(2);
+    expect(
+      within(comparison).getByText(/Modeled OSM building shade, not measured/)
+    ).toBeInTheDocument();
+    expect(within(comparison).getAllByText(/\d+\.\d{2} km/)).toHaveLength(2);
+  });
+
+  it("presents incomplete shade comparisons without a recommendation", async () => {
+    mockFetch(
+      jsonResponse({ status: "ok", mode: "fixture" }),
+      jsonResponse({
+        ...successResponse,
+        state: "degraded",
+        routes: insufficientRoutes,
+        degraded_reasons: {
+          routes: "Route comparison requires manual trade-off review.",
+        },
+      })
+    );
+    const user = userEvent.setup();
+
+    render(<App />);
+    await screen.findByText("Fixture replay");
+    await user.click(screen.getByRole("button", { name: "Analyze trip" }));
+
+    const comparison = await screen.findByRole("region", {
+      name: "Walking routes",
+    });
+    expect(
+      within(comparison).getByRole("heading", {
+        name: "Compare route trade-offs",
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(comparison).getByText(
+        "No route is recommended because shade evidence is incomplete."
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(comparison).queryByText("Recommended route")
+    ).not.toBeInTheDocument();
+    expect(within(comparison).getByText("insufficient")).toBeInTheDocument();
+    expect(
+      within(comparison).getByText(
+        "building search is limited to 250 m around the route"
+      )
+    ).toBeInTheDocument();
+    expect(within(comparison).getByText("Explicit 70%")).toBeInTheDocument();
+    expect(within(comparison).getAllByText("Inferred 10%")).toHaveLength(2);
+    expect(within(comparison).getByText("Unknown 20%")).toBeInTheDocument();
+    expect(within(comparison).getByText("Unknown 50%")).toBeInTheDocument();
   });
 
   it("announces busy state and disables setup controls", async () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -270,6 +270,8 @@ export type RouteComparisonResult = {
   provenance: ApiProvenance;
   routing_provenance: ApiProvenance | null;
   heat_provenance: ApiProvenance | null;
+  building_provenance: ApiProvenance | null;
+  solar_provenance: ApiProvenance | null;
   fallback_reason: string | null;
   heat_interpretation: HeatInterpretation | null;
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -166,6 +166,8 @@ export type HourlyConcernProfile = {
   primary_thermal_metric: "tcm" | "heat_index_celsius";
 };
 
+export type TemporalEvidenceState = "exact" | "inconsistent" | "unavailable";
+
 export type BestTimeResult = {
   hourly: Array<{
     hour: number;
@@ -188,6 +190,9 @@ export type BestTimeResult = {
   persistence_hours: number | null;
   framing_threshold_celsius: number | null;
   framing_direction: "above" | "below" | null;
+  recommendation_time: string | null;
+  recommendation_timezone: string | null;
+  temporal_evidence: TemporalEvidenceState;
 };
 
 export type TripAnalysisRequest = {
@@ -211,6 +216,10 @@ export type RouteSetState =
 export type RouteDecisionState =
   | "mild_shortest_recommended"
   | "shade_required"
+  | "shade_shadiest_recommended"
+  | "shade_only_route_recommended"
+  | "nighttime_coolest_recommended"
+  | "insufficient_shade_comparison_required"
   | "heat_unavailable"
   | "no_suitable_returned_route";
 
@@ -229,8 +238,16 @@ export type RouteOptionResult = {
   heat_source: RouteHeatSource | null;
   heat_interpretation: HeatInterpretation | null;
   modeled_shade_percent: number | null;
-  shade_confidence: "sufficient" | "insufficient" | null;
+  shade_confidence: "sufficient" | "insufficient" | "not_applicable" | null;
   building_coverage: number;
+  building_explicit_fraction: number;
+  building_inferred_levels_fraction: number;
+  building_unknown_fraction: number;
+  building_explicit_count: number;
+  building_inferred_levels_count: number;
+  building_unknown_count: number;
+  dropped_building_geometry_count: number;
+  shade_limitations: string[];
   recommended: boolean;
   recommendation_reason: string | null;
   shade_model_label: string | null;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "heat-aware-tourism-guide"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "astral==3.2",
     "fastapi==0.141.1",
     "pyproj==3.7.2",
     "shapely==2.1.2",

--- a/tests/test_building_execution.py
+++ b/tests/test_building_execution.py
@@ -1,0 +1,265 @@
+"""Shared OSM building acquisition: exact cache, exact fixture, explicit unavailability."""
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.domain.hotels import BoundingBox
+from app.domain.provenance import AcquisitionRecord, CacheKey
+from app.domain.route_shade import ShadeConfidence, solar_position
+from app.integrations.osrm.client import normalize_response
+from app.integrations.overpass.buildings import (
+    build_building_query,
+    building_request_payload,
+    osm_source_timestamp,
+)
+from app.integrations.overpass.errors import OverpassError, OverpassRateLimited
+from app.services.building_execution import BuildingExecution, BuildingsUnavailable
+from app.services.cache import CacheService
+from app.services.route_shade import RouteShadeService, _shared_bbox
+from app.services.sidecars import write_sidecar
+
+ENDPOINT = "https://overpass.example/api/interpreter"
+AOI = BoundingBox(29.4223, -98.4890, 29.4281, -98.4832)
+OTHER_AOI = BoundingBox(29.4223, -98.4890, 29.4281, -98.4820)
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+CANONICAL_BUILDINGS = FIXTURES / "acquired" / "overpass-buildings-canonical.json"
+CANONICAL_ROUTE = FIXTURES / "acquired" / "osrm-canonical.json"
+
+
+def _response(osm_base: str = "2026-08-24T18:03:11Z") -> dict[str, Any]:
+    return {
+        "version": 0.6,
+        "osm3s": {"timestamp_osm_base": osm_base},
+        "elements": [
+            {
+                "type": "way",
+                "id": 1,
+                "tags": {"building": "yes", "height": "18"},
+                "geometry": [
+                    {"lat": 29.4250, "lon": -98.4866},
+                    {"lat": 29.4250, "lon": -98.4863},
+                    {"lat": 29.4252, "lon": -98.4863},
+                    {"lat": 29.4252, "lon": -98.4866},
+                    {"lat": 29.4250, "lon": -98.4866},
+                ],
+            }
+        ],
+    }
+
+
+def _execution(**overrides: Any) -> BuildingExecution:
+    values: dict[str, Any] = {
+        "endpoint": ENDPOINT,
+        "search_distance_m": 250.0,
+        "clock": lambda: datetime(2026, 8, 30, 9, tzinfo=timezone.utc),
+    }
+    values.update(overrides)
+    return BuildingExecution(**values)
+
+
+def _fixture(tmp_path: Path, identity: dict[str, Any], **overrides: Any) -> Path:
+    path = tmp_path / "buildings.json"
+    path.write_text(json.dumps(_response("2026-08-20T04:00:00Z")), encoding="utf-8")
+    values: dict[str, Any] = {
+        "source": "synthesized",
+        "endpoint": ENDPOINT,
+        "request_configuration": identity,
+        "retrieved_at": None,
+        "data_date": "2026-08-20",
+        "status": "ok",
+        "schema_version": "building-v1",
+        "provider_config_version": "overpass-building-config-v1",
+        "activity_id": None,
+    }
+    values.update(overrides)
+    write_sidecar(path, AcquisitionRecord(**values))
+    return path
+
+
+def test_building_query_selects_both_building_tags_for_ways_and_relations() -> None:
+    query = build_building_query(AOI)
+
+    assert query.startswith("[out:json][timeout:60];")
+    assert query.endswith("out body geom;")
+    for tag in ("building", "building:part"):
+        for object_type in ("way", "relation"):
+            assert f'{object_type}["{tag}"](29.4223,-98.489,29.4281,-98.4832);' in query
+
+
+def test_live_success_caches_under_the_complete_request_identity() -> None:
+    cache = CacheService()
+    execution = _execution(live_loader=lambda aoi: _response(), cache=cache)
+
+    outcome = execution.run(AOI)
+
+    assert (outcome.source, outcome.stale) == ("provider", False)
+    assert outcome.data_date == "2026-08-24"
+    assert outcome.retrieved_at == datetime(2026, 8, 30, 9, tzinfo=timezone.utc)
+    key = CacheKey.create(
+        ENDPOINT, "building-v1", execution.identity(AOI), "overpass-building-config-v1"
+    )
+    assert cache.get(key) is not None
+
+
+def test_provider_failure_replays_the_exact_cache_entry_and_keeps_the_osm_data_date() -> None:
+    calls = 0
+
+    def loader(aoi: BoundingBox) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise OverpassRateLimited("throttled")
+        return _response()
+
+    execution = _execution(live_loader=loader, cache=CacheService())
+    live = execution.run(AOI)
+    replay = execution.run(AOI)
+
+    assert calls == 2
+    assert (replay.source, replay.stale) == ("cache", True)
+    assert replay.data_date == live.data_date == "2026-08-24"
+    assert replay.reason is not None and "stale" in replay.reason
+
+
+def test_a_different_aoi_never_replays_another_aois_cache_entry() -> None:
+    execution = _execution(live_loader=lambda aoi: _response(), cache=CacheService())
+    execution.run(AOI)
+    execution.live_loader = lambda aoi: (_ for _ in ()).throw(OverpassError("offline"))
+
+    assert execution.run(AOI).source == "cache"
+    with pytest.raises(BuildingsUnavailable, match="no matching cache entry or fixture"):
+        execution.run(OTHER_AOI)
+
+
+def test_matching_fixture_replays_as_stale_with_its_own_osm_data_date(tmp_path: Path) -> None:
+    execution = _execution()
+    outcome = _execution(
+        fixture_path=_fixture(tmp_path, execution.identity(AOI)),
+        live_loader=lambda aoi: (_ for _ in ()).throw(OverpassError("offline")),
+    ).run(AOI)
+
+    assert (outcome.source, outcome.stale) == ("fixture", True)
+    assert outcome.data_date == "2026-08-20"
+    assert outcome.retrieved_at is None
+
+
+@pytest.mark.parametrize(  # type: ignore[misc]
+    ("execution_overrides", "sidecar_overrides"),
+    [
+        ({}, {"request_configuration": {"aoi": "somewhere else"}}),
+        ({}, {"endpoint": "https://overpass.other/api/interpreter"}),
+        ({}, {"schema_version": "building-v2"}),
+        ({}, {"provider_config_version": "overpass-building-config-v2"}),
+        ({}, {"status": "failed", "data_date": None}),
+        ({"model_version": "route-shade-v2"}, {}),
+        ({"search_distance_m": 400.0}, {}),
+    ],
+)
+def test_fixture_replay_requires_exact_request_identity(
+    tmp_path: Path,
+    execution_overrides: dict[str, Any],
+    sidecar_overrides: dict[str, Any],
+) -> None:
+    identity = _execution().identity(AOI)
+    execution = _execution(
+        fixture_path=_fixture(tmp_path, identity, **sidecar_overrides),
+        live_loader=lambda aoi: (_ for _ in ()).throw(OverpassError("offline")),
+        **execution_overrides,
+    )
+
+    with pytest.raises(BuildingsUnavailable):
+        execution.run(AOI)
+
+
+def test_a_response_without_an_osm_source_timestamp_is_a_provider_failure() -> None:
+    execution = _execution(live_loader=lambda aoi: {"elements": []}, cache=CacheService())
+
+    with pytest.raises(BuildingsUnavailable):
+        execution.run(AOI)
+    with pytest.raises(OverpassError, match="missing its OSM source timestamp"):
+        osm_source_timestamp({"elements": []})
+
+
+def test_unconfigured_live_acquisition_without_replay_is_explicit() -> None:
+    with pytest.raises(BuildingsUnavailable, match="not configured"):
+        _execution().run(AOI)
+
+
+def test_request_identity_separates_aoi_search_distance_and_model_version() -> None:
+    baseline = building_request_payload(
+        AOI, search_distance_m=250.0, model_version="route-shade-v1"
+    )
+
+    assert (
+        building_request_payload(OTHER_AOI, search_distance_m=250.0, model_version="route-shade-v1")
+        != baseline
+    )
+    assert (
+        building_request_payload(AOI, search_distance_m=400.0, model_version="route-shade-v1")
+        != baseline
+    )
+    assert (
+        building_request_payload(AOI, search_distance_m=250.0, model_version="route-shade-v2")
+        != baseline
+    )
+
+
+def _canonical_routes() -> Any:
+    return normalize_response(
+        json.loads(CANONICAL_ROUTE.read_text(encoding="utf-8")),
+        provider_instance="fossgis-routed-foot",
+    )
+
+
+def test_the_committed_canonical_building_fixture_matches_the_canonical_route_aoi() -> None:
+    routes = _canonical_routes()
+    execution = BuildingExecution(
+        fixture_path=CANONICAL_BUILDINGS,
+        endpoint="https://overpass-api.de/api/interpreter",
+        search_distance_m=250.0,
+    )
+
+    outcome = execution.run(_shared_bbox(routes, 250.0))
+
+    assert (outcome.source, outcome.stale) == ("fixture", True)
+    assert outcome.data_date == osm_source_timestamp(outcome.payload).date().isoformat()
+
+
+def test_canonical_fixture_replay_yields_sufficient_daytime_shade_evidence() -> None:
+    routes = _canonical_routes()
+    service = RouteShadeService(
+        BuildingExecution(
+            fixture_path=CANONICAL_BUILDINGS,
+            endpoint="https://overpass-api.de/api/interpreter",
+            search_distance_m=250.0,
+        )
+    )
+    instant = datetime(2026, 8, 29, 10, 30, tzinfo=ZoneInfo("America/Chicago"))
+    solar = solar_position(instant, 29.4252122, -98.4861309)
+
+    evidence = service.load(routes, solar, instant)["route-1"]
+
+    assert evidence.confidence is ShadeConfidence.SUFFICIENT
+    assert evidence.building_coverage >= 0.70
+    assert evidence.dropped_geometry_count == 0
+    assert 0 < evidence.modeled_shade_percent <= 100
+
+
+def test_shade_evidence_is_explicitly_unavailable_when_no_building_source_answers() -> None:
+    service = RouteShadeService(_execution())
+    instant = datetime(2026, 8, 29, 10, 30, tzinfo=ZoneInfo("America/Chicago"))
+    solar = solar_position(instant, 29.4252122, -98.4861309)
+
+    evidence = service.load(_canonical_routes(), solar, instant)
+
+    assert set(evidence) == {"route-1"}
+    unavailable = evidence["route-1"]
+    assert unavailable.confidence is ShadeConfidence.INSUFFICIENT
+    assert unavailable.modeled_shade_percent == 0.0
+    assert unavailable.building_coverage == 0.0
+    assert any("no OSM building geometry was available" in item for item in unavailable.limitations)

--- a/tests/test_building_execution.py
+++ b/tests/test_building_execution.py
@@ -242,7 +242,7 @@ def test_canonical_fixture_replay_yields_sufficient_daytime_shade_evidence() -> 
     instant = datetime(2026, 8, 29, 10, 30, tzinfo=ZoneInfo("America/Chicago"))
     solar = solar_position(instant, 29.4252122, -98.4861309)
 
-    evidence = service.load(routes, solar, instant)["route-1"]
+    evidence = service.load(routes, solar, instant).evidence["route-1"]
 
     assert evidence.confidence is ShadeConfidence.SUFFICIENT
     assert evidence.building_coverage >= 0.70
@@ -255,10 +255,12 @@ def test_shade_evidence_is_explicitly_unavailable_when_no_building_source_answer
     instant = datetime(2026, 8, 29, 10, 30, tzinfo=ZoneInfo("America/Chicago"))
     solar = solar_position(instant, 29.4252122, -98.4861309)
 
-    evidence = service.load(_canonical_routes(), solar, instant)
+    outcome = service.load(_canonical_routes(), solar, instant)
 
-    assert set(evidence) == {"route-1"}
-    unavailable = evidence["route-1"]
+    assert outcome.building is None
+    assert outcome.unavailable_reason is not None and "not configured" in outcome.unavailable_reason
+    assert set(outcome.evidence) == {"route-1"}
+    unavailable = outcome.evidence["route-1"]
     assert unavailable.confidence is ShadeConfidence.INSUFFICIENT
     assert unavailable.modeled_shade_percent == 0.0
     assert unavailable.building_coverage == 0.0

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -6,6 +6,7 @@ unavailable/error states as required by Issue #9.
 
 import pytest
 
+from app.domain.route_shade import ShadeConfidence
 from app.domain.contracts import (
     Confidence,
     Coordinates,
@@ -61,7 +62,7 @@ def _valid_route_option(identity: str = "route-a", *, recommended: bool = False)
         heat_metric=HeatMetricName.TCM,
         heat_status=HeatStatus.ELEVATED,
         modeled_shade_percent=65 if recommended else None,
-        shade_confidence=Confidence.SUFFICIENT if recommended else None,
+        shade_confidence=ShadeConfidence.SUFFICIENT if recommended else None,
         building_coverage=0.9,
         recommended=recommended,
         recommendation_reason="highest modeled shade" if recommended else None,

--- a/tests/test_route_analysis.py
+++ b/tests/test_route_analysis.py
@@ -1,8 +1,11 @@
 """Route acquisition and heat-branch orchestration tests."""
 
 from collections.abc import Callable, Mapping
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
 
 from app.domain.contracts import (
     BestTimeResult,
@@ -22,13 +25,17 @@ from app.domain.contracts import (
 from app.domain.heat_policy import classify_heat
 from app.domain.route_heat import SharedRouteHeatRequest
 from app.domain.route_shade import (
+    SOLAR_MODEL_IDENTITY,
     RouteShadeEvidence,
     ShadeConfidence,
     SolarPosition,
     solar_position,
+    unavailable_shade_evidence,
 )
 from app.domain.routing import RouteRequest, RouteSet
+from app.services.building_execution import BuildingOutcome
 from app.services.route_analysis import RouteAnalysisService
+from app.services.route_shade import RouteShadeOutcome
 from app.services.routing import RouteExecution
 
 
@@ -46,7 +53,14 @@ def _request() -> TripAnalysisRequest:
     )
 
 
-def _best_time(value: float = 32.0, *, exact: bool = False) -> BestTimeResult:
+def _timezone_label(zone: tzinfo) -> str:
+    key = getattr(zone, "key", None)
+    return key if isinstance(key, str) else str(zone)
+
+
+def _best_time(
+    value: float = 32.0, *, exact: bool = False, zone: tzinfo = timezone.utc
+) -> BestTimeResult:
     provenance = Provenance(
         source="provider",
         data_date="2020-08-23",
@@ -77,8 +91,8 @@ def _best_time(value: float = 32.0, *, exact: bool = False) -> BestTimeResult:
         hourly_coverage=1 / 24,
         heat_interpretation=classify_heat(value, metric=HeatMetricName.TCM),
         recommended_hour_tcm_celsius=value,
-        recommendation_time=(datetime(2020, 8, 23, 9, tzinfo=timezone.utc) if exact else None),
-        recommendation_timezone="America/Chicago" if exact else None,
+        recommendation_time=(datetime(2020, 8, 23, 9, tzinfo=zone) if exact else None),
+        recommendation_timezone=_timezone_label(zone) if exact else None,
         temporal_evidence=(
             TemporalEvidenceState.EXACT if exact else TemporalEvidenceState.UNAVAILABLE
         ),
@@ -115,8 +129,7 @@ def _service(
     route_loader: Callable[[RouteRequest], Mapping[str, object]],
     *,
     shared_loader: Callable[[SharedRouteHeatRequest], Mapping[str, object]] | None = None,
-    shade_loader: Callable[[RouteSet, SolarPosition, datetime], Mapping[str, RouteShadeEvidence]]
-    | None = None,
+    shade_loader: Callable[[RouteSet, SolarPosition, datetime], RouteShadeOutcome] | None = None,
     solar_locator: Callable[[datetime, float, float], SolarPosition] | None = None,
 ) -> RouteAnalysisService:
     execution = RouteExecution(
@@ -140,6 +153,28 @@ def _service(
         shade_evidence_loader=shade_loader,
         solar_locator=solar_locator or solar_position,
         clock=lambda: datetime(2020, 8, 23, 14, tzinfo=timezone.utc),
+    )
+
+
+def _shade_outcome(
+    evidence: Mapping[str, RouteShadeEvidence],
+    *,
+    building: BuildingOutcome | None = None,
+) -> RouteShadeOutcome:
+    resolved = building or BuildingOutcome(
+        payload={"elements": []},
+        source="cache",
+        stale=True,
+        retrieved_at=datetime(2020, 8, 22, 6, tzinfo=timezone.utc),
+        data_date="2020-08-21",
+        reason="replayed a stale cached building response",
+    )
+    return RouteShadeOutcome(
+        evidence=evidence,
+        request_identity={"aoi": {"south": 29.42, "west": -98.49, "north": 29.43, "east": -98.48}},
+        metres_per_level=3.0,
+        minimum_building_coverage=0.70,
+        building=resolved,
     )
 
 
@@ -250,12 +285,10 @@ def test_elevated_nighttime_bypasses_shade_loader_and_recommends_coolest(
 ) -> None:
     shade_calls = 0
 
-    def load_shade(
-        routes: RouteSet, solar: SolarPosition, instant: datetime
-    ) -> Mapping[str, RouteShadeEvidence]:
+    def load_shade(routes: RouteSet, solar: SolarPosition, instant: datetime) -> RouteShadeOutcome:
         nonlocal shade_calls
         shade_calls += 1
-        return {}
+        return _shade_outcome({})
 
     result = _service(
         tmp_path,
@@ -272,15 +305,15 @@ def test_elevated_nighttime_bypasses_shade_loader_and_recommends_coolest(
 def test_elevated_daytime_loads_shade_once_and_recommends_shadiest(tmp_path: Path) -> None:
     shade_calls = 0
 
-    def load_shade(
-        routes: RouteSet, solar: SolarPosition, instant: datetime
-    ) -> Mapping[str, RouteShadeEvidence]:
+    def load_shade(routes: RouteSet, solar: SolarPosition, instant: datetime) -> RouteShadeOutcome:
         nonlocal shade_calls
         shade_calls += 1
-        return {
-            routes.routes[0].identity: _shade(40.0, 0.8),
-            routes.routes[1].identity: _shade(65.0, 0.75),
-        }
+        return _shade_outcome(
+            {
+                routes.routes[0].identity: _shade(40.0, 0.8),
+                routes.routes[1].identity: _shade(65.0, 0.75),
+            }
+        )
 
     result = _service(
         tmp_path,
@@ -300,7 +333,7 @@ def test_daytime_without_exact_time_keeps_routes_without_forced_recommendation(
     result = _service(
         tmp_path,
         lambda request: _osrm_payload(),
-        shade_loader=lambda routes, solar, instant: {},
+        shade_loader=lambda routes, solar, instant: _shade_outcome({}),
     ).analyze(_request(), _best_time(39.0))
 
     assert result.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED
@@ -349,3 +382,197 @@ def test_long_route_heat_failure_preserves_routes_without_landmark_substitution(
     assert result.recommended_id is None
     assert all(option.heat_value is None for option in result.alternatives)
     assert all(option.heat_source is None for option in result.alternatives)
+
+
+def test_elevated_daytime_keeps_routing_heat_building_and_solar_provenance_distinct(
+    tmp_path: Path,
+) -> None:
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: _shade_outcome(
+            {
+                routes.routes[0].identity: _shade(40.0, 0.8),
+                routes.routes[1].identity: _shade(65.0, 0.75),
+            }
+        ),
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(180.0, 45.0),
+    ).analyze(_request(), _best_time(39.0, exact=True))
+
+    assert result.routing_provenance is not None
+    assert result.heat_provenance is not None
+    assert result.building_provenance is not None
+    assert result.solar_provenance is not None
+    providers = {
+        result.routing_provenance.provider,
+        result.heat_provenance.provider,
+        result.building_provenance.provider,
+        result.solar_provenance.provider,
+    }
+    assert providers == {"osrm", "fortyguard", "overpass", "astral"}
+    versions = {
+        result.routing_provenance.transformation_version,
+        result.heat_provenance.transformation_version,
+        result.building_provenance.transformation_version,
+        result.solar_provenance.transformation_version,
+    }
+    assert len(versions) == 4
+
+
+def test_building_provenance_records_the_osm_data_date_staleness_aoi_and_policy(
+    tmp_path: Path,
+) -> None:
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: _shade_outcome(
+            {
+                routes.routes[0].identity: _shade(40.0, 0.8),
+                routes.routes[1].identity: _shade(65.0, 0.75),
+            }
+        ),
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(180.0, 45.0),
+    ).analyze(_request(), _best_time(39.0, exact=True))
+
+    building = result.building_provenance
+    assert building is not None
+    assert (building.source, building.fresh) == ("cache", False)
+    assert building.data_date == "2020-08-21"
+    assert building.retrieved_at == "2020-08-22T06:00:00+00:00"
+    assert building.confidence is Confidence.SUFFICIENT
+    assert building.request_configuration["metres_per_level"] == 3.0
+    assert building.request_configuration["minimum_building_coverage"] == 0.70
+    assert building.request_configuration["dropped_geometry_count"] == 0
+    assert isinstance(building.request_configuration["aoi"], dict)
+    assert building.coverage == 0.75
+
+
+def test_building_provenance_names_the_replay_time_when_a_fixture_has_none(
+    tmp_path: Path,
+) -> None:
+    fixture_replay = BuildingOutcome(
+        payload={"elements": []},
+        source="fixture",
+        stale=True,
+        retrieved_at=None,
+        data_date="2026-08-29",
+    )
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: _shade_outcome(
+            {
+                routes.routes[0].identity: _shade(40.0, 0.8),
+                routes.routes[1].identity: _shade(65.0, 0.75),
+            },
+            building=fixture_replay,
+        ),
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(180.0, 45.0),
+    ).analyze(_request(), _best_time(39.0, exact=True))
+
+    building = result.building_provenance
+    assert building is not None
+    assert building.retrieved_at == "2020-08-23T14:00:00+00:00"
+    assert building.note is not None and "no provider retrieval time" in building.note
+    assert building.data_date == "2026-08-29"
+
+
+def test_unavailable_buildings_produce_explicit_unavailable_building_provenance(
+    tmp_path: Path,
+) -> None:
+    unavailable = RouteShadeOutcome(
+        evidence={
+            "route-1": unavailable_shade_evidence(),
+            "route-2": unavailable_shade_evidence(),
+        },
+        request_identity={"aoi": {"south": 29.42, "west": -98.49, "north": 29.43, "east": -98.48}},
+        metres_per_level=3.0,
+        minimum_building_coverage=0.70,
+        unavailable_reason="the building request failed and no cache entry or fixture is available",
+    )
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: unavailable,
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(180.0, 45.0),
+    ).analyze(_request(), _best_time(39.0, exact=True))
+
+    building = result.building_provenance
+    assert building is not None
+    assert (building.source, building.response_status) == ("unavailable", "unavailable")
+    assert building.confidence is Confidence.INSUFFICIENT
+    assert building.fresh is False
+    assert building.note == unavailable.unavailable_reason
+    assert building.coverage == 0.0
+    assert result.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED
+
+
+def test_solar_provenance_records_the_named_zone_instant_place_and_model(tmp_path: Path) -> None:
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: _shade_outcome(
+            {
+                routes.routes[0].identity: _shade(40.0, 0.8),
+                routes.routes[1].identity: _shade(65.0, 0.75),
+            }
+        ),
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(122.5, 45.0),
+    ).analyze(_request(), _best_time(39.0, exact=True, zone=ZoneInfo("America/Chicago")))
+
+    solar = result.solar_provenance
+    assert solar is not None
+    configuration = solar.request_configuration
+    assert configuration["timezone"] == "America/Chicago"
+    assert configuration["instant"] == "2020-08-23T09:00:00-05:00"
+    assert configuration["utc_offset_seconds"] == -18000
+    assert configuration["azimuth_degrees"] == 122.5
+    assert configuration["elevation_degrees"] == 45.0
+    assert configuration["model_version"] == SOLAR_MODEL_IDENTITY
+    assert configuration["transformations"] == [
+        {"name": "local_instant_to_utc", "version": 1},
+        {"name": "apparent_solar_position", "version": 1},
+    ]
+    assert (solar.data_date, solar.fresh, solar.source) == ("2020-08-23", True, "computed")
+    assert configuration["latitude"] == pytest.approx(29.4258, abs=1e-3)
+    assert configuration["longitude"] == pytest.approx(-98.4858, abs=1e-3)
+
+
+def test_nighttime_records_solar_provenance_without_building_acquisition(tmp_path: Path) -> None:
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: _shade_outcome({}),
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(300.0, -6.0),
+    ).analyze(_request(), _best_time(39.0, exact=True))
+
+    assert result.decision_state is RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED
+    assert result.building_provenance is None
+    assert result.solar_provenance is not None
+    assert result.solar_provenance.request_configuration["elevation_degrees"] == -6.0
+
+
+def test_inexact_recommendation_time_records_neither_solar_nor_building_provenance(
+    tmp_path: Path,
+) -> None:
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: _shade_outcome({}),
+    ).analyze(_request(), _best_time(39.0))
+
+    assert result.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED
+    assert result.solar_provenance is None
+    assert result.building_provenance is None
+
+
+def test_mild_heat_records_no_building_or_solar_provenance(tmp_path: Path) -> None:
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: _shade_outcome({}),
+    ).analyze(_request(), _best_time(24.0, exact=True))
+
+    assert result.decision_state is RouteDecisionState.MILD_SHORTEST_RECOMMENDED
+    assert result.building_provenance is None
+    assert result.solar_provenance is None

--- a/tests/test_route_analysis.py
+++ b/tests/test_route_analysis.py
@@ -77,9 +77,7 @@ def _best_time(value: float = 32.0, *, exact: bool = False) -> BestTimeResult:
         hourly_coverage=1 / 24,
         heat_interpretation=classify_heat(value, metric=HeatMetricName.TCM),
         recommended_hour_tcm_celsius=value,
-        recommendation_time=(
-            datetime(2020, 8, 23, 9, tzinfo=timezone.utc) if exact else None
-        ),
+        recommendation_time=(datetime(2020, 8, 23, 9, tzinfo=timezone.utc) if exact else None),
         recommendation_timezone="America/Chicago" if exact else None,
         temporal_evidence=(
             TemporalEvidenceState.EXACT if exact else TemporalEvidenceState.UNAVAILABLE
@@ -117,9 +115,7 @@ def _service(
     route_loader: Callable[[RouteRequest], Mapping[str, object]],
     *,
     shared_loader: Callable[[SharedRouteHeatRequest], Mapping[str, object]] | None = None,
-    shade_loader: Callable[
-        [RouteSet, SolarPosition, datetime], Mapping[str, RouteShadeEvidence]
-    ]
+    shade_loader: Callable[[RouteSet, SolarPosition, datetime], Mapping[str, RouteShadeEvidence]]
     | None = None,
     solar_locator: Callable[[datetime, float, float], SolarPosition] | None = None,
 ) -> RouteAnalysisService:

--- a/tests/test_route_analysis.py
+++ b/tests/test_route_analysis.py
@@ -15,12 +15,19 @@ from app.domain.contracts import (
     Provenance,
     RouteDecisionState,
     RouteHeatSource,
+    TemporalEvidenceState,
     TripAnalysisRequest,
     TripMode,
 )
 from app.domain.heat_policy import classify_heat
 from app.domain.route_heat import SharedRouteHeatRequest
-from app.domain.routing import RouteRequest
+from app.domain.route_shade import (
+    RouteShadeEvidence,
+    ShadeConfidence,
+    SolarPosition,
+    solar_position,
+)
+from app.domain.routing import RouteRequest, RouteSet
 from app.services.route_analysis import RouteAnalysisService
 from app.services.routing import RouteExecution
 
@@ -39,7 +46,7 @@ def _request() -> TripAnalysisRequest:
     )
 
 
-def _best_time(value: float = 32.0) -> BestTimeResult:
+def _best_time(value: float = 32.0, *, exact: bool = False) -> BestTimeResult:
     provenance = Provenance(
         source="provider",
         data_date="2020-08-23",
@@ -70,6 +77,13 @@ def _best_time(value: float = 32.0) -> BestTimeResult:
         hourly_coverage=1 / 24,
         heat_interpretation=classify_heat(value, metric=HeatMetricName.TCM),
         recommended_hour_tcm_celsius=value,
+        recommendation_time=(
+            datetime(2020, 8, 23, 9, tzinfo=timezone.utc) if exact else None
+        ),
+        recommendation_timezone="America/Chicago" if exact else None,
+        temporal_evidence=(
+            TemporalEvidenceState.EXACT if exact else TemporalEvidenceState.UNAVAILABLE
+        ),
     )
 
 
@@ -103,6 +117,11 @@ def _service(
     route_loader: Callable[[RouteRequest], Mapping[str, object]],
     *,
     shared_loader: Callable[[SharedRouteHeatRequest], Mapping[str, object]] | None = None,
+    shade_loader: Callable[
+        [RouteSet, SolarPosition, datetime], Mapping[str, RouteShadeEvidence]
+    ]
+    | None = None,
+    solar_locator: Callable[[datetime, float, float], SolarPosition] | None = None,
 ) -> RouteAnalysisService:
     execution = RouteExecution(
         fixture_path=tmp_path / "route.json",
@@ -122,7 +141,24 @@ def _service(
         corridor_buffer_m=25.0,
         corridor_granularity=100,
         shared_heat_loader=shared_loader,
+        shade_evidence_loader=shade_loader,
+        solar_locator=solar_locator or solar_position,
         clock=lambda: datetime(2020, 8, 23, 14, tzinfo=timezone.utc),
+    )
+
+
+def _shade(percent: float, coverage: float) -> RouteShadeEvidence:
+    return RouteShadeEvidence(
+        modeled_shade_percent=percent,
+        building_coverage=coverage,
+        confidence=ShadeConfidence.SUFFICIENT,
+        explicit_area_fraction=coverage,
+        inferred_levels_area_fraction=0.0,
+        unknown_area_fraction=1.0 - coverage,
+        explicit_count=1,
+        inferred_levels_count=0,
+        unknown_count=1,
+        dropped_geometry_count=0,
     )
 
 
@@ -211,6 +247,68 @@ def test_any_long_route_executes_one_shared_activity_and_defers_elevated_heat(
         RouteHeatSource.SHARED_CORRIDOR
     }
     assert all(option.heat_value == 38.0 for option in result.alternatives)
+
+
+def test_elevated_nighttime_bypasses_shade_loader_and_recommends_coolest(
+    tmp_path: Path,
+) -> None:
+    shade_calls = 0
+
+    def load_shade(
+        routes: RouteSet, solar: SolarPosition, instant: datetime
+    ) -> Mapping[str, RouteShadeEvidence]:
+        nonlocal shade_calls
+        shade_calls += 1
+        return {}
+
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=load_shade,
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(180.0, -1.0),
+    ).analyze(_request(), _best_time(39.0, exact=True))
+
+    assert shade_calls == 0
+    assert result.decision_state is RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED
+    assert result.recommended_id == "route-1"
+
+
+def test_elevated_daytime_loads_shade_once_and_recommends_shadiest(tmp_path: Path) -> None:
+    shade_calls = 0
+
+    def load_shade(
+        routes: RouteSet, solar: SolarPosition, instant: datetime
+    ) -> Mapping[str, RouteShadeEvidence]:
+        nonlocal shade_calls
+        shade_calls += 1
+        return {
+            routes.routes[0].identity: _shade(40.0, 0.8),
+            routes.routes[1].identity: _shade(65.0, 0.75),
+        }
+
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=load_shade,
+        solar_locator=lambda instant, latitude, longitude: SolarPosition(180.0, 45.0),
+    ).analyze(_request(), _best_time(39.0, exact=True))
+
+    assert shade_calls == 1
+    assert result.decision_state is RouteDecisionState.SHADE_SHADIEST_RECOMMENDED
+    assert result.recommended_id == "route-2"
+
+
+def test_daytime_without_exact_time_keeps_routes_without_forced_recommendation(
+    tmp_path: Path,
+) -> None:
+    result = _service(
+        tmp_path,
+        lambda request: _osrm_payload(),
+        shade_loader=lambda routes, solar, instant: {},
+    ).analyze(_request(), _best_time(39.0))
+
+    assert result.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED
+    assert result.recommended_id is None
 
 
 def test_route_unavailable_returns_explicit_no_suitable_route_state(tmp_path: Path) -> None:

--- a/tests/test_route_decision.py
+++ b/tests/test_route_decision.py
@@ -50,15 +50,11 @@ def _evidence(*values: float | None, coverage: float = 0.8) -> tuple[RouteHeatEv
     )
 
 
-def _shade(
-    percent: float, coverage: float, *, sufficient: bool = True
-) -> RouteShadeEvidence:
+def _shade(percent: float, coverage: float, *, sufficient: bool = True) -> RouteShadeEvidence:
     return RouteShadeEvidence(
         modeled_shade_percent=percent,
         building_coverage=coverage,
-        confidence=(
-            ShadeConfidence.SUFFICIENT if sufficient else ShadeConfidence.INSUFFICIENT
-        ),
+        confidence=(ShadeConfidence.SUFFICIENT if sufficient else ShadeConfidence.INSUFFICIENT),
         explicit_area_fraction=coverage,
         inferred_levels_area_fraction=0.0,
         unknown_area_fraction=1.0 - coverage,
@@ -183,8 +179,7 @@ def test_sufficient_shade_recommends_shadiest_with_distance_tie_break() -> None:
         "highest modeled shade among returned routes"
     )
     assert all(
-        route.shade_confidence is ShadeConfidence.SUFFICIENT
-        for route in result.alternatives
+        route.shade_confidence is ShadeConfidence.SUFFICIENT for route in result.alternatives
     )
 
 
@@ -227,8 +222,7 @@ def test_nighttime_recommends_coolest_then_distance_and_marks_shade_not_applicab
     assert result.recommended_id == "route-1"
     assert [route.modeled_shade_percent for route in result.alternatives] == [0.0, 0.0]
     assert all(
-        route.shade_confidence is ShadeConfidence.NOT_APPLICABLE
-        for route in result.alternatives
+        route.shade_confidence is ShadeConfidence.NOT_APPLICABLE for route in result.alternatives
     )
 
 

--- a/tests/test_route_decision.py
+++ b/tests/test_route_decision.py
@@ -9,6 +9,7 @@ from app.domain.contracts import (
 )
 from app.domain.route_decision import RouteDecisionInput, decide_route_comparison
 from app.domain.route_heat import RouteHeatEvidence
+from app.domain.route_shade import RouteShadeEvidence, ShadeConfidence
 from app.domain.routing import RouteGeometry, RouteSet, ReturnedRoute
 
 
@@ -46,6 +47,25 @@ def _evidence(*values: float | None, coverage: float = 0.8) -> tuple[RouteHeatEv
             route.identity, value, coverage, value is not None, 1 if value is not None else 0
         )
         for route, value in zip(_routes().routes, values, strict=True)
+    )
+
+
+def _shade(
+    percent: float, coverage: float, *, sufficient: bool = True
+) -> RouteShadeEvidence:
+    return RouteShadeEvidence(
+        modeled_shade_percent=percent,
+        building_coverage=coverage,
+        confidence=(
+            ShadeConfidence.SUFFICIENT if sufficient else ShadeConfidence.INSUFFICIENT
+        ),
+        explicit_area_fraction=coverage,
+        inferred_levels_area_fraction=0.0,
+        unknown_area_fraction=1.0 - coverage,
+        explicit_count=1,
+        inferred_levels_count=0,
+        unknown_count=0 if coverage == 1 else 1,
+        dropped_geometry_count=0,
     )
 
 
@@ -137,6 +157,96 @@ def test_single_returned_route_is_usable_with_limited_comparison_state() -> None
         heat_provenance=None,
     )
     assert result.route_set_state is RouteSetState.SINGLE_ROUTE
+    assert result.recommended_id == "route-1"
+
+
+def test_sufficient_shade_recommends_shadiest_with_distance_tie_break() -> None:
+    result = decide_route_comparison(
+        RouteDecisionInput(
+            _routes(),
+            None,
+            _evidence(39.0, 38.0),
+            shade_evidence={
+                "route-1": _shade(60.0, 0.8),
+                "route-2": _shade(60.0, 0.9),
+            },
+        ),
+        cautious=False,
+        provenance=_provenance(),
+        routing_provenance=_provenance(),
+        heat_provenance=_provenance(),
+    )
+
+    assert result.decision_state is RouteDecisionState.SHADE_SHADIEST_RECOMMENDED
+    assert result.recommended_id == "route-1"
+    assert result.alternatives[0].recommendation_reason == (
+        "highest modeled shade among returned routes"
+    )
+    assert all(
+        route.shade_confidence is ShadeConfidence.SUFFICIENT
+        for route in result.alternatives
+    )
+
+
+def test_any_weak_shade_evidence_preserves_metrics_without_recommendation() -> None:
+    result = decide_route_comparison(
+        RouteDecisionInput(
+            _routes(),
+            None,
+            _evidence(39.0, 38.0),
+            shade_evidence={
+                "route-1": _shade(70.0, 0.8),
+                "route-2": _shade(45.0, 0.69, sufficient=False),
+            },
+        ),
+        cautious=False,
+        provenance=_provenance(),
+        routing_provenance=_provenance(),
+        heat_provenance=_provenance(),
+    )
+
+    assert result.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED
+    assert result.recommended_id is None
+    assert [route.modeled_shade_percent for route in result.alternatives] == [70.0, 45.0]
+    assert [route.shade_confidence for route in result.alternatives] == [
+        ShadeConfidence.SUFFICIENT,
+        ShadeConfidence.INSUFFICIENT,
+    ]
+
+
+def test_nighttime_recommends_coolest_then_distance_and_marks_shade_not_applicable() -> None:
+    result = decide_route_comparison(
+        RouteDecisionInput(_routes(), None, _evidence(39.0, 39.0), nighttime=True),
+        cautious=False,
+        provenance=_provenance(),
+        routing_provenance=_provenance(),
+        heat_provenance=_provenance(),
+    )
+
+    assert result.decision_state is RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED
+    assert result.recommended_id == "route-1"
+    assert [route.modeled_shade_percent for route in result.alternatives] == [0.0, 0.0]
+    assert all(
+        route.shade_confidence is ShadeConfidence.NOT_APPLICABLE
+        for route in result.alternatives
+    )
+
+
+def test_single_elevated_route_with_sufficient_shade_uses_only_route_state() -> None:
+    route_set = RouteSet((_routes().routes[0],), "fossgis-routed-foot")
+    result = decide_route_comparison(
+        RouteDecisionInput(
+            route_set,
+            landmark_tcm_celsius=39.0,
+            shade_evidence={"route-1": _shade(35.0, 0.7)},
+        ),
+        cautious=False,
+        provenance=_provenance(),
+        routing_provenance=_provenance(),
+        heat_provenance=None,
+    )
+
+    assert result.decision_state is RouteDecisionState.SHADE_ONLY_ROUTE_RECOMMENDED
     assert result.recommended_id == "route-1"
 
 

--- a/tests/test_route_shade.py
+++ b/tests/test_route_shade.py
@@ -1,0 +1,102 @@
+"""OSM building-height and deterministic shadow geometry behavior."""
+
+from datetime import datetime
+import math
+from zoneinfo import ZoneInfo
+
+import pytest
+from shapely.geometry import LineString, Polygon
+
+from app.domain.route_shade import (
+    BuildingFootprint,
+    BuildingHeightQuality,
+    SolarPosition,
+    classify_building_height,
+    parse_height,
+    route_shade_percent,
+    solar_position,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("12", 12.0),
+        ("12 m", 12.0),
+        ("40 ft", 12.192),
+        ("10'6\"", 3.2004),
+    ],
+)
+def test_parse_height_accepts_supported_osm_forms(raw: str, expected: float) -> None:
+    assert parse_height(raw) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("raw", [None, "", "0", "-2", "10;12", "10-12", "ten"])
+def test_parse_height_rejects_missing_ambiguous_or_nonpositive_values(raw: object) -> None:
+    assert parse_height(raw) is None
+
+
+def test_explicit_height_precedes_levels_and_invalid_height_falls_back() -> None:
+    assert classify_building_height({"height": "12", "building:levels": "9"}) == (
+        12.0,
+        BuildingHeightQuality.EXPLICIT,
+    )
+    assert classify_building_height({"height": "unknown", "building:levels": "4"}) == (
+        12.0,
+        BuildingHeightQuality.INFERRED_LEVELS,
+    )
+    assert classify_building_height({"building:levels": "0"}) == (
+        None,
+        BuildingHeightQuality.UNKNOWN,
+    )
+
+
+def test_solar_position_distinguishes_summer_daytime_and_nighttime() -> None:
+    zone = ZoneInfo("America/Chicago")
+    noon = solar_position(datetime(2026, 6, 21, 13, tzinfo=zone), 29.42, -98.49)
+    night = solar_position(datetime(2026, 6, 21, 1, tzinfo=zone), 29.42, -98.49)
+
+    assert noon.elevation_degrees > 70
+    assert night.elevation_degrees < 0
+    assert 0 <= noon.azimuth_degrees < 360
+
+
+def test_nighttime_has_zero_modeled_building_shade() -> None:
+    route = LineString([(-98.49, 29.42), (-98.489, 29.42)])
+    building = BuildingFootprint(
+        "way/1",
+        Polygon(
+            [
+                (-98.4896, 29.4199),
+                (-98.4895, 29.4199),
+                (-98.4895, 29.4201),
+                (-98.4896, 29.4201),
+            ]
+        ),
+        12.0,
+        BuildingHeightQuality.EXPLICIT,
+    )
+
+    assert route_shade_percent(route, (building,), SolarPosition(180.0, 0.0)) == 0.0
+
+
+def test_shadow_union_returns_a_bounded_finite_percentage() -> None:
+    route = LineString([(-98.49, 29.42), (-98.489, 29.42)])
+    building = BuildingFootprint(
+        "way/1",
+        Polygon(
+            [
+                (-98.4896, 29.42002),
+                (-98.4895, 29.42002),
+                (-98.4895, 29.42012),
+                (-98.4896, 29.42012),
+            ]
+        ),
+        20.0,
+        BuildingHeightQuality.EXPLICIT,
+    )
+
+    shade = route_shade_percent(route, (building,), SolarPosition(0.0, 45.0))
+
+    assert math.isfinite(shade)
+    assert 0 < shade <= 100

--- a/tests/test_route_shade.py
+++ b/tests/test_route_shade.py
@@ -1,6 +1,6 @@
 """OSM building-height and deterministic shadow geometry behavior."""
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import math
 from zoneinfo import ZoneInfo
 
@@ -18,7 +18,7 @@ from app.domain.route_shade import (
 )
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[misc]
     ("raw", "expected"),
     [
         ("12", 12.0),
@@ -31,7 +31,7 @@ def test_parse_height_accepts_supported_osm_forms(raw: str, expected: float) -> 
     assert parse_height(raw) == pytest.approx(expected)
 
 
-@pytest.mark.parametrize("raw", [None, "", "0", "-2", "10;12", "10-12", "ten"])
+@pytest.mark.parametrize("raw", [None, "", "0", "-2", "10;12", "10-12", "ten"])  # type: ignore[misc]
 def test_parse_height_rejects_missing_ambiguous_or_nonpositive_values(raw: object) -> None:
     assert parse_height(raw) is None
 
@@ -59,6 +59,83 @@ def test_solar_position_distinguishes_summer_daytime_and_nighttime() -> None:
     assert noon.elevation_degrees > 70
     assert night.elevation_degrees < 0
     assert 0 <= noon.azimuth_degrees < 360
+
+
+_SAN_ANTONIO = (29.4245914, -98.4864288)
+_CHICAGO = ZoneInfo("America/Chicago")
+_AXIAL_TILT_DEGREES = 23.44
+
+
+def test_solar_noon_elevation_matches_solstice_reference_geometry() -> None:
+    """Solar-noon elevation is 90 - |latitude - declination| at each solstice."""
+    latitude = _SAN_ANTONIO[0]
+    summer = solar_position(datetime(2026, 6, 21, 13, 35, tzinfo=_CHICAGO), *_SAN_ANTONIO)
+    winter = solar_position(datetime(2026, 12, 21, 12, 30, tzinfo=_CHICAGO), *_SAN_ANTONIO)
+
+    assert summer.elevation_degrees == pytest.approx(90 - (latitude - _AXIAL_TILT_DEGREES), abs=0.2)
+    assert winter.elevation_degrees == pytest.approx(90 - (latitude + _AXIAL_TILT_DEGREES), abs=0.2)
+
+
+def test_solar_azimuth_moves_from_east_to_west_across_the_day() -> None:
+    morning = solar_position(datetime(2026, 6, 21, 8, tzinfo=_CHICAGO), *_SAN_ANTONIO)
+    evening = solar_position(datetime(2026, 6, 21, 19, tzinfo=_CHICAGO), *_SAN_ANTONIO)
+
+    assert 45 < morning.azimuth_degrees < 135
+    assert 225 < evening.azimuth_degrees < 315
+    assert morning.elevation_degrees > 0
+    assert evening.elevation_degrees > 0
+
+
+def test_solar_position_depends_on_the_instant_not_the_wall_clock() -> None:
+    """One instant expressed in two zones resolves to a single solar position."""
+    local = datetime(2026, 6, 21, 13, tzinfo=_CHICAGO)
+
+    assert solar_position(local, *_SAN_ANTONIO) == solar_position(
+        local.astimezone(timezone.utc), *_SAN_ANTONIO
+    )
+
+
+def test_solar_position_honors_daylight_saving_offsets() -> None:
+    """The same local hour resolves through CDT in summer and CST in winter."""
+    daylight = datetime(2026, 6, 21, 13, tzinfo=_CHICAGO)
+    standard = datetime(2026, 12, 21, 13, tzinfo=_CHICAGO)
+
+    assert daylight.utcoffset() == timedelta(hours=-5)
+    assert standard.utcoffset() == timedelta(hours=-6)
+    assert solar_position(daylight, *_SAN_ANTONIO).elevation_degrees > 80
+    assert solar_position(standard, *_SAN_ANTONIO).elevation_degrees < 40
+
+
+def test_solar_position_requires_a_timezone_aware_instant() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        solar_position(datetime(2026, 6, 21, 13), *_SAN_ANTONIO)
+
+
+@pytest.mark.parametrize(("latitude", "longitude"), [(91.0, 0.0), (0.0, 181.0)])  # type: ignore[misc]
+def test_solar_position_rejects_out_of_range_coordinates(latitude: float, longitude: float) -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        solar_position(datetime(2026, 6, 21, 13, tzinfo=_CHICAGO), latitude, longitude)
+
+
+def test_sun_below_the_horizon_yields_no_modeled_building_shade() -> None:
+    night = solar_position(datetime(2026, 6, 21, 3, tzinfo=_CHICAGO), *_SAN_ANTONIO)
+    route = LineString([(-98.49, 29.42), (-98.489, 29.42)])
+    building = BuildingFootprint(
+        "way/1",
+        Polygon(
+            [
+                (-98.4896, 29.42002),
+                (-98.4895, 29.42002),
+                (-98.4895, 29.42012),
+                (-98.4896, 29.42012),
+            ]
+        ),
+        20.0,
+        BuildingHeightQuality.EXPLICIT,
+    )
+
+    assert night.elevation_degrees < 0
+    assert route_shade_percent(route, (building,), night) == 0.0
 
 
 def test_nighttime_has_zero_modeled_building_shade() -> None:

--- a/tests/test_route_shade.py
+++ b/tests/test_route_shade.py
@@ -157,6 +157,35 @@ def test_nighttime_has_zero_modeled_building_shade() -> None:
     assert route_shade_percent(route, (building,), SolarPosition(180.0, 0.0)) == 0.0
 
 
+def test_a_courtyard_casts_no_shadow_across_its_own_open_sky() -> None:
+    # A 100 m block around a 55 m courtyard; a 10 m wall throws 10 m of shadow at 45 deg.
+    building = BuildingFootprint(
+        "relation/1",
+        Polygon(
+            [
+                (-98.4900, 29.4200),
+                (-98.4890, 29.4200),
+                (-98.4890, 29.4209),
+                (-98.4900, 29.4209),
+            ],
+            [
+                [
+                    (-98.48975, 29.42020),
+                    (-98.48925, 29.42020),
+                    (-98.48925, 29.42070),
+                    (-98.48975, 29.42070),
+                ]
+            ],
+        ),
+        10.0,
+        BuildingHeightQuality.EXPLICIT,
+    )
+    route = LineString([(-98.48965, 29.42045), (-98.48935, 29.42045)])
+
+    # A convex hull over the swept footprint would wrongly report this route fully shaded.
+    assert route_shade_percent(route, (building,), SolarPosition(0.0, 45.0)) == 0.0
+
+
 def test_shadow_union_returns_a_bounded_finite_percentage() -> None:
     route = LineString([(-98.49, 29.42), (-98.489, 29.42)])
     building = BuildingFootprint(

--- a/tests/test_route_shade_geometry.py
+++ b/tests/test_route_shade_geometry.py
@@ -1,0 +1,390 @@
+"""Overpass building geometry normalization: rings, holes, drops, and part partitioning."""
+
+from typing import Any
+
+import pytest
+from shapely.geometry import Polygon
+from shapely.ops import unary_union
+
+from app.domain.route_shade import BuildingHeightQuality
+from app.services.route_shade import _normalize_buildings
+
+
+def _points(*coordinates: tuple[float, float]) -> list[dict[str, float]]:
+    return [{"lat": latitude, "lon": longitude} for longitude, latitude in coordinates]
+
+
+def _square(
+    west: float, south: float, size: float, *, closed: bool = True
+) -> list[dict[str, float]]:
+    corners = [
+        (west, south),
+        (west + size, south),
+        (west + size, south + size),
+        (west, south + size),
+    ]
+    return _points(*(corners + [corners[0]] if closed else corners))
+
+
+def _way(identity: int, geometry: list[dict[str, float]], **tags: str) -> dict[str, Any]:
+    return {"type": "way", "id": identity, "tags": tags, "geometry": geometry}
+
+
+def _relation(identity: int, members: list[dict[str, Any]], **tags: str) -> dict[str, Any]:
+    return {
+        "type": "relation",
+        "id": identity,
+        "tags": {"type": "multipolygon", **tags},
+        "members": members,
+    }
+
+
+def _member(geometry: list[dict[str, float]] | None, role: str = "outer") -> dict[str, Any]:
+    member: dict[str, Any] = {"type": "way", "ref": 1, "role": role}
+    if geometry is not None:
+        member["geometry"] = geometry
+    return member
+
+
+def _area(response: dict[str, Any]) -> float:
+    buildings, _ = _normalize_buildings(response)
+    return float(unary_union([building.geometry for building in buildings]).area)
+
+
+def test_relation_inner_rings_become_courtyard_holes() -> None:
+    outer = _square(-98.49, 29.42, 0.004)
+    courtyard = _square(-98.489, 29.421, 0.002)
+    response = {
+        "elements": [
+            _relation(
+                1,
+                [_member(outer, "outer"), _member(courtyard, "inner")],
+                building="hotel",
+                height="40",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert dropped == 0
+    assert len(buildings) == 1
+    geometry = buildings[0].geometry
+    expected = (
+        Polygon([(point["lon"], point["lat"]) for point in outer]).area
+        - Polygon([(point["lon"], point["lat"]) for point in courtyard]).area
+    )
+    assert geometry.area == pytest.approx(expected, rel=1e-9)
+    # The courtyard centre is open sky, not building.
+    assert not geometry.contains(Polygon([(point["lon"], point["lat"]) for point in courtyard]))
+
+
+def test_fragmented_outer_ways_are_stitched_into_one_ring() -> None:
+    whole = _square(-98.49, 29.42, 0.004)
+    first, second = whole[:3], whole[2:]
+    response = {
+        "elements": [
+            _relation(
+                2,
+                [_member(first, "outer"), _member(second, "outer")],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert dropped == 0
+    assert len(buildings) == 1
+    assert buildings[0].geometry.geom_type == "Polygon"
+    assert buildings[0].geometry.area == pytest.approx(
+        Polygon([(point["lon"], point["lat"]) for point in whole]).area, rel=1e-9
+    )
+
+
+def test_fragmented_outer_ways_stitch_regardless_of_member_direction() -> None:
+    whole = _square(-98.49, 29.42, 0.004)
+    first, second = whole[:3], list(reversed(whole[2:]))
+    response = {
+        "elements": [
+            _relation(
+                3,
+                [_member(second, "outer"), _member(first, "outer")],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert dropped == 0
+    assert buildings[0].geometry.area == pytest.approx(
+        Polygon([(point["lon"], point["lat"]) for point in whole]).area, rel=1e-9
+    )
+
+
+def test_a_fragmented_outer_ring_with_a_gap_drops_the_whole_relation() -> None:
+    whole = _square(-98.49, 29.42, 0.004)
+    detached = _points((-98.470, 29.410), (-98.469, 29.411))
+    response = {
+        "elements": [
+            _relation(
+                4,
+                [_member(whole[:3], "outer"), _member(detached, "outer")],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert buildings == ()
+    assert dropped == 1
+
+
+def test_malformed_relation_members_are_counted_while_valid_rings_survive() -> None:
+    outer = _square(-98.49, 29.42, 0.004)
+    response = {
+        "elements": [
+            _relation(
+                5,
+                [
+                    _member(outer, "outer"),
+                    _member(None, "outer"),
+                    _member([{"lat": 91.0, "lon": -98.48}, {"lat": 29.42, "lon": -98.48}], "inner"),
+                    "not a member",  # type: ignore[list-item]
+                ],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert len(buildings) == 1
+    assert dropped == 3
+    assert buildings[0].geometry.area == pytest.approx(
+        Polygon([(point["lon"], point["lat"]) for point in outer]).area, rel=1e-9
+    )
+
+
+def test_a_relation_without_any_usable_outer_ring_counts_as_one_dropped_building() -> None:
+    response = {
+        "elements": [
+            _relation(
+                6,
+                [_member(None, "outer"), _member(None, "inner")],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert buildings == ()
+    assert dropped == 1
+
+
+def test_node_and_sub_relation_members_discard_no_area() -> None:
+    outer = _square(-98.49, 29.42, 0.004)
+    response = {
+        "elements": [
+            _relation(
+                7,
+                [
+                    _member(outer, "outer"),
+                    {"type": "node", "ref": 9, "role": "label"},
+                    {"type": "relation", "ref": 8, "role": "outer"},
+                ],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert dropped == 0
+    assert len(buildings) == 1
+
+
+def test_inner_ring_covering_the_whole_outer_ring_leaves_no_building() -> None:
+    outer = _square(-98.49, 29.42, 0.004)
+    response = {
+        "elements": [
+            _relation(
+                8,
+                [_member(outer, "outer"), _member(outer, "inner")],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert buildings == ()
+    assert dropped == 1
+
+
+def test_disjoint_outer_rings_stay_a_single_multipolygon_building() -> None:
+    response = {
+        "elements": [
+            _relation(
+                9,
+                [
+                    _member(_square(-98.49, 29.42, 0.001), "outer"),
+                    _member(_square(-98.48, 29.43, 0.001), "outer"),
+                ],
+                building="yes",
+                height="20",
+            )
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert dropped == 0
+    assert len(buildings) == 1
+    assert buildings[0].geometry.geom_type == "MultiPolygon"
+
+
+def test_parent_and_part_partitioning_preserves_total_effective_area() -> None:
+    parent = _square(-98.49, 29.42, 0.004)
+    part = _square(-98.489, 29.421, 0.002)
+    response: dict[str, Any] = {
+        "elements": [
+            _way(101, parent, building="office", height="30"),
+            _way(102, part, **{"building:part": "yes", "height": "70"}),
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert dropped == 0
+    raw_union = unary_union(
+        [
+            Polygon([(point["lon"], point["lat"]) for point in parent]),
+            Polygon([(point["lon"], point["lat"]) for point in part]),
+        ]
+    )
+    effective = unary_union([building.geometry for building in buildings])
+    assert effective.area == pytest.approx(raw_union.area, rel=1e-9)
+    # Effective footprints partition the union: no pair overlaps.
+    total = sum(building.geometry.area for building in buildings)
+    assert total == pytest.approx(effective.area, rel=1e-9)
+
+
+def test_a_part_keeps_its_own_height_and_never_inherits_the_parent() -> None:
+    response: dict[str, Any] = {
+        "elements": [
+            _way(201, _square(-98.49, 29.42, 0.004), building="office", height="30"),
+            _way(
+                202,
+                _square(-98.489, 29.421, 0.002),
+                **{"building:part": "yes", "building:levels": "9"},
+            ),
+        ]
+    }
+
+    buildings, _ = _normalize_buildings(response)
+
+    by_identity = {building.identity: building for building in buildings}
+    assert by_identity["way/202"].height_m == pytest.approx(27.0)
+    assert by_identity["way/202"].height_quality is BuildingHeightQuality.INFERRED_LEVELS
+    assert by_identity["way/201"].height_m == pytest.approx(30.0)
+    assert by_identity["way/201"].height_quality is BuildingHeightQuality.EXPLICIT
+
+
+def test_overlapping_parts_are_never_double_counted() -> None:
+    first = _square(-98.49, 29.42, 0.003)
+    second = _square(-98.4885, 29.4215, 0.003)
+    response: dict[str, Any] = {
+        "elements": [
+            _way(301, first, **{"building:part": "yes", "height": "40"}),
+            _way(302, second, **{"building:part": "yes", "height": "60"}),
+        ]
+    }
+
+    buildings, _ = _normalize_buildings(response)
+
+    expected = unary_union(
+        [
+            Polygon([(point["lon"], point["lat"]) for point in first]),
+            Polygon([(point["lon"], point["lat"]) for point in second]),
+        ]
+    )
+    assert sum(building.geometry.area for building in buildings) == pytest.approx(
+        expected.area, rel=1e-9
+    )
+
+
+def test_a_part_covering_its_parent_entirely_replaces_it() -> None:
+    footprint = _square(-98.49, 29.42, 0.003)
+    response: dict[str, Any] = {
+        "elements": [
+            _way(401, footprint, building="office", height="30"),
+            _way(402, footprint, **{"building:part": "yes", "height": "80"}),
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert dropped == 0
+    assert [building.identity for building in buildings] == ["way/402"]
+    assert buildings[0].height_m == pytest.approx(80.0)
+
+
+def test_an_unclosed_standalone_way_is_dropped() -> None:
+    response = {
+        "elements": [
+            _way(501, _square(-98.49, 29.42, 0.003, closed=False), building="yes", height="20")
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert buildings == ()
+    assert dropped == 1
+
+
+def test_untagged_and_non_building_elements_are_skipped_without_counting_drops() -> None:
+    response = {
+        "elements": [
+            _way(601, _square(-98.49, 29.42, 0.003), highway="footway"),
+            {"type": "way", "id": 602, "geometry": _square(-98.48, 29.43, 0.003)},
+            {"type": "node", "id": 603, "tags": {"building": "yes"}},
+        ]
+    }
+
+    buildings, dropped = _normalize_buildings(response)
+
+    assert buildings == ()
+    assert dropped == 0
+
+
+def test_a_courtyard_hole_removes_exactly_its_own_area_from_the_building() -> None:
+    outer = _square(-98.49, 29.42, 0.006)
+    courtyard = _square(-98.4885, 29.4215, 0.003)
+    solid = _area({"elements": [_relation(701, [_member(outer, "outer")], building="yes")]})
+    hollow = _area(
+        {
+            "elements": [
+                _relation(
+                    702,
+                    [_member(outer, "outer"), _member(courtyard, "inner")],
+                    building="yes",
+                )
+            ]
+        }
+    )
+
+    assert hollow < solid
+    assert solid - hollow == pytest.approx(
+        Polygon([(point["lon"], point["lat"]) for point in courtyard]).area, rel=1e-9
+    )

--- a/tests/test_route_shade_service.py
+++ b/tests/test_route_shade_service.py
@@ -1,0 +1,236 @@
+"""Per-route shade coverage, height-quality fractions, and confidence thresholds."""
+
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.domain.contracts import Confidence, Provenance, RouteDecisionState
+from app.domain.route_decision import RouteDecisionInput, decide_route_comparison
+from app.domain.route_heat import RouteHeatEvidence
+from app.domain.route_shade import RouteShadeEvidence, ShadeConfidence, solar_position
+from app.domain.routing import ReturnedRoute, RouteGeometry, RouteSet
+from app.services.building_execution import BuildingExecution
+from app.services.route_shade import RouteShadeService
+
+ENDPOINT = "https://overpass.example/api/interpreter"
+INSTANT = datetime(2026, 8, 29, 10, 30, tzinfo=ZoneInfo("America/Chicago"))
+SOLAR = solar_position(INSTANT, 29.4250, -98.4860)
+
+# Mid-morning here the sun sits east-southeast, so shadows fall roughly 30 m west
+# of a 30 m building. Both routes run north-south; buildings sit just east of one.
+ROUTE_LON = -98.4860
+FAR_ROUTE_LON = -98.4600
+BUILDING_WEST = ROUTE_LON + 0.00015
+BUILDING_EAST = ROUTE_LON + 0.00040
+
+NEAR_ROUTE = RouteGeometry(((ROUTE_LON, 29.4230), (ROUTE_LON, 29.4270)))
+FAR_ROUTE = RouteGeometry(((FAR_ROUTE_LON, 29.4230), (FAR_ROUTE_LON, 29.4270)))
+
+
+def _routes(*geometries: RouteGeometry) -> RouteSet:
+    return RouteSet(
+        tuple(
+            ReturnedRoute(f"route-{index}", 900.0 + index, 700.0 + index, geometry)
+            for index, geometry in enumerate(geometries or (NEAR_ROUTE,), start=1)
+        ),
+        "fossgis-routed-foot",
+    )
+
+
+def _ring(west: float, south: float, east: float, north: float) -> list[dict[str, float]]:
+    corners = [(west, south), (east, south), (east, north), (west, north), (west, south)]
+    return [{"lat": latitude, "lon": longitude} for longitude, latitude in corners]
+
+
+def _building(identity: int, south: float, span: float, **tags: str) -> dict[str, Any]:
+    """One building just east of the near route, `span` degrees of latitude tall."""
+    return {
+        "type": "way",
+        "id": identity,
+        "tags": tags,
+        "geometry": _ring(BUILDING_WEST, south, BUILDING_EAST, south + span),
+    }
+
+
+def _payload(*elements: Any) -> dict[str, Any]:
+    return {
+        "version": 0.6,
+        "osm3s": {"timestamp_osm_base": "2026-08-24T18:03:11Z"},
+        "elements": list(elements),
+    }
+
+
+def _all_evidence(
+    payload: dict[str, Any], *, routes: RouteSet | None = None, **overrides: Any
+) -> dict[str, RouteShadeEvidence]:
+    service = RouteShadeService(
+        BuildingExecution(
+            live_loader=lambda aoi: payload,
+            endpoint=ENDPOINT,
+            search_distance_m=250.0,
+            clock=lambda: datetime(2026, 8, 30, 9, tzinfo=timezone.utc),
+        ),
+        **overrides,
+    )
+    return dict(service.load(routes or _routes(), SOLAR, INSTANT).evidence)
+
+
+def _evidence(payload: dict[str, Any], **overrides: Any) -> RouteShadeEvidence:
+    return _all_evidence(payload, **overrides)["route-1"]
+
+
+def test_area_fractions_split_explicit_inferred_and_unknown_by_area() -> None:
+    payload = _payload(
+        _building(1, 29.4235, 0.0004, building="office", height="30"),
+        _building(2, 29.4242, 0.0004, building="yes", **{"building:levels": "9"}),
+        _building(3, 29.4249, 0.0004, building="yes"),
+    )
+
+    evidence = _evidence(payload)
+
+    assert evidence.explicit_area_fraction == pytest.approx(1 / 3, abs=1e-3)
+    assert evidence.inferred_levels_area_fraction == pytest.approx(1 / 3, abs=1e-3)
+    assert evidence.unknown_area_fraction == pytest.approx(1 / 3, abs=1e-3)
+    assert evidence.building_coverage == pytest.approx(2 / 3, abs=1e-3)
+    counts = (evidence.explicit_count, evidence.inferred_levels_count, evidence.unknown_count)
+    assert counts == (1, 1, 1)
+    # Two thirds of the known-height area falls short of the 70% minimum.
+    assert evidence.confidence is ShadeConfidence.INSUFFICIENT
+    # The unknown-height building shades nothing, but it still occupies its area.
+    assert 0 < evidence.modeled_shade_percent < 100
+
+
+def test_zero_relevant_building_area_is_insufficient_with_no_modeled_shade() -> None:
+    # The only building stands beside the far route, kilometres from this corridor.
+    payload = _payload(
+        {
+            "type": "way",
+            "id": 10,
+            "tags": {"building": "yes", "height": "30"},
+            "geometry": _ring(FAR_ROUTE_LON + 0.00015, 29.4235, FAR_ROUTE_LON + 0.0004, 29.4239),
+        }
+    )
+
+    evidence = _evidence(payload)
+
+    assert evidence.modeled_shade_percent == 0.0
+    assert evidence.building_coverage == 0.0
+    assert evidence.explicit_area_fraction == 0.0
+    assert evidence.unknown_area_fraction == 0.0
+    assert (evidence.explicit_count, evidence.unknown_count) == (0, 0)
+    assert evidence.confidence is ShadeConfidence.INSUFFICIENT
+
+
+def test_malformed_geometry_forces_insufficient_confidence_despite_full_coverage() -> None:
+    payload = _payload(
+        _building(11, 29.4235, 0.0004, building="office", height="30"),
+        # Three points that never close: a real building whose geometry is unusable.
+        {
+            "type": "way",
+            "id": 12,
+            "tags": {"building": "yes", "height": "24"},
+            "geometry": _ring(BUILDING_WEST, 29.4245, BUILDING_EAST, 29.4249)[:3],
+        },
+    )
+
+    evidence = _evidence(payload)
+
+    assert evidence.building_coverage == pytest.approx(1.0)
+    assert evidence.dropped_geometry_count == 1
+    # Known heights alone cannot carry confidence while geometry is missing.
+    assert evidence.confidence is ShadeConfidence.INSUFFICIENT
+
+
+def test_coverage_at_the_minimum_is_sufficient_and_a_hair_below_it_is_not() -> None:
+    # Equal-longitude rectangles: projected area follows their latitude heights, 7:3.
+    payload = _payload(
+        _building(21, 29.4235, 0.0007, building="office", height="30"),
+        _building(22, 29.4245, 0.0003, building="yes"),
+    )
+
+    measured = _evidence(payload).building_coverage
+
+    assert measured == pytest.approx(0.70, abs=1e-3)
+    assert _evidence(payload, minimum_building_coverage=measured).confidence is (
+        ShadeConfidence.SUFFICIENT
+    )
+    assert _evidence(payload, minimum_building_coverage=measured + 1e-9).confidence is (
+        ShadeConfidence.INSUFFICIENT
+    )
+
+
+def test_relation_courtyards_and_building_parts_reach_route_evidence() -> None:
+    def _relation(*members: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "type": "relation",
+            "id": 31,
+            "tags": {"type": "multipolygon", "building": "hotel", "height": "40"},
+            "members": list(members),
+        }
+
+    def _member(geometry: list[dict[str, float]], role: str) -> dict[str, Any]:
+        return {"type": "way", "ref": 1, "role": role, "geometry": geometry}
+
+    outer = _member(_ring(BUILDING_WEST, 29.4235, BUILDING_EAST + 0.0006, 29.4245), "outer")
+    courtyard = _member(
+        _ring(BUILDING_WEST + 0.0002, 29.4237, BUILDING_EAST + 0.0004, 29.4243), "inner"
+    )
+    parent = _building(32, 29.4255, 0.0004, building="yes", **{"building:levels": "9"})
+    part = _building(33, 29.4256, 0.0002, height="60", **{"building:part": "yes"})
+
+    evidence = _evidence(_payload(_relation(outer, courtyard), parent, part))
+
+    # The relation and the part carry explicit heights; the parent way infers its own.
+    assert (evidence.explicit_count, evidence.inferred_levels_count) == (2, 1)
+    assert evidence.unknown_count == 0
+    assert evidence.building_coverage == pytest.approx(1.0)
+    assert evidence.dropped_geometry_count == 0
+    solid = _evidence(_payload(_relation(outer), parent, part))
+    # A courtyard is open sky: it can never add shade over the solid footprint.
+    assert 0 < evidence.modeled_shade_percent <= solid.modeled_shade_percent
+
+
+def test_each_route_gets_the_evidence_of_its_own_corridor() -> None:
+    payload = _payload(_building(41, 29.4235, 0.0020, building="office", height="30"))
+
+    evidence = _all_evidence(payload, routes=_routes(NEAR_ROUTE, FAR_ROUTE))
+
+    assert evidence["route-1"].confidence is ShadeConfidence.SUFFICIENT
+    assert evidence["route-1"].modeled_shade_percent > 0
+    assert evidence["route-2"].confidence is ShadeConfidence.INSUFFICIENT
+    assert evidence["route-2"].modeled_shade_percent == 0.0
+
+
+def test_one_route_without_shade_evidence_blocks_any_recommendation() -> None:
+    payload = _payload(_building(51, 29.4235, 0.0020, building="office", height="30"))
+    routes = _routes(NEAR_ROUTE, FAR_ROUTE)
+    provenance = Provenance(
+        source="provider",
+        data_date="2026-08-29",
+        confidence=Confidence.SUFFICIENT,
+        retrieved_at="2026-08-29T15:30:00+00:00",
+        transformation_version="route-v1",
+        provider="test",
+        response_status="completed",
+        request_configuration={},
+        fresh=True,
+    )
+
+    result = decide_route_comparison(
+        RouteDecisionInput(
+            routes,
+            None,
+            tuple(RouteHeatEvidence(route.identity, 39.0, 0.8, True, 1) for route in routes.routes),
+            shade_evidence=_all_evidence(payload, routes=routes),
+        ),
+        cautious=False,
+        provenance=provenance,
+        routing_provenance=provenance,
+        heat_provenance=provenance,
+    )
+
+    assert result.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED
+    assert result.recommended_id is None
+    assert all(not route.recommended for route in result.alternatives)

--- a/tests/test_routing_contracts.py
+++ b/tests/test_routing_contracts.py
@@ -75,6 +75,8 @@ def _comparison(
     route_set_state: RouteSetState,
     decision_state: RouteDecisionState,
     recommended_id: str | None,
+    building_provenance: Provenance | None = None,
+    solar_provenance: Provenance | None = None,
 ) -> RouteComparisonResult:
     values = [route.heat_value for route in alternatives if route.heat_value is not None]
     return RouteComparisonResult(
@@ -99,6 +101,8 @@ def _comparison(
         else None,
         routing_provenance=_provenance("osrm"),
         heat_provenance=_provenance("fortyguard") if values else None,
+        building_provenance=building_provenance,
+        solar_provenance=solar_provenance,
     )
 
 
@@ -215,3 +219,27 @@ def test_heat_unavailable_routes_carry_no_heat_or_recommendation() -> None:
             decision_state=RouteDecisionState.HEAT_UNAVAILABLE,
             recommended_id=None,
         )
+
+
+def test_building_provenance_requires_the_solar_position_it_was_modeled_at() -> None:
+    with pytest.raises(ValueError, match="building provenance requires the solar position"):
+        _comparison(
+            (_option("route-1", 900.0, recommended=True),),
+            route_set_state=RouteSetState.SINGLE_ROUTE,
+            decision_state=RouteDecisionState.MILD_SHORTEST_RECOMMENDED,
+            recommended_id="route-1",
+            building_provenance=_provenance("overpass"),
+        )
+
+
+def test_solar_provenance_may_stand_alone_for_nighttime_decisions() -> None:
+    result = _comparison(
+        (_option("route-1", 900.0, recommended=True),),
+        route_set_state=RouteSetState.SINGLE_ROUTE,
+        decision_state=RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED,
+        recommended_id="route-1",
+        solar_provenance=_provenance("astral"),
+    )
+
+    assert result.building_provenance is None
+    assert result.solar_provenance is not None and result.solar_provenance.provider == "astral"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,6 +7,7 @@ from app.settings import (
     FortyGuardAreaSettings,
     FortyGuardPollingSettings,
     OverpassSettings,
+    ShadeSettings,
     SettingsError,
     load_settings,
 )
@@ -196,6 +197,31 @@ def test_invalid_overpass_policy_or_district_bounds_are_rejected() -> None:
         load_settings(environ={"OVERPASS_RETRY_DELAY_SECONDS": "inf"})
     with pytest.raises(SettingsError, match="HOTEL_DISTRICT_BBOX"):
         load_settings(environ={"HOTEL_DISTRICT_BBOX": "29.5,-98.5,29.4,-98.4"})
+
+
+def test_shade_policy_defaults_and_overrides_are_validated() -> None:
+    assert load_settings(environ={}).shade == ShadeSettings()
+    settings = load_settings(
+        environ={
+            "SHADE_BUILDING_SEARCH_DISTANCE_M": "300",
+            "SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE": "0.75",
+            "SHADE_METRES_PER_LEVEL": "3.2",
+            "TRIP_CANONICAL_TIMEZONE": "America/New_York",
+        }
+    ).shade
+    assert settings.building_search_distance_m == 300.0
+    assert settings.minimum_building_height_coverage == 0.75
+    assert settings.metres_per_level == 3.2
+    assert settings.canonical_timezone == "America/New_York"
+
+
+def test_invalid_shade_policy_is_rejected() -> None:
+    with pytest.raises(SettingsError, match="SHADE_BUILDING_SEARCH_DISTANCE_M"):
+        load_settings(environ={"SHADE_BUILDING_SEARCH_DISTANCE_M": "0"})
+    with pytest.raises(SettingsError, match="SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE"):
+        load_settings(environ={"SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE": "1.1"})
+    with pytest.raises(SettingsError, match="TRIP_CANONICAL_TIMEZONE"):
+        load_settings(environ={"TRIP_CANONICAL_TIMEZONE": "Not/AZone"})
 
 
 def test_call_budget_defaults_to_record_only_and_is_overridable() -> None:

--- a/tests/test_trip_domain.py
+++ b/tests/test_trip_domain.py
@@ -51,7 +51,7 @@ def test_route_comparator_fetches_routes_once_and_uses_shortest_when_heat_is_low
     assert result.shade_was_computed is False
 
 
-def test_route_comparator_uses_maximum_heat_and_weak_coverage_shortest_fallback() -> None:
+def test_route_comparator_uses_maximum_heat_and_weak_coverage_has_no_fallback() -> None:
     result = RouteComparator().compare(
         lambda: [RouteCandidate("short", 1000, 600), RouteCandidate("shady", 1200, 700)],
         heat_value=38,
@@ -61,8 +61,8 @@ def test_route_comparator_uses_maximum_heat_and_weak_coverage_shortest_fallback(
         building_coverage=0.5,
     )
     assert result.corridor_heat_value == 38
-    assert result.recommended_id == "short"
-    assert result.reason == "insufficient shade coverage"
+    assert result.recommended_id is None
+    assert result.reason == "insufficient shade coverage; traveler comparison required"
     assert result.shade_was_computed is True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,18 @@ wheels = [
 ]
 
 [[package]]
+name = "astral"
+version = "3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/d1/1adbf06a38dc339e41a1666f6c7135924594c20fd46e060fb263248c564d/astral-3.2.tar.gz", hash = "sha256:9b7c3b412e9e69d172cfb24be0e6addcc9f1bd01a28db8bebe66d75ccc533d88", size = 48075, upload-time = "2022-11-05T18:12:02.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/80/d6edd9c3259913cfe39aff2bea4da65de5ad0235a578405e37aabace5f2c/astral-3.2-py3-none-any.whl", hash = "sha256:cb7b49a3f0d4c64ae666be131276d2a3226134c598db10e672028cf8ff855f83", size = 38325, upload-time = "2022-11-05T18:12:01.164Z" },
+]
+
+[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +314,7 @@ name = "heat-aware-tourism-guide"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "astral" },
     { name = "fastapi" },
     { name = "pyproj" },
     { name = "shapely" },
@@ -322,6 +335,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "astral", specifier = "==3.2" },
     { name = "fastapi", specifier = "==0.141.1" },
     { name = "httpx2", marker = "extra == 'dev'", specifier = "==2.12.0" },
     { name = "httpx2", marker = "extra == 'test'", specifier = "==2.12.0" },
@@ -340,8 +354,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
-    { name = "truststore", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1216,6 +1230,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces support for modeled building shade and building height provenance in route recommendations, along with several new route decision states and related contract and validation updates. The changes add new fields to route comparison and option models, clarify the meaning and requirements of shade and building evidence, and update documentation to describe these new concepts and policies.

**Major new features and provenance tracking:**

* `app/domain/contracts.py`, `app/domain/route_decision.py`: Added support for modeled building shade, including new fields for `building_provenance` and `solar_provenance` in `RouteComparisonResult` and corresponding propagation in the decision pipeline. [[1]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R884-R885) [[2]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R918-R919) [[3]](diffhunk://#diff-2afbd352a7c30db03f72452f69f97032d6959610012a0d95381781e7796dd33dR44-R45) [[4]](diffhunk://#diff-2afbd352a7c30db03f72452f69f97032d6959610012a0d95381781e7796dd33dR55-R56) [[5]](diffhunk://#diff-2afbd352a7c30db03f72452f69f97032d6959610012a0d95381781e7796dd33dR74-R75) [[6]](diffhunk://#diff-2afbd352a7c30db03f72452f69f97032d6959610012a0d95381781e7796dd33dR112-R113)
* `app/domain/contracts.py`, `app/domain/route_decision.py`: Introduced new route decision states for shade-based and nighttime recommendations, and updated validation logic to enforce correct recommendations for these states. [[1]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R60-R73) [[2]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R982-R994) [[3]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R1148-R1151)

**Contract and evidence model enhancements:**

* `app/domain/contracts.py`, `app/domain/route_decision.py`: Added new fields to `RouteOption` for detailed building height quality fractions and counts, as well as `shade_limitations`, with validation to ensure their correctness. [[1]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L744-R770) [[2]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R779-R796) [[3]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R816-R837)
* [`app/domain/contracts.py`](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R60-R73): Added `TemporalEvidenceState` and corresponding fields and validation to `BestTimeResult` to track the temporal precision of recommendations. [[1]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R60-R73) [[2]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R573-R575) [[3]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R625-R636)
* `app/domain/contracts.py`, `app/domain/route_decision.py`: Updated shade confidence typing to use `ShadeConfidence` instead of a generic confidence type. [[1]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2R17) [[2]](diffhunk://#diff-56f01f36d20e6c90c4421eed5ecff33522079e20d5d5c29a5554c9b39f2255d2L744-R770) [[3]](diffhunk://#diff-2afbd352a7c30db03f72452f69f97032d6959610012a0d95381781e7796dd33dR19)

**Documentation updates:**

* `AGENTS.md`, `CONTEXT.md`: Documented the new modeled shade and building height provenance concepts, nighttime decision logic, and the policy for Python environment usage. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R4) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R145-R166) [[3]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R185-R186)