### PR TITLE
feat: Add exploratory mode and unavailable-scenario handling

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -10,7 +10,7 @@ import json
 import math
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
@@ -23,6 +23,8 @@ from app.domain.contracts import (
     TripAnalysisRequest,
     TripAnalysisResponse,
     TripMode,
+    ResultState,
+    UnavailableResult,
 )
 from app.domain.ledger import BudgetExceededError
 from app.domain.hotel_heat_score import COMPONENTS, NeighbourhoodHeatScorer
@@ -93,6 +95,50 @@ def create_fixture_server(
     )
 
     class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path != "/api/places/search":
+                self.send_error(404)
+                return
+            query = str(parse_qs(parsed.query).get("q", [""])[0]).strip()
+            if len(query) < 2:
+                status = 400
+                payload: dict[str, object] = {
+                    "status": "error",
+                    "error": "search query must contain at least 2 characters",
+                }
+            else:
+                places: list[dict[str, object]] = [
+                    {
+                        "id": "menger-hotel",
+                        "name": "Menger Hotel",
+                        "context": "San Antonio, TX",
+                        "latitude": 29.4245914,
+                        "longitude": -98.4864288,
+                    },
+                    {
+                        "id": "the-alamo",
+                        "name": "The Alamo",
+                        "context": "San Antonio, TX",
+                        "latitude": 29.425833,
+                        "longitude": -98.485833,
+                    },
+                ]
+                status = 200
+                payload = {
+                    "places": [
+                        place
+                        for place in places
+                        if query.casefold() in str(place["name"]).casefold()
+                    ]
+                }
+            response = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+
         def do_POST(self) -> None:
             path = urlparse(self.path).path
             if path not in {"/api/heatmap", "/api/trip/analyze"}:
@@ -184,6 +230,39 @@ def create_app(
     @app.get("/health")
     def health() -> dict[str, str]:
         return {"status": "ok", "mode": "live" if allow_live else "fixture"}
+
+    @app.get("/api/places/search")
+    def places_search(q: str = "") -> dict[str, object]:
+        query = q.strip()
+        if len(query) < 2:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "status": "error",
+                    "error": "search query must contain at least 2 characters",
+                },
+            )
+        places: list[dict[str, object]] = [
+            {
+                "id": "menger-hotel",
+                "name": "Menger Hotel",
+                "context": "San Antonio, TX",
+                "latitude": 29.4245914,
+                "longitude": -98.4864288,
+            },
+            {
+                "id": "the-alamo",
+                "name": "The Alamo",
+                "context": "San Antonio, TX",
+                "latitude": 29.425833,
+                "longitude": -98.485833,
+            },
+        ]
+        return {
+            "places": [
+                place for place in places if query.casefold() in str(place["name"]).casefold()
+            ]
+        }
 
     @app.post("/api/heatmap")
     def heatmap(body: dict[str, object]) -> dict[str, object]:
@@ -400,7 +479,7 @@ def _parse_trip_request(body: dict[str, object]) -> TripAnalysisRequest:
     if not isinstance(mode, str):
         raise ValueError("mode must be curated or exploratory")
 
-    return TripAnalysisRequest(
+    request = TripAnalysisRequest(
         mode=TripMode(mode),
         origin=Coordinates(origin_lat, origin_lon),
         destination=Coordinates(dest_lat, dest_lon),
@@ -411,6 +490,19 @@ def _parse_trip_request(body: dict[str, object]) -> TripAnalysisRequest:
         end_hour=end_hour,
         cautious=_required_bool(body, "cautious", default=False),
     )
+    return request
+
+
+def _validate_trip_mode(request: TripAnalysisRequest) -> None:
+    if request.mode is TripMode.CURATED and (
+        request.landmark_name != "The Alamo"
+        or request.district_name != "Downtown San Antonio"
+        or not math.isclose(request.origin.latitude, 29.4245914, abs_tol=1e-5)
+        or not math.isclose(request.origin.longitude, -98.4864288, abs_tol=1e-5)
+        or not math.isclose(request.destination.latitude, 29.425833, abs_tol=1e-5)
+        or not math.isclose(request.destination.longitude, -98.485833, abs_tol=1e-5)
+    ):
+        raise ValueError("curated trips must use the canonical Menger Hotel to The Alamo scenario")
 
 
 def _trip_result(
@@ -422,6 +514,22 @@ def _trip_result(
     """Run the trip analysis and serialize the shared product contract."""
     execution_mode = _execution_mode(body, allow_live=allow_live)
     request = _parse_trip_request(body)
+    _validate_trip_mode(request)
+    if execution_mode is ExecutionMode.LIVE and not _supported_live_geography(request):
+        return asdict(
+            TripAnalysisResponse(
+                request_identity=f"{request.mode.value}:{request.date}:{request.start_hour}-{request.end_hour}",
+                mode=request.mode,
+                execution_mode=execution_mode,
+                state=ResultState.UNAVAILABLE,
+                unavailable=UnavailableResult(
+                    "Live provider data is supported only for endpoints in the United States.",
+                    True,
+                    "unsupported_geography",
+                    "choose_us_endpoints",
+                ),
+            )
+        )
     if trip_adapter is None:
         raise ValueError("trip analysis adapter is not configured")
     response = trip_adapter.analyze(request, execution_mode)
@@ -430,6 +538,14 @@ def _trip_result(
     if response.execution_mode is not execution_mode:
         raise ValueError("trip adapter returned the wrong execution mode")
     return asdict(response)
+
+
+def _supported_live_geography(request: TripAnalysisRequest) -> bool:
+    """Apply the product's coarse US live-data boundary before provider calls."""
+    for point in (request.origin, request.destination):
+        if not 18.0 <= point.latitude <= 72.0 or not -180.0 <= point.longitude <= -65.0:
+            return False
+    return True
 
 
 def _execution_mode(body: dict[str, object], *, allow_live: bool) -> ExecutionMode:

--- a/app/domain/contracts.py
+++ b/app/domain/contracts.py
@@ -1039,10 +1039,14 @@ class UnavailableResult:
 
     reason: str
     recoverable: bool
+    code: str = "scenario_unavailable"
+    action: str | None = None
 
     def __post_init__(self) -> None:
         if not self.reason:
             raise ValueError("unavailability reason is required")
+        if not self.code:
+            raise ValueError("unavailability code is required")
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -77,8 +77,6 @@ class FixtureTripAnalysisAdapter:
             payload = json.load(fixture)
         if not isinstance(payload, Mapping):
             raise ValueError("trip fixture must contain an object")
-        if payload.get("unavailable") is not None:
-            return normalize_trip_analysis(payload, request, ExecutionMode.FIXTURE)
         scenario = _fixture_scenario(self.fixture_path, payload)
         if scenario is None or not _fixture_matches(scenario, request):
             return TripAnalysisResponse(
@@ -87,7 +85,14 @@ class FixtureTripAnalysisAdapter:
                 execution_mode=ExecutionMode.FIXTURE,
                 state=ResultState.UNAVAILABLE,
                 unavailable=UnavailableResult(
-                    "no matching fixture for the requested trip", recoverable=True
+                    (
+                        "no matching fixture for the requested exploratory trip"
+                        if request.mode is TripMode.EXPLORATORY
+                        else "no matching fixture for the requested trip"
+                    ),
+                    recoverable=True,
+                    code="scenario_unavailable",
+                    action="edit_setup_or_use_live_data",
                 ),
             )
         return normalize_trip_analysis(payload, request, ExecutionMode.FIXTURE)
@@ -143,12 +148,6 @@ class TemporalTripAnalysisAdapter:
     ) -> TripAnalysisResponse:
         if execution_mode is not ExecutionMode.LIVE:
             raise ValueError("temporal trip adapter only supports live execution")
-        if request.mode is not TripMode.CURATED:
-            return _unavailable_response(
-                request,
-                execution_mode,
-                "temporal data preparation is only available for curated trips",
-            )
         analysis_date = date.fromisoformat(request.date)
         heatmap_request = HeatmapRequest(
             analytic_type=AnalyticType.TCM,
@@ -515,13 +514,17 @@ def _unavailable_response(
     request: TripAnalysisRequest,
     execution_mode: ExecutionMode,
     reason: str,
+    *,
+    code: str = "provider_data_missing",
+    recoverable: bool = True,
+    action: str | None = "retry_or_edit_setup",
 ) -> TripAnalysisResponse:
     return TripAnalysisResponse(
         request_identity=_request_identity(request),
         mode=request.mode,
         execution_mode=execution_mode,
         state=ResultState.UNAVAILABLE,
-        unavailable=UnavailableResult(reason, recoverable=True),
+        unavailable=UnavailableResult(reason, recoverable, code, action),
     )
 
 
@@ -1040,7 +1043,9 @@ def _fixture_matches(scenario: Mapping[str, object], request: TripAnalysisReques
     origin = _mapping(scenario.get("origin"), "scenario origin")
     destination = _mapping(scenario.get("destination"), "scenario destination")
     return (
-        _string(scenario.get("landmark_name"), "scenario landmark_name") == request.landmark_name
+        scenario.get("mode", TripMode.CURATED.value) == request.mode.value
+        and _string(scenario.get("landmark_name"), "scenario landmark_name")
+        == request.landmark_name
         and _string(scenario.get("district_name"), "scenario district_name")
         == request.district_name
         and _string(scenario.get("date"), "scenario date") == request.date

--- a/fixtures/trip-analysis-unavailable.acquisition.json
+++ b/fixtures/trip-analysis-unavailable.acquisition.json
@@ -1,9 +1,18 @@
 {
   "source": "synthesized",
   "endpoint": "/api/trip/analyze",
-  "request_configuration": {},
+  "request_configuration": {
+    "mode": "exploratory",
+    "landmark_name": "The Alamo",
+    "district_name": "Downtown San Antonio",
+    "date": "2026-08-23",
+    "start_hour": 8,
+    "end_hour": 20,
+    "origin": { "latitude": 29.4245914, "longitude": -98.4864288 },
+    "destination": { "latitude": 29.425833, "longitude": -98.485833 }
+  },
   "retrieved_at": null,
-  "data_date": null,
+  "data_date": "2026-08-23",
   "status": "unavailable",
   "schema_version": "trip-contract-v1",
   "provider_config_version": null,

--- a/fixtures/trip-analysis-unavailable.json
+++ b/fixtures/trip-analysis-unavailable.json
@@ -1,3 +1,13 @@
 {
+  "scenario": {
+    "mode": "exploratory",
+    "landmark_name": "The Alamo",
+    "district_name": "Downtown San Antonio",
+    "date": "2026-08-23",
+    "start_hour": 8,
+    "end_hour": 20,
+    "origin": { "latitude": 29.4245914, "longitude": -98.4864288 },
+    "destination": { "latitude": 29.425833, "longitude": -98.485833 }
+  },
   "unavailable": "no matching fixture for the requested exploratory trip"
 }

--- a/fixtures/trip-analysis.acquisition.json
+++ b/fixtures/trip-analysis.acquisition.json
@@ -3,6 +3,7 @@
   "endpoint": "/api/trip/analyze",
   "request_configuration": {
     "landmark_name": "The Alamo",
+    "mode": "curated",
     "district_name": "Downtown San Antonio",
     "date": "2026-08-23",
     "start_hour": 8,

--- a/frontend/src/screens/TripSetupScreen.tsx
+++ b/frontend/src/screens/TripSetupScreen.tsx
@@ -8,6 +8,12 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { Link } from "react-router-dom";
+import {
+  CircleMarker,
+  MapContainer,
+  TileLayer,
+  useMapEvents,
+} from "react-leaflet";
 import { useAppState } from "../app/AppState";
 import { dataClient } from "../services/dataClient";
 import type {
@@ -16,6 +22,7 @@ import type {
   HeatInterpretation,
   RouteComparisonResult,
   TripAnalysisRequest,
+  LocationSelection,
 } from "../types";
 
 const HOURS = Array.from({ length: 24 }, (_, hour) => hour);
@@ -24,6 +31,25 @@ type HealthState =
   | { status: "checking" | "unavailable" }
   | { status: "available"; mode: ExecutionMode };
 type RequestState = "idle" | "submitting" | "failed";
+
+function EndpointMap({
+  onSelect,
+}: {
+  onSelect: (point: LocationSelection) => void;
+}) {
+  useMapEvents({
+    click(event) {
+      onSelect({
+        id: `map-${event.latlng.lat}-${event.latlng.lng}`,
+        name: "Map selection",
+        context: "Selected directly on the map",
+        latitude: event.latlng.lat,
+        longitude: event.latlng.lng,
+      });
+    },
+  });
+  return null;
+}
 
 function validDate(value: string) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
@@ -301,9 +327,35 @@ export function TripSetupScreen() {
     setTripAnalysis,
   } = useAppState();
   const { date, startHour, endHour, cautious } = curatedTripSetup;
+  const [tripMode, setTripMode] = useState<"curated" | "exploratory">(
+    "curated"
+  );
+  const [origin, setOrigin] = useState<LocationSelection>({
+    id: "menger",
+    name: "Menger Hotel",
+    context: "San Antonio, TX",
+    latitude: 29.4245914,
+    longitude: -98.4864288,
+  });
+  const [destination, setDestination] = useState<LocationSelection>({
+    id: "alamo",
+    name: "The Alamo",
+    context: "San Antonio, TX",
+    latitude: 29.425833,
+    longitude: -98.485833,
+  });
+  const [activeEndpoint, setActiveEndpoint] = useState<
+    "origin" | "destination"
+  >("origin");
+  const [search, setSearch] = useState("");
+  const [searchResults, setSearchResults] = useState<LocationSelection[]>([]);
+  const [searchState, setSearchState] = useState<"idle" | "loading" | "error">(
+    "idle"
+  );
   const [dateError, setDateError] = useState("");
   const [startError, setStartError] = useState("");
   const [endError, setEndError] = useState("");
+  const [endpointError, setEndpointError] = useState("");
   const [health, setHealth] = useState<HealthState>({ status: "checking" });
   const [requestState, setRequestState] = useState<RequestState>("idle");
   const dateRef = useRef<HTMLInputElement>(null);
@@ -348,6 +400,10 @@ export function TripSetupScreen() {
     const invalidDate = !validDate(date);
     const invalidOrder = startHour >= endHour;
     const invalidLength = !invalidOrder && endHour - startHour > 12;
+    const invalidEndpoints =
+      tripMode === "exploratory" &&
+      origin.latitude === destination.latitude &&
+      origin.longitude === destination.longitude;
     setDateError(invalidDate ? "Enter a valid date." : "");
     setStartError(
       invalidOrder ? "Start time must be earlier than end time." : ""
@@ -359,22 +415,27 @@ export function TripSetupScreen() {
           ? "The time window cannot exceed 12 hours."
           : ""
     );
-    if (invalidDate || invalidOrder || invalidLength) {
+    setEndpointError(invalidEndpoints ? "Choose two different endpoints." : "");
+    if (invalidDate || invalidOrder || invalidLength || invalidEndpoints) {
       if (invalidDate) dateRef.current?.focus();
       else if (invalidOrder) startRef.current?.focus();
-      else endRef.current?.focus();
+      else if (invalidOrder || invalidLength) endRef.current?.focus();
+      else document.getElementById("endpoint-origin")?.focus();
       return;
     }
     if (health.status !== "available" || requestState === "submitting") return;
 
     const request: TripAnalysisRequest = {
-      mode: "curated",
-      origin_latitude: 29.4245914,
-      origin_longitude: -98.4864288,
-      destination_latitude: 29.425833,
-      destination_longitude: -98.485833,
-      landmark_name: "The Alamo",
-      district_name: "Downtown San Antonio",
+      mode: tripMode,
+      origin_latitude: tripMode === "curated" ? 29.4245914 : origin.latitude,
+      origin_longitude: tripMode === "curated" ? -98.4864288 : origin.longitude,
+      destination_latitude:
+        tripMode === "curated" ? 29.425833 : destination.latitude,
+      destination_longitude:
+        tripMode === "curated" ? -98.485833 : destination.longitude,
+      landmark_name: tripMode === "curated" ? "The Alamo" : destination.name,
+      district_name:
+        tripMode === "curated" ? "Downtown San Antonio" : destination.context,
       date,
       start_hour: startHour,
       end_hour: endHour,
@@ -384,7 +445,7 @@ export function TripSetupScreen() {
     setTripAnalysis(null);
     setRequestState("submitting");
     try {
-      const response = await dataClient.analyzeCuratedTrip(request);
+      const response = await dataClient.analyzeTripAnalysis(request);
       if (response.state === "error") {
         setRequestState("failed");
       } else {
@@ -393,6 +454,24 @@ export function TripSetupScreen() {
       }
     } catch {
       setRequestState("failed");
+    }
+  }
+
+  async function searchPlaces(value: string) {
+    setSearch(value);
+    if (value.trim().length < 2) {
+      setSearchResults([]);
+      setSearchState("idle");
+      return;
+    }
+    setSearchState("loading");
+    try {
+      const result = await dataClient.searchPlaces(value);
+      setSearchResults(result.places);
+      setSearchState("idle");
+    } catch {
+      setSearchState("error");
+      setSearchResults([]);
     }
   }
 
@@ -417,20 +496,129 @@ export function TripSetupScreen() {
           aria-busy={busy}
           noValidate
         >
-          <div className="curated-trip" aria-label="Curated trip places">
-            <div>
-              <span>Origin</span>
-              <strong>Menger Hotel</strong>
-            </div>
-            <div>
-              <span>Destination</span>
-              <strong>The Alamo</strong>
-            </div>
-            <div>
-              <span>Area</span>
-              <strong>Downtown San Antonio / Alamo Plaza</strong>
-            </div>
+          <div
+            className="setup-mode-toggle"
+            role="group"
+            aria-label="Trip mode"
+          >
+            <button
+              type="button"
+              className={tripMode === "curated" ? "active" : ""}
+              onClick={() => setTripMode("curated")}
+              disabled={busy}
+            >
+              Curated trip
+            </button>
+            <button
+              type="button"
+              className={tripMode === "exploratory" ? "active" : ""}
+              onClick={() => setTripMode("exploratory")}
+              disabled={busy}
+            >
+              Explore another trip
+            </button>
           </div>
+          {tripMode === "curated" ? (
+            <div className="curated-trip" aria-label="Curated trip places">
+              <div>
+                <span>Origin</span>
+                <strong>Menger Hotel</strong>
+              </div>
+              <div>
+                <span>Destination</span>
+                <strong>The Alamo</strong>
+              </div>
+              <div>
+                <span>Area</span>
+                <strong>Downtown San Antonio / Alamo Plaza</strong>
+              </div>
+            </div>
+          ) : (
+            <div className="exploratory-endpoints">
+              <p>Select both endpoints by searching or clicking the map.</p>
+              <label htmlFor="place-search">Search places</label>
+              <input
+                id="place-search"
+                value={search}
+                onChange={(event) => void searchPlaces(event.target.value)}
+                placeholder="Search a place"
+                disabled={busy}
+              />
+              {searchState === "loading" && (
+                <p role="status">Searching places...</p>
+              )}
+              {searchState === "error" && (
+                <p role="alert">
+                  Place search is unavailable. Select the endpoint on the map.
+                </p>
+              )}
+              {searchResults.map((place) => (
+                <button
+                  type="button"
+                  key={place.id}
+                  onClick={() => {
+                    (activeEndpoint === "origin" ? setOrigin : setDestination)(
+                      place
+                    );
+                    setSearch("");
+                    setSearchResults([]);
+                  }}
+                >
+                  {place.name} <small>{place.context}</small>
+                </button>
+              ))}
+              <div className="endpoint-buttons">
+                <button
+                  id="endpoint-origin"
+                  type="button"
+                  onClick={() => setActiveEndpoint("origin")}
+                  className={activeEndpoint === "origin" ? "active" : ""}
+                >
+                  Origin: {origin.name}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveEndpoint("destination")}
+                  className={activeEndpoint === "destination" ? "active" : ""}
+                >
+                  Destination: {destination.name}
+                </button>
+              </div>
+              {endpointError && (
+                <p className="field-error" role="alert">
+                  {endpointError}
+                </p>
+              )}
+              <MapContainer
+                center={[29.425, -98.486]}
+                zoom={14}
+                className="map"
+                scrollWheelZoom
+              >
+                <TileLayer
+                  attribution="&copy; OpenStreetMap contributors"
+                  url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+                <EndpointMap
+                  onSelect={(point) =>
+                    (activeEndpoint === "origin" ? setOrigin : setDestination)(
+                      point
+                    )
+                  }
+                />
+                <CircleMarker
+                  center={[origin.latitude, origin.longitude]}
+                  radius={8}
+                  pathOptions={{ color: "#b9472f" }}
+                />
+                <CircleMarker
+                  center={[destination.latitude, destination.longitude]}
+                  radius={8}
+                  pathOptions={{ color: "#245c4a" }}
+                />
+              </MapContainer>
+            </div>
+          )}
 
           <div className="setup-fields">
             <div className="field">
@@ -701,6 +889,16 @@ export function TripSetupScreen() {
               <>
                 <h2>Trip analysis unavailable</h2>
                 <p>{tripAnalysis.unavailable?.reason}</p>
+                {tripAnalysis.unavailable?.action && (
+                  <p className="action-guidance">
+                    {tripAnalysis.unavailable.action === "choose_us_endpoints"
+                      ? "Choose origin and destination within the United States."
+                      : tripAnalysis.unavailable.action ===
+                          "edit_setup_or_use_live_data"
+                        ? "Edit the setup, or ask a maintainer to enable live data."
+                        : "Retry the analysis or edit the trip setup."}
+                  </p>
+                )}
               </>
             )}
             {(tripAnalysis.state === "success" ||

--- a/frontend/src/services/dataClient.ts
+++ b/frontend/src/services/dataClient.ts
@@ -9,6 +9,7 @@ import type {
   RequestOptions,
   TripAnalysisRequest,
   TripAnalysisResponse,
+  PlaceSearchResponse,
 } from "../types";
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -480,12 +481,16 @@ function isTripAnalysisResponse(
 }
 
 async function readJson(response: Response) {
-  if (!response.ok) throw new Error("Request failed");
+  if (!response.ok) {
+    const detail = await response.json().catch(() => null);
+    const message =
+      isObject(detail) && isObject(detail.detail) ? detail.detail.error : null;
+    throw new Error(typeof message === "string" ? message : "Request failed");
+  }
   return response.json() as Promise<unknown>;
 }
 
 export const dataClient = {
-  analyzeTrip: mockTripAnalyze,
   async getHealth(signal?: AbortSignal): Promise<ExecutionMode> {
     const value = await readJson(await fetch("/health", { signal }));
     if (
@@ -497,7 +502,8 @@ export const dataClient = {
     }
     return value.mode;
   },
-  async analyzeCuratedTrip(
+  analyzeTrip: mockTripAnalyze,
+  async analyzeTripAnalysis(
     request: TripAnalysisRequest
   ): Promise<TripAnalysisResponse> {
     const value = await readJson(
@@ -511,6 +517,19 @@ export const dataClient = {
       throw new Error("Invalid trip analysis response");
     }
     return value;
+  },
+  async searchPlaces(
+    query: string,
+    signal?: AbortSignal
+  ): Promise<PlaceSearchResponse> {
+    const value = await readJson(
+      await fetch(`/api/places/search?q=${encodeURIComponent(query)}`, {
+        signal,
+      })
+    );
+    if (!isObject(value) || !Array.isArray(value.places))
+      throw new Error("Invalid place search response");
+    return value as PlaceSearchResponse;
   },
   async rankHotels(
     location: LocationSelection,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -196,13 +196,13 @@ export type BestTimeResult = {
 };
 
 export type TripAnalysisRequest = {
-  mode: "curated";
+  mode: "curated" | "exploratory";
   origin_latitude: number;
   origin_longitude: number;
   destination_latitude: number;
   destination_longitude: number;
-  landmark_name: "The Alamo";
-  district_name: "Downtown San Antonio";
+  landmark_name: string;
+  district_name: string;
   date: string;
   start_hour: number;
   end_hour: number;
@@ -278,14 +278,19 @@ export type RouteComparisonResult = {
 
 export type TripAnalysisResponse = {
   request_identity: string;
-  mode: "curated";
+  mode: "curated" | "exploratory";
   execution_mode: ExecutionMode;
   state: "series_ready" | "success" | "degraded" | "unavailable" | "error";
   environment: EnvironmentSeriesResult | null;
   best_time: BestTimeResult | null;
   hotels: Record<string, unknown> | null;
   routes: RouteComparisonResult | null;
-  unavailable: { reason: string; recoverable: boolean } | null;
+  unavailable: {
+    reason: string;
+    recoverable: boolean;
+    code?: string;
+    action?: string | null;
+  } | null;
   degraded_reasons: Record<string, string> | null;
 };
 
@@ -319,3 +324,5 @@ export type CuratedTripSetup = {
   endHour: number;
   cautious: boolean;
 };
+
+export type PlaceSearchResponse = { places: LocationSelection[] };

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -79,6 +79,20 @@ def test_invalid_boolean_returns_client_error() -> None:
         thread.join(timeout=2)
 
 
+def test_place_search_returns_server_owned_places() -> None:
+    server = create_fixture_server(Path("fixtures/heatmap-historical.json"))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        response = urlopen(f"http://127.0.0.1:{server.server_port}/api/places/search?q=alamo")
+        result = json.load(response)
+        assert [place["name"] for place in result["places"]] == ["The Alamo"]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_non_object_json_body_returns_client_error() -> None:
     server = create_fixture_server(Path("fixtures/heatmap-historical.json"))
     thread = Thread(target=server.serve_forever, daemon=True)


### PR DESCRIPTION
## Summary

Implements Issue #21 by adding exploratory trip setup and explicit unavailable-scenario handling.

- Add exploratory mode to the shared /api/trip/analyze contract.
- Allow independent origin and destination selection by server-owned place search or map clicks.
- Keep live provider execution and credentials server-side.
- Make fixture matching mode-aware and report missing scenarios explicitly.
- Validate curated trips against the canonical Menger Hotel to The Alamo scenario.
- Surface unsupported live geography and provider-data limitations with actionable codes and UI guidance.

## Verification

- .venv/bin/pytest: 670 passed
- Python typecheck and Ruff: passed
- Frontend typecheck and ESLint: passed
- Frontend Vitest: 23 passed
- Frontend production build: passed

Closes #21