### PR TITLE
docs: Complete Diataxis documentation, demo script, and submission artifacts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -245,6 +245,8 @@ directly.
 - `docs/research/issue-23-alternate-scenarios.md` — Issue #23 place identities
   and observed route/height evidence.
 - `docs/design/fortyguard-extraction.md` — extraction contract from issue #6.
+- `docs/README.md` — the Diataxis documentation map: tutorials, how-to
+  guides, reference, and explanation, plus the demo script.
 - Layout: `app/domain/` (pure contracts), `app/services/` (cache, execution,
   acquisition, sidecars, ledger store), `app/integrations/fortyguard/`
   (provider client stack + live adapter), `app/api.py` + `app/main.py` +

--- a/README.md
+++ b/README.md
@@ -1,49 +1,87 @@
 # Heat-Aware Tourism Guide
 
-Heat-aware trip planning for visitors to hot US cities. The application
-combines landmark timing, outdoor neighborhood heat, and walking-route
-comparison in one fixture-backed web experience.
+A San Antonio tourism guide that helps a traveler make three connected
+decisions in hot weather: when to visit a landmark, which hotel
+neighborhoods have lower outdoor heat exposure, and which returned walking
+route has the lower modeled heat and shade burden. It combines FortyGuard
+urban-heat data, OSRM walking routes, and OpenStreetMap buildings behind one
+FastAPI service with a React/Vite map UI.
+
+**Status:** built for the FortyGuard '26 Hackathon. The core flows, fixture
+set, quality gates, and deployment are complete; final validation and the
+submission recording are the remaining work.
 
 **Public demo:** <https://heat-aware-tourism-guide-demo.onrender.com/>
 
-The free Render service sleeps after 15 minutes without traffic, so allow about
-one minute for the first load during judging.
+The demo runs on Render's free tier in fixture mode: it replays committed,
+provenance-labelled provider data (canonical date `2024-07-15`) and makes no
+live provider calls. It sleeps after 15 minutes without traffic, so allow
+about one minute for the first load. Local setup takes about fifteen minutes
+in the [tutorial](docs/tutorials/first-run.md).
 
-## Project Shape
+## Architecture
 
-- React/Vite responsive UI with Leaflet map.
-- FastAPI orchestration and provider integrations.
-- FortyGuard heat data, OSRM walking alternatives, and OpenStreetMap data.
-- Fixture mode for public deployment, CI, and offline review.
-- San Antonio, Texas as the primary validated scenario; Austin as fallback.
+```text
+React/Vite build ──> FastAPI static assets and API
+                            │
+                            ├─ fixture/live execution ─── provenance, cache, degradation
+                            ├─ FortyGuard client ─────── submit-and-poll, bounded polling
+                            ├─ OSRM client ───────────── one request, returned alternatives
+                            ├─ Overpass acquisition ──── hotels, buildings
+                            └─ local decisions ───────── heat policy, hotel ranking, shade
+```
 
-The implementation decisions and constraints are in
-[`docs/design/design-doc.md`](docs/design/design-doc.md). External fact checks
-are collected in [`docs/research/`](docs/research/).
+The server owns all provider credentials and external calls; the frontend
+never calls a provider directly. Fixture and live execution share one domain
+schema, and every result carries its execution mode and provenance. See
+[Architecture](docs/explanation/architecture.md) and the ADR index.
+
+## Prerequisites
+
+- Git, Python 3.12, and Node.js 22.
+- No API keys for fixture mode, CI, or the public demo. Live provider
+  execution is a maintainer capability.
 
 ## Documentation
 
-Detailed contributor setup, live-mode acquisition, deployment, API reference,
-and demo instructions are organized under the Diataxis structure:
+Documentation is organized under the Diátaxis structure:
 
-- [Design explanation](docs/design/design-doc.md)
-- [Deployment guide](docs/deployment.md)
-- [Deployment decision](docs/adr/0009-separated-public-fixture-and-protected-live-deployments.md)
-- [Fixture demo script](docs/demo-script.md)
-- [Provider and coordinate research](docs/research/)
+- **Tutorial:** [clone to first fixture-backed run](docs/tutorials/first-run.md)
+- **How-to guides:** [configure live mode](docs/how-to/configure-live-mode.md),
+  [acquire fixtures](docs/how-to/acquire-fixtures.md),
+  [deploy](docs/how-to/deploy.md),
+  [record the demo](docs/how-to/record-the-demo.md)
+- **Reference:** [environment variables](docs/reference/environment-variables.md),
+  [HTTP API](docs/reference/api.md),
+  [domain schemas](docs/reference/domain-schemas.md),
+  [commands](docs/reference/commands.md),
+  [configuration](docs/reference/configuration.md)
+- **Explanation:** [architecture](docs/explanation/architecture.md),
+  [cost model](docs/explanation/cost-model.md),
+  [heat metrics](docs/explanation/heat-metrics.md),
+  [hotel weights](docs/explanation/hotel-weights.md),
+  [shade assumptions](docs/explanation/shade-assumptions.md),
+  [limitations](docs/explanation/limitations.md)
+- **Design and research:** [design document](docs/design/design-doc.md),
+  [research notes](docs/research/), [demo script](docs/demo-script.md)
 
-## Contributor Quality Gates
-
-Install the Python dependencies into the repository virtual environment, then install the Node tooling:
+## Quick start
 
 ```bash
 python3 -m venv .venv
 .venv/bin/python -m pip install -e '.[dev]'
 npm ci
 npm ci --prefix frontend
+ALLOW_LIVE=false .venv/bin/uvicorn app.main:app --reload   # backend on :8000
+npm run frontend:dev                                       # frontend on :5173
 ```
 
-Run the local quality gates:
+Open `http://127.0.0.1:5173`, set the trip date to `2024-07-15`, and analyze
+the curated Menger Hotel to The Alamo trip. The full walkthrough, including
+alternate scenarios and the unavailable state, is in the
+[tutorial](docs/tutorials/first-run.md).
+
+## Quality gates
 
 ```bash
 npm run format:check
@@ -62,67 +100,24 @@ npm audit --audit-level=high
 npm audit --prefix frontend --audit-level=high
 ```
 
-For the browser-level fixture flow, install Chromium once and run Playwright:
+Browser-level fixture flow:
 
 ```bash
 npx --prefix frontend playwright install chromium
 npm run e2e
 ```
 
-`npm install` enables Husky. Each commit formats staged files with lint-staged,
-then runs the local Python and frontend type checks and unit tests. CI also runs
-the fixture-backed HTTP integration suite and browser flow.
+`npm install` enables Husky; each commit runs staged formatting plus local
+type checks and unit tests. CI additionally runs the fixture-backed HTTP
+integration suite, the Playwright flow, and dependency audits. All automated
+checks set `ALLOW_LIVE=false`, require no provider credentials, and make no
+FortyGuard, Overpass, or OSRM requests. The complete command catalog is in
+the [commands reference](docs/reference/commands.md).
 
-All automated checks set or retain `ALLOW_LIVE=false`. They require no provider
-credentials and make no FortyGuard, Overpass, OSRM, or other metered provider
-requests. Live acquisition remains an explicit maintainer operation through the
-scripts documented below.
+## Honesty boundaries
 
-## Live Credit Usage
-
-The salvaged quickstart account-usage endpoint is available as a credential-safe
-terminal command. Load `FORTYGUARD_API_KEY` into the process environment without
-printing it, then run:
-
-```bash
-python scripts/fortyguard_usage.py
-python scripts/fortyguard_usage.py --start 2026-08-01 --end 2026-08-24
-```
-
-The command reports the selected window, total credits, and provider activity
-breakdown. It never prints the API key. The source is the quickstart's
-`POST /v1/system/fetch-api-key-custom-usage` utility; the original
-`notebooks/00_setup.ipynb` remains the reference walkthrough.
-
-## Lidar Corridor Prototype
-
-The official USGS National Map coverage probe records classified lidar
-products intersecting the bounded Austin and San Antonio route corridors:
-
-```bash
-python scripts/lidar_corridor_probe.py
-```
-
-This writes local, gitignored metadata to `data/lidar-prototype/coverage.json`.
-It does not download point-cloud binaries. Review the tile metadata and source
-dates before adding an opt-in download/derivation workflow.
-
-The local research environment can inspect a downloaded LAZ tile with
-`laspy[lazrs]` (the package is not an application dependency):
-
-```bash
-python scripts/derive_lidar_corridor_stats.py \
-  data/lidar-prototype/laz/USGS_LPC_TX_Central_B2_2017_stratmap17_50cm_2998373a1_LAS_2019.laz
-```
-
-For the canonical San Antonio corridor, the bounded OpenStreetMap XML extract
-and classified LAZ tile can be compared at building-footprint level with:
-
-```bash
-python scripts/validate_building_lidar_heights.py \
-  /path/to/san-antonio.osm \
-  data/lidar-prototype/laz/USGS_LPC_TX_Central_B2_2017_stratmap17_50cm_2998373a1_LAS_2019.laz
-```
-
-Pass the saved OSRM response with `--route-json` to use the full walking route
-instead of the endpoint chord.
+Results are fixture replays or live observations with explicit provenance;
+routes are compared only among returned alternatives; shade is modeled from
+OSM building data, never measured; heat guidance is product policy, not
+medical advice. The full list is in
+[Limitations](docs/explanation/limitations.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,51 @@
+# Documentation
+
+This documentation follows the [Diátaxis](https://diataxis.fr/) structure:
+tutorials (learning-oriented), how-to guides (task-oriented), reference
+(information-oriented), and explanation (understanding-oriented).
+
+## Tutorials
+
+- [From clone to first fixture-backed run](tutorials/first-run.md) — start
+  here.
+
+## How-to guides
+
+- [Configure live provider execution](how-to/configure-live-mode.md)
+- [Acquire fixtures](how-to/acquire-fixtures.md)
+- [Deploy the public fixture demo](how-to/deploy.md)
+- [Record the demo](how-to/record-the-demo.md)
+
+## Reference
+
+- [Environment variables](reference/environment-variables.md)
+- [HTTP API](reference/api.md)
+- [Domain schemas](reference/domain-schemas.md)
+- [Commands](reference/commands.md)
+- [Configuration options](reference/configuration.md)
+
+## Explanation
+
+- [Architecture and ADR index](explanation/architecture.md)
+- [Cost model](explanation/cost-model.md)
+- [Heat metrics](explanation/heat-metrics.md)
+- [Hotel weights](explanation/hotel-weights.md)
+- [Shade assumptions](explanation/shade-assumptions.md)
+- [Limitations](explanation/limitations.md)
+
+## Design, research, and decisions
+
+- [Product design document](design/design-doc.md) — the implementation
+  source of truth.
+- [ADR index](explanation/architecture.md#adr-index) — numbered
+  architecture decision records under `docs/adr/`.
+- [Research notes](research/) — externally verifiable facts and their
+  citations: [proposal fact check](research/proposal-fact-check.md),
+  [San Antonio provider validation](research/issue-7-san-antonio-provider-validation.md),
+  [canonical coordinates](research/issue-40-menger-alamo-coordinates.md),
+  [alternate scenarios](research/issue-23-alternate-scenarios.md),
+  [fixture schema](research/issue-23-fixture-schema.md), and
+  [lidar/shade feasibility](research/lidar-dsm-shade-feasibility-austin-san-antonio.md).
+- [Demo script](demo-script.md) — narration and fallback handling for the
+  submission recording.
+- [`CONTEXT.md`](../CONTEXT.md) — the shared domain vocabulary.

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,41 +1,150 @@
 # Fixture Demo Script
 
-## Primary Scenario
+The narration, scene order, and fallback handling for the submission
+recording. Preparation (environment choice, wake-up, post-recording checks)
+is in [How to record the demo](how-to/record-the-demo.md). Target length:
+four to five minutes.
 
-Open the hosted fixture demonstration at
-<https://heat-aware-tourism-guide-demo.onrender.com/>. The free service sleeps
-after 15 minutes without traffic, so allow about one minute for its first load.
+Every claim in the narration is worded to match what the data provenance
+supports. Do not improvise stronger claims while recording.
 
-For an offline fallback, run the unified fixture-backed application locally:
+## Deterministic flow
+
+The recording follows this exact sequence every time:
+
+1. Trip setup with the canonical date `2024-07-15` and the 08:00-20:00
+   window.
+2. Best-time evidence and the selected recommendation hour.
+3. Hotel ranking and the district provenance.
+4. Returned walking routes: geometry, heat evidence, coverage, and the
+   explicit route decision state.
+5. One alternate scenario (San Fernando Cathedral to Spanish Governor's
+   Palace) showing two returned routes and no recommendation under weak
+   shade evidence.
+6. One deliberate unavailable state, then the restored canonical result.
+
+## Environment
+
+**Primary — hosted fixture demonstration:**
+<https://heat-aware-tourism-guide-demo.onrender.com/>. The free service
+sleeps after 15 minutes without traffic; allow about one minute for its
+first load, and warm it before recording.
+
+**Known hosted state at time of writing:** the hosted curated form pins the
+date `2026-08-23`, which does not match the committed fixture date
+`2024-07-15`, so the hosted curated submission currently returns the
+explicit `scenario_unavailable` state, and the hosted UI does not offer the
+alternate scenarios. Before recording against the hosted demo, correct the
+pinned date in `frontend/src/screens/TripSetupScreen.tsx`
+(`PUBLIC_FIXTURE_DATE`) and redeploy, or record the primary flow locally.
+The hotel ranking flow is date-independent and works hosted either way.
+
+**Deterministic fallback — local fixture run:**
 
 ```bash
 ALLOW_LIVE=false .venv/bin/uvicorn app.main:app --reload
 npm run frontend:dev
 ```
 
-Open the frontend and submit the curated trip from Menger Hotel to The Alamo.
-Use the committed San Antonio fixture and show these states in order:
+Open the frontend, use the curated trip, and enter `2024-07-15` as the
+date. The local flow supports every scene below, including the alternate
+scenarios and the unavailable state.
 
-1. Trip setup with the canonical date and time window.
-2. Best-time evidence and the selected recommendation hour.
-3. Hotel ranking and the district provenance.
-4. Returned walking routes, their geometry, heat evidence, coverage, and
-   explicit route decision state.
+## Scene-by-scene narration
 
-The route comparison is limited to routes returned by OSRM. The application
-must not describe a route as globally optimal.
+### Scene 1 — Opening (trip setup)
 
-## Fallback Path
+> "This is the Heat-Aware Tourism Guide, a trip planner for hot-weather
+> city visits. I'm planning the canonical demonstration trip: walking from
+> the Menger Hotel to The Alamo in Downtown San Antonio. The banner shows
+> the server is running in fixture mode — every result you'll see is
+> replayed from committed provider data with its provenance attached, and
+> the demo makes no live provider calls."
 
-To demonstrate an unavailable fixture, change the trip date or time window and
-submit again. The server must return an explicit unavailable state rather than
-an empty success response. Restore the canonical date and window before the
-recording ends.
+Show the health banner reading "Fixture replay". Enter date `2024-07-15`
+(if the form allows) and leave hours at 08:00 to 20:00.
 
-For a route-provider failure in a maintainer environment, use an exact cache or
-fixture replay. The result must retain its `fixture` or `cache` provenance and
-mark stale replay appropriately. Budget exhaustion remains an HTTP 503 and is
-not converted into ordinary degradation.
+### Scene 2 — Best time
+
+> "First: when to go. The analysis returns hourly heat evidence for my
+> window and recommends a visit hour with its reason. The recommendation is
+> hour-only — the provider's environmental series carries a timezone
+> inconsistency, so the product deliberately avoids claiming an exact
+> timestamp it cannot support."
+
+Point at the recommended hour, the hourly evidence, and the hour-only note.
+
+### Scene 3 — Hotel ranking
+
+> "Second: where to stay. One district-level heat analysis ranks the
+> downtown hotels. Each hotel shows its heat components — night heat, hot
+> hours, persistence, and day heat — as candidate-relative percentiles, with
+> the weights visible and adjustable. These weights are product defaults,
+> not scientific truths."
+
+Point at the component values, a percentile, and the weights summary.
+
+### Scene 4 — Route comparison
+
+> "Third: how to walk there. The routing provider returned one valid
+> pedestrian route for this request, so the product shows that route with
+> limited-comparison wording — it never invents a second route, and it never
+> claims any route is globally optimal. The route's heat evidence, coverage,
+> and the explicit decision state are all shown with the data date."
+
+Open the route comparison. Point at the map geometry, the heat label, and
+the decision wording.
+
+### Scene 5 — Alternate scenario (local flow)
+
+Switch to "Explore another trip", select San Fernando Cathedral as origin
+and Spanish Governor's Palace as destination (hours pin to 10:00-17:00),
+and analyze.
+
+> "Here the provider returned two routes. The corridor's building-height
+> evidence is weak, so the product keeps every route and metric visible but
+> makes no recommendation — the traveler compares the trade-offs. Weak
+> evidence yields honesty, not a guess."
+
+Point at both route cards, the weak-coverage notice, and the absence of a
+recommended badge.
+
+### Scene 6 — Unavailable state
+
+Change the trip date (or window) to a non-fixture value and analyze once.
+
+> "Finally, what failure looks like. There's no fixture for this setup, so
+> the product returns an explicit unavailable state with recovery guidance —
+> never an empty success. Restore the canonical setup and the analysis
+> returns."
+
+Restore `2024-07-15` (and the canonical window) and re-run the canonical
+analysis so the recording ends on the working result.
+
+### Scene 7 — Closing
+
+> "Everything you saw ran on committed fixtures through the same domain
+> contracts the live path uses — provenance, degradation, and budgets are
+> enforced server-side. The repository, documentation, and this fixture set
+> are public for inspection."
+
+## Fallback handling
+
+- **Hosted service asleep, slow, or regressed:** record the local fixture
+  flow above with the same scenes and narration; note the switch in the
+  recording. See the [deployment guide](how-to/deploy.md) for warm-up,
+  keep-warm, and rollback procedures.
+- **To demonstrate an unavailable fixture deliberately:** change the trip
+  date or time window and submit again. The server returns the explicit
+  unavailable state rather than an empty success. Restore the canonical
+  date and window before the recording ends.
+- **Route-provider failure in a maintainer environment:** use an exact cache
+  or fixture replay. The result retains its `fixture` or `cache` provenance
+  and stale marking. Budget exhaustion remains an HTTP 503 and is never
+  converted into ordinary degradation.
+- **Missing map tiles:** continue recording; browser OSM tiles are allowed
+  but are not a readiness dependency. A degraded basemap does not invalidate
+  the fixture demo.
 
 ## Verification
 
@@ -47,9 +156,6 @@ npm run test
 npm run frontend:build
 ```
 
-The fixture flow makes no FortyGuard, Overpass, or OSRM requests. Live provider
-acquisition is a separate maintainer operation and must not be used for the
-public recording. Browser OSM tiles are allowed, but they are not a readiness
-dependency; a missing basemap does not invalidate the fixture demo. For hosted
-deployment smoke tests, health, warm-up, and rollback procedures are in the
-[deployment guide](deployment.md).
+The fixture flow makes no FortyGuard, Overpass, or OSRM requests. Live
+provider acquisition is a separate maintainer operation and must not be
+used for the public recording.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,103 @@
+# Explanation: Architecture
+
+How the system is put together, and why. For step-by-step material see the
+[tutorial](../tutorials/first-run.md) and the
+[how-to guides](../how-to/); for exact interfaces see the
+[reference pages](../reference/api.md). The authoritative decision record is
+the [ADR index](#adr-index) below; the product design source of truth is
+[the design document](../design/design-doc.md), and the shared vocabulary is
+[`CONTEXT.md`](../../CONTEXT.md).
+
+## One service, two execution paths
+
+```text
+React/Vite build ──> FastAPI static assets and API
+                            │
+                            ├─ fixture/live execution ─── provenance, cache, degradation
+                            ├─ FortyGuard client ─────── submit-and-poll, bounded polling
+                            ├─ OSRM client ───────────── one request, returned alternatives
+                            ├─ Overpass acquisition ──── hotels, buildings
+                            └─ local decisions ───────── heat policy, hotel ranking, shade
+```
+
+The FastAPI server owns all provider credentials and external calls; the
+frontend never calls a provider directly and never receives an API key.
+Deploying one service keeps the public demo simple and makes the fixture/live
+boundary server-enforced rather than UI-enforced.
+
+## Layered layout
+
+- `app/domain/` — pure contracts and decisions: heat policy, hotel scoring,
+  route decision state machine, provenance, tokens. No I/O; fully unit
+  tested.
+- `app/services/` — orchestration: execution (fixture/live/cache
+  degradation), trip adapters, route analysis, shade, hotel discovery,
+  enrichment, ledger store, sidecars, the trip-contract-v2 codec, and
+  offline snapshot generation.
+- `app/integrations/fortyguard/` — the provider client stack plus the live
+  adapter (transport, polling, normalization, transformations).
+- `app/api.py` + `app/main.py` + `app/wiring.py` + `app/settings.py` —
+  composition root: settings, profile validation, route table, app assembly.
+
+The seam that matters is the `TripAnalysisAdapter` protocol: fixture replay
+and live execution implement the same contract, so every downstream decision
+is provenance-agnostic and every result carries its execution mode.
+
+## Execution modes, provenance, and degradation
+
+Every result records where it came from: `fixture` (committed
+provider-shape JSON, offline), `live` (`provider`, authenticated call), or
+`cache` (replayed earlier result). There is no unmarked fourth case — an
+empty success is impossible by contract.
+
+When live execution fails, the degradation chain runs: exact cache entry →
+matching fixture → explicit unavailable error. Replays keep their true data
+date and are marked stale; a forecast-mode replay is date-relaxed but never
+presented as a current forecast. Budget exhaustion is deliberately outside
+the chain: it returns HTTP 503 rather than degrading, because silently
+serving stale data to protect a budget would hide the budget state.
+
+## Fixtures as first-class data
+
+Fixtures are not test doubles bolted on; they are the public deployment's
+data source and the CI substrate. Each fixture is a sanitized raw provider
+payload plus an acquisition sidecar that is the single authoritative match
+identity. Product-level snapshots (`trip-contract-v2`) are generated
+offline from normalized lower-level acquisitions through production domain
+code and are linked to their inputs by content hashes. This is why the
+demo, the tests, and the judges' experience all exercise the same code
+path.
+
+## Why the decisions were made
+
+The numbered decision records, newest last:
+
+| ADR                                                                            | Decision                                                                                     |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| [0001](../adr/0001-live-provider-adapter-boundary.md)                          | Live provider adapter boundary: server owns credentials; sync submit/poll model.             |
+| [0002](../adr/0002-live-unit-and-freshness-inference.md)                       | Unit and freshness inference, with named/versioned transformations stamped in provenance.    |
+| [0003](../adr/0003-bounded-polling-and-404-tolerance.md)                       | Bounded polling, a 404 tolerance window after submission, and submit-once for billable work. |
+| [0004](../adr/0004-fixture-cache-provenance-ledger.md)                         | Acquisition sidecars, cache identity, the degradation chain, and the JSONL cost ledger.      |
+| [0005](../adr/0005-best-time-decision-orchestration.md)                        | Best-time decision orchestration and retained route-gating evidence.                         |
+| [0006](../adr/0006-returned-route-heat-analysis.md)                            | Shared route-heat AOI, conservative per-route aggregation, recommendation staging.           |
+| [0007](../adr/0007-exact-time-modeled-shade-decisions.md)                      | Exact-time modeled shade, nighttime decisions, weak shade-evidence behavior.                 |
+| [0008](../adr/0008-optional-enrichment-budgets-and-boundaries.md)              | Optional enrichment budgets, signed result-set tokens, base-result preservation.             |
+| [0009](../adr/0009-separated-public-fixture-and-protected-live-deployments.md) | Separated public fixture and protected live deployments.                                     |
+| [0010](../adr/0010-trip-v2-product-snapshots.md)                               | Trip v2 product snapshots from normalized acquisitions.                                      |
+
+## Where the boundaries are
+
+- **Geography.** Live provider data is supported for the United States
+  only, because that is FortyGuard's documented coverage. The canonical
+  scenario is San Antonio; fixture replay has no geography.
+- **Routing.** OSRM is consumed, not implemented. One request per trip; the
+  product compares only returned alternatives and never claims global
+  optimality.
+- **Heat claims.** Provider `tcm` is never labeled as NOAA Heat Index; the
+  product avoids calling any condition comfortable or safe.
+- **Shade.** Building-shadow percentages are model outputs from OSM data,
+  not measurements; weak evidence yields no recommendation instead of a
+  guess.
+
+These boundaries and the remaining known limitations are collected in
+[Limitations](limitations.md).

--- a/docs/explanation/cost-model.md
+++ b/docs/explanation/cost-model.md
@@ -1,0 +1,74 @@
+# Explanation: Cost Model
+
+How provider spending is understood, recorded, and bounded. Operations are
+in [How to configure live mode](../how-to/configure-live-mode.md) and
+[How to acquire fixtures](../how-to/acquire-fixtures.md); the contract is
+[ADR 0004](../adr/0004-fixture-cache-provenance-ledger.md) §5.
+
+## What is known and what is not
+
+- The hackathon access is Premium, with roughly 2,000,000 credits per
+  teammate and about 6,000,000 collectively. Published offerings list Basic
+  at 1,000,000 monthly credits and Pro at 5,000,000, with heatmap area caps
+  of 10 and 50 mi² ([API pricing](https://fortyguard.com/api-pricing)).
+- Public documentation does not establish exact per-request credit costs or
+  numeric rate limits, and responses do not carry a credit field. The
+  account's plan tier is not exposed.
+- Observed account-level usage for one window (2026-07-26 to 2026-08-25)
+  was 108,660 credits: satellite segmentation 57,600 (4 calls), heatmap
+  generation 33,760 (8), environment parameter analysis 8,700 (3),
+  streetview segmentation 8,600 (1). This is recorded in
+  [the issue 7 validation note](../research/issue-7-san-antonio-provider-validation.md).
+
+The design consequence: **measure, never assume**. Every billable
+submission is recorded, and credit truth comes only from the provider's own
+account endpoint.
+
+## The ledger
+
+`data/ledger.jsonl` (gitignored) is an append-only JSONL log loaded at
+startup, with two record kinds:
+
+- **Call records** — one per submitted provider call: activity ID, endpoint,
+  `credits_used` (null when the provider did not price it), completion
+  time, status, and core/enrichment scope.
+- **Reconciliation records** — the provider's authoritative account credit
+  total for a date window, appended by `scripts/reconcile_ledger.py` from
+  `POST /v1/system/fetch-api-key-custom-usage`.
+
+Reload is idempotent (deduplication by activity ID and window).
+
+## Why budgets count calls, not credits
+
+The usage endpoint's breakdown is aggregated by activity name with no
+activity IDs, so per-call credit attribution is impossible. A budget
+expressed in credits would therefore be unenforceable. `FORTYGUARD_CALL_BUDGET`
+caps the **call count** — the one thing the application can measure exactly —
+and reconciliation supplies the credit facts afterwards. When the budget is
+unset, the ledger records without enforcing (record-only mode).
+
+Optional enrichment has a separate per-UTC-calendar-day budget
+(`FORTYGUARD_ENRICHMENT_CALL_BUDGET`): one submitted enrichment activity
+consumes one unit even if it later fails, while cache hits and fixture
+replay consume none. The per-kind "estimated credits" values surfaced in
+enrichment responses are declared estimates, not attributed usage.
+
+## What spending looks like in practice
+
+- **Public deployment and CI: zero.** Fixture replay makes no provider
+  requests; automated checks run with `ALLOW_LIVE=false`.
+- **Acquisition: bounded and explicit.** Maintainer-run scripts submit
+  documented activities; the staged issue 23 plan was nine FortyGuard
+  activities, resumable and ledger-recorded. Submit-once means a transport
+  hiccup never silently double-bills.
+- **Protected live deployment: capped.** A positive call budget and a
+  persistent absolute ledger path are startup requirements; budget
+  exhaustion is an HTTP 503 that is never converted into degradation.
+
+## Free dependencies
+
+OSRM (FOSSGIS pedestrian instance), Overpass, and OSM tiles are free public
+services. They are treated carefully anyway — bounded queries, descriptive
+User-Agents, HTTP 429 retry with delay, caching, and no CI dependency —
+because they are shared resources that may throttle or fail
+([proposal fact check](../research/proposal-fact-check.md)).

--- a/docs/explanation/heat-metrics.md
+++ b/docs/explanation/heat-metrics.md
@@ -1,0 +1,90 @@
+# Explanation: Heat Metrics
+
+How the product turns temperatures into bands, decisions, and wording. The
+code is `app/domain/heat_policy.py`; thresholds are fixed there rather than
+configured. External facts are cited in
+[the proposal fact check](../research/proposal-fact-check.md).
+
+## Two metrics, never conflated
+
+| Metric               | Source                | Meaning                                               |
+| -------------------- | --------------------- | ----------------------------------------------------- |
+| `tcm`                | FortyGuard heatmap    | Provider tile temperature in °C.                      |
+| `heat_index_celsius` | FortyGuard env-params | Actual NOAA Heat Index, when the provider returns it. |
+
+`tcm` is **not** a Heat Index and is never labeled as one. When an actual
+Heat Index value is available it is preferred for NOAA classification; when
+it is not, the UI shows the Celsius metric with a separately named product
+band. The two band families below exist precisely so the labels cannot
+collide.
+
+## NOAA Heat Index bands (verified)
+
+Boundaries 80 / 90 / 105 / 130 °F — approximately 26.7, 32.2, 40.6, and
+54.4 °C — from [NWS Heat Index](https://www.weather.gov/safety/heat-index):
+
+| Band            | Heat index    |
+| --------------- | ------------- |
+| Below caution   | below 26.7 °C |
+| Caution         | 26.7-32.2 °C  |
+| Extreme caution | 32.2-40.6 °C  |
+| Danger          | 40.6-54.4 °C  |
+| Extreme danger  | above 54.4 °C |
+
+Heat Index assumes shady, light-wind conditions and is distinct from WBGT.
+"Comfortable" is not an NOAA category, and the product never uses it.
+
+## Product TCM bands (product policy)
+
+Boundaries 30 / 35 / 40 °C, chosen by the team, not derived from any
+standard:
+
+| Band                           | TCM             |
+| ------------------------------ | --------------- |
+| Lower provider temperature     | below 30 °C     |
+| Moderate provider temperature  | 30-35 °C        |
+| Higher provider temperature    | 35-40 °C        |
+| Very high provider temperature | 40 °C and above |
+
+## Guidance policies
+
+`classify_heat` assigns a band, then an action threshold:
+
+- **Standard guidance** acts from the third band (Extreme caution for NOAA;
+  Higher provider temperature for TCM).
+- **Cautious guidance** — the optional traveler preference — shifts the
+  action threshold one band earlier (Caution; Moderate). The measured value
+  and the displayed observation band do not change; only the
+  "action required" decision moves. `policy_applied` records which policy
+  produced the decision.
+
+This one-band-earlier shift is an explicit product safety policy informed
+by general public-health guidance (heat-vulnerable groups include older
+adults and people with chronic conditions, per
+[NWS heat safety](https://www.weather.gov/safety/heat) and
+[WHO](https://www.who.int/news-room/fact-sheets/detail/climate-change-heat-and-health)).
+It is not a clinical risk assessment, collects no medical profile, and
+provides no medical advice.
+
+## Environmental concern thresholds
+
+The best-time decision also assesses the returned environmental parameters
+hour by hour against declared thresholds (`app/domain/best_time.py`):
+heat index 26.7 / 40.6 °C, apparent temperature 30 / 40 °C, wet-bulb
+28 / 32 °C, EPA AQI family 51 / 101, relative humidity 60 / 80 %,
+precipitation 0.1 / 5.0 mm, and solar irradiance 400 / 600 W/m². Missing
+parameters are reported as `not_reported`, never assumed safe, and do not
+count against an hour during best-time selection.
+
+## Framing metrics
+
+Exceedance and persistence heatmaps summarize a district against a declared
+threshold — 35 °C, direction above, in this product. They are framing
+evidence visible in provenance, not hidden substitutes for the hourly
+curve, and the 35 °C value is a product choice, not an NOAA boundary.
+
+## Wording rules
+
+Preferred phrasing: "no elevated heat concern detected by the selected
+metric" and "more cautious guidance selected". Avoided phrasing: any claim
+that a condition is comfortable, safe, or clinically assessed.

--- a/docs/explanation/hotel-weights.md
+++ b/docs/explanation/hotel-weights.md
@@ -1,0 +1,62 @@
+# Explanation: Hotel Weights
+
+How the district hotel ranking is computed, what the weights mean, and what
+they must never be presented as. Code: `app/domain/hotel_heat_score.py`;
+per-request configuration is documented in the
+[configuration reference](../reference/configuration.md).
+
+## The strongest proof point
+
+One district-level heat analysis ranks every hotel; hotel lookup,
+percentiles, ties, and re-weighting are computed locally. Hotel count never
+multiplies provider jobs — the billable work is the district heatmap set,
+not per-hotel requests.
+
+## Components and default weights
+
+Four heat components are acquired per district (data date `2024-07-15` for
+the committed fixtures):
+
+| Component                                  | Unit  | Default weight |
+| ------------------------------------------ | ----- | -------------- |
+| Night heat (`00:00-05:00` declared window) | °C    | 35 %           |
+| Hot hours (exceedance above 35 °C)         | hours | 25 %           |
+| Persistence (longest run above 35 °C)      | hours | 20 %           |
+| Day heat (`10:00-17:00` declared window)   | °C    | 20 %           |
+
+Each hotel receives its component values through local point-in-tile
+lookup, with assignment quality, tile resolution, distance, and coverage
+recorded per component.
+
+## What the score is
+
+- Component values are converted to **candidate-relative percentiles**
+  within the discovered set; the aggregate is a weighted sum of inverted
+  percentiles, normalized per correlation group.
+- Hotels are ranked with **tie groups** — equal aggregates share a rank —
+  and the response exposes components, percentiles, tile resolution, and
+  the weights used (`product defaults` or `custom`).
+- Ranking requires at least five complete usable candidates; fewer is an
+  explicit unavailable state, not an empty success.
+
+## What the score is not
+
+- **Not objective truth.** The 35/25/20/20 split is a provisional product
+  default, not a scientific or satisfaction-derived value. No absolute
+  "score out of 100" is presented as if it were measured.
+- **Not indoor comfort.** The ranking concerns outdoor heat exposure around
+  the hotel. Room quality, service, price, and season are out of scope, and
+  hotel review sentiment was explicitly rejected as evidence because those
+  factors confound it.
+- **Not interval maxima.** The declared night/day windows are metadata over
+  date-level TCM evidence; the
+  `date_level_not_interval_maximum` caveat stays attached to results.
+
+## Re-weighting
+
+Travelers may adjust the four weights (they must stay non-negative and sum
+to 1); the client re-ranks locally without another provider request, and
+the API accepts the same `weights` object on
+`POST /api/hotels/rank`. Sensitivity analysis of the defaults remains open
+follow-up work; the research basis is collected in
+[the proposal fact check](../research/proposal-fact-check.md).

--- a/docs/explanation/limitations.md
+++ b/docs/explanation/limitations.md
@@ -1,0 +1,86 @@
+# Explanation: Limitations
+
+What the product deliberately does not claim. This page is the honest
+boundary of the submission; the acceptance language behind it is audited in
+[the proposal fact check](../research/proposal-fact-check.md). Detailed
+reasoning lives in the linked explanation pages and ADRs.
+
+## Coverage and geography
+
+- **Live data is United States-only**, because that is FortyGuard's
+  documented current coverage. Requests outside the supported US extent get
+  an explicit `unsupported_geography` unavailable response. This is a
+  provider boundary, not a product choice to ignore other regions.
+- **One validated city.** San Antonio, Texas is the primary scenario;
+  Austin was the validated fallback. Multi-city support is out of scope.
+- **Curated public flow.** The public deployment demonstrates the fixed
+  canonical trip and hotel district; exploratory trips with live providers
+  are a maintainer capability.
+
+## Data recency and honesty
+
+- **The public demo replays fixtures** acquired for the date `2024-07-15`
+  (canonical window 08:00-20:00, alternates 10:00-17:00). Results are
+  labelled `fixture` with their true data date and are not presented as
+  current conditions.
+- **The env-params series is anchored, not forecast.** Environmental
+  parameters are fixed to a caller-supplied temperature anchor and carry
+  the standing warning "not a real 24-hour forecast".
+- **Heat evidence has known temporal caveats.** The canonical environment
+  series' provider timezone (`GMT-7`) conflicts with the canonical
+  `America/Chicago` interpretation, so the best-time recommendation is
+  hour-only (`temporal_evidence: "inconsistent"`). Hotel night/day windows
+  are declared metadata over date-level TCM, not interval maxima
+  (`date_level_not_interval_maximum`).
+
+## Routing
+
+- **Only returned alternatives are compared.** OSRM alternatives are not
+  guaranteed; the canonical request genuinely returned one route, which is
+  shown with limited-comparison wording. The product never fabricates a
+  route and never claims a route is globally optimal, shortest-possible, or
+  the only one that exists.
+- **Distances and durations are provider estimates**, not measured walks.
+
+## Shade
+
+- **Modeled, not measured.** Building-shadow percentages come from OSM
+  footprints, inferred or explicit heights, and solar geometry; they
+  exclude trees, awnings, terrain, clouds, and temporary obstructions. See
+  [Shade assumptions](shade-assumptions.md).
+- **Weak evidence yields no recommendation.** When building-height coverage
+  is below the product's 0.70 policy threshold, all route evidence remains
+  visible but nothing is recommended.
+
+## Heat and safety
+
+- **No medical claims.** The product is not a clinical risk assessment,
+  collects no medical profile, and gives no medical advice. NOAA category
+  names are used only for actual Heat Index values; provider `tcm` gets
+  separately named product bands. Nothing is called "comfortable" or
+  "safe"; preferred wording is "no elevated heat concern detected by the
+  selected metric".
+- **Thresholds are policy.** The 35 °C framing threshold, the 30/35/40 °C
+  TCM bands, the 1,500 m representative-route distance, the 0.70 coverage
+  gates, the one-band-earlier cautious shift, and the 35/25/20/20 hotel
+  weights are team decisions, not standards. Sensitivity analysis of the
+  hotel weights remains open work.
+
+## Product scope
+
+Out of scope by design: booking, pricing, availability, indoor hotel
+comfort, a routing engine, city-wide optimal cool-route search, medical
+risk scoring, treating segmentation imagery as the core shade measurement,
+and any requirement that public deployment or CI make live provider calls.
+
+## Operational limits
+
+- The public demo runs on Render's free tier: it sleeps after 15 idle
+  minutes (about one minute to wake) and is bounded by free-tier hours and
+  bandwidth. Keep-warm layers mitigate but do not remove this; see
+  [How to deploy](../how-to/deploy.md).
+- The cache is process-local and lost on restart; the ledger is the only
+  persistent operational record.
+- Enrichment estimates are declared approximations; actual credit usage is
+  knowable only through account-level reconciliation
+  ([Cost model](cost-model.md)).

--- a/docs/explanation/shade-assumptions.md
+++ b/docs/explanation/shade-assumptions.md
@@ -1,0 +1,76 @@
+# Explanation: Shade Assumptions
+
+What "modeled building shade" is, what feeds it, and what it must never be
+claimed to be. Code: `app/domain/route_shade.py` and
+`app/services/route_shade.py`; the decision policy is
+[ADR 0007](../adr/0007-exact-time-modeled-shade-decisions.md).
+
+## The model
+
+For each returned route, the product:
+
+1. Acquires OSM `building` and `building:part` ways and relations within a
+   250 m corridor (`SHADE_BUILDING_SEARCH_DISTANCE_M`) via one bounded
+   Overpass query.
+2. Resolves each footprint's height: a valid explicit `height` tag first
+   (feet converted at 0.3048 m/ft); otherwise a valid `building:levels`
+   multiplied by the documented 3 m-per-level approximation
+   (`SHADE_METRES_PER_LEVEL`); otherwise unknown. Height origin is tracked
+   as `explicit`, `inferred_levels`, or `unknown`.
+3. Computes the solar position (azimuth and elevation, solar model identity
+   `astral-3.2-apparent`) for the exact recommended local timestamp in the
+   canonical timezone.
+4. Projects building-shadow geometry and reports the fraction of the route's
+   length intersecting it while the sun is above the horizon.
+
+The result is a deterministic function of the OSM snapshot, the height
+rules, and the timestamp — labeled "modeled shade estimate, based on OSM
+building data".
+
+## Coverage and confidence
+
+**Building-height coverage** is the area-weighted fraction of relevant
+footprints in the route's analysis corridor with explicit or inferred
+heights. A route with no mapped footprints has zero coverage. The 0.70
+sufficiency default (`SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE`) is product
+policy, not an OSM or scientific standard.
+
+Measured downtown examples: the canonical corridor's 2017 USGS-lidar
+validation found modeled heights for 5/5 intersecting footprints, while the
+Cathedral-to-Governor's-Palace corridor computes roughly 0.34 on current
+OSM tags — comfortably below the gate. Both are recorded with their methods
+in [the issue 7 note](../research/issue-7-san-antonio-provider-validation.md)
+and [the issue 23 scenarios note](../research/issue-23-alternate-scenarios.md).
+
+## What the model excludes
+
+- Trees, awnings, canopies, and other vegetation or temporary structures —
+  no data source represents them here.
+- Clouds and weather; shadows are clear-sky geometry.
+- Terrain and sidewalk side; the model is 2D footprints extruded by height.
+- OSM errors and omissions: missing, stale, moved, or split footprints, and
+  inaccurate or absent `height`/`building:levels` tags.
+- Sub-footprint detail such as architectural setbacks.
+
+The lidar feasibility study ([research note](../research/lidar-dsm-shade-feasibility-austin-san-antonio.md))
+established that USGS classified point clouds can supply modeled heights
+where OSM tags are sparse — used as research validation, not as a
+production shade source.
+
+## Decision behavior
+
+- **Nighttime** (sun at or below the horizon): building shade is zero and
+  not applicable; the coolest returned route by retained route TCM is
+  recommended, with distance breaking exact ties.
+- **Sufficient coverage**: the shadiest returned route (or the only route)
+  is recommended among returned alternatives.
+- **Insufficient coverage**: all alternatives and available metrics stay
+  visible, but the product makes **no route recommendation** — the traveler
+  compares the trade-offs. There is no shortest-route fallback that would
+  masquerade as a heat-informed answer.
+
+## Wording rules
+
+"Modeled shade estimate, based on OSM building data" — never "measured",
+"observed", or "real-world" shade. Results carry the shade limitations list
+and the model/provider version identities.

--- a/docs/how-to/acquire-fixtures.md
+++ b/docs/how-to/acquire-fixtures.md
@@ -1,0 +1,148 @@
+# How To Acquire Fixtures
+
+Fixture acquisition is the explicit, maintainer-run process that turns real
+provider responses into committed, replayable fixtures. Real credits are
+spent on the FortyGuard paths. This guide covers the acquisition script, the
+trip snapshot generator, and credit reconciliation. The design contract —
+sidecars as the single match identity, the degradation chain, and the ledger
+— is [ADR 0004](../adr/0004-fixture-cache-provenance-ledger.md); the Issue
+#23 outcome, including hashes and network-blocked test coverage, is recorded
+in
+[the issue 23 fixture schema note](../research/issue-23-fixture-schema.md).
+
+Before acquiring anything, read
+[How to configure live mode](configure-live-mode.md): FortyGuard acquisition
+requires `ALLOW_LIVE=true` and `FORTYGUARD_API_KEY` in the maintainer
+environment.
+
+## What a fixture is
+
+Every fixture is a pair:
+
+- `<stem>.json` — the sanitized raw provider payload (API keys, request IDs,
+  and credit fields stripped).
+- `<stem>.acquisition.json` — the acquisition sidecar, the authoritative
+  record: `source` (`provider` or `synthesized`), provider identity,
+  endpoint, `request_configuration` (the matching identity), retrieval time,
+  data date, status, schema version, provider configuration version, safe
+  activity ID, and transformations.
+
+Two rules keep the set honest:
+
+1. A `provider` sidecar must carry a real retrieval time, provider identity,
+   and terminal status. A `synthesized` sidecar must carry `null` activity
+   ID and retrieval time — never fabricated ones.
+2. Provider payloads are observed, product failure states are synthesized,
+   and product recommendations are computed. None of the three may be
+   relabeled as another.
+
+`tests/test_fixture_inventory.py` enforces these rules, the one-sidecar-per-
+fixture invariant, exact `derived_from` content hashes, and a secret scan
+over every committed fixture.
+
+## Acquire one provider scenario
+
+`scripts/acquire_fixture.py` runs one documented provider request, proves it
+normalizes through the live pipeline, and writes the fixture pair:
+
+```bash
+# FortyGuard heatmaps (billable: requires ALLOW_LIVE=true + API key)
+python scripts/acquire_fixture.py --scenario tcm-historical
+python scripts/acquire_fixture.py --scenario tcm-forecast
+python scripts/acquire_fixture.py --scenario exceedance-historical
+python scripts/acquire_fixture.py --scenario env-params-anchor35
+
+# OSRM routes (free; no ALLOW_LIVE required)
+python scripts/acquire_fixture.py --scenario canonical-menger-alamo
+python scripts/acquire_fixture.py --scenario main-plaza-market-square
+python scripts/acquire_fixture.py --scenario cathedral-governors-palace
+
+# Overpass buildings (free; requires the matching OSRM fixture first)
+python scripts/acquire_fixture.py --scenario cathedral-governors-palace-buildings
+```
+
+Useful flags:
+
+- `--out-dir` — output directory (default `fixtures/acquired` for single
+  scenarios; the issue 23 modes write to `fixtures/providers/...`).
+- `--ledger-path` — override `FORTYGUARD_LEDGER_PATH` for this run.
+
+Behaviour to expect:
+
+- The script **refuses to overwrite** an existing fixture pair; move the old
+  files aside deliberately instead of clobbering history.
+- The buildings scenario enforces a per-route building-height coverage gate
+  and requires the referenced OSRM fixture to exist.
+- FortyGuard calls are appended to the ledger and obey `FORTYGUARD_CALL_BUDGET`.
+- Prints output paths, the activity ID, and the ledger call count.
+
+## Run the staged issue 23 plan
+
+The Issue #23 acquisitions (canonical and alternate scenarios, data date
+`2024-07-15`) are a staged, resumable plan of nine FortyGuard activities:
+three destination TCMs, three destination env-params series, and three
+canonical-district hotel components.
+
+```bash
+# Inspect the plan without spending credits (secret-free JSON)
+python scripts/acquire_fixture.py --plan-issue-23
+
+# Execute it
+python scripts/acquire_fixture.py --execute-issue-23
+```
+
+Recovery modes exist for partial completion:
+`--plan-issue-23-hotels-resume` / `--execute-issue-23-hotels-resume`
+(the three independent hotel activities) and
+`--plan-issue-23-canonical-env-recovery` /
+`--execute-issue-23-canonical-env-recovery --activity-id <id>`
+(status-only recovery of a prior env-params activity; guarded so it cannot
+change the ledger). The older `--*-canonical-resume` modes are superseded
+and raise an error.
+
+## Generate trip product snapshots
+
+`fixtures/trips/*.trip.json` are product-level `trip-contract-v2` snapshots.
+They are generated offline from the committed raw acquisitions — never
+hand-authored — and linked to their inputs by content-addressed
+`derived_from` references:
+
+```bash
+python scripts/generate_trip_snapshots.py
+```
+
+The generator SHA-256-verifies all pinned inputs, builds the four scenarios
+(canonical, Main Plaza to Market Square, Cathedral to Governor's Palace,
+Briscoe to Tower unavailable) through production domain code with a fixed
+clock, round-trips each response through the strict shared codec, and
+refuses to overwrite existing outputs unless `--overwrite` is passed.
+
+If any input changed, regeneration is mandatory: a snapshot silently claiming
+stale inputs fails the hash checks in
+`tests/test_fixture_inventory.py`.
+
+## Reconcile credits afterwards
+
+Acquisition records calls; only the provider's account endpoint reports
+credit truth. After an acquisition session, append a reconciliation record:
+
+```bash
+python scripts/reconcile_ledger.py --start 2026-08-01 --end 2026-08-30
+```
+
+The breakdown is aggregated by activity name with no activity IDs, so
+per-call credit attribution is impossible by design (ADR 0004 §5). See
+[Cost model](../explanation/cost-model.md).
+
+## Committing rules
+
+1. Commit the fixture and its sidecar together, never one without the other.
+2. Never edit a `provider` fixture in place; if the request identity must
+   change, acquire a new fixture. Synthesized fixtures may be corrected in
+   place when the correction is documented.
+3. Never commit secrets. The inventory test scans committed JSON for
+   key-shaped keys and `fg_`/`sk_`/Bearer/JWT value prefixes.
+4. Keep filenames descriptive but remember they are **not** matching
+   identity; the sidecar `request_configuration` is.
+5. Update `docs/research/issue-23-alternate-scenarios.md` or a new research
+   note when a scenario's observed facts change.

--- a/docs/how-to/configure-live-mode.md
+++ b/docs/how-to/configure-live-mode.md
@@ -1,0 +1,126 @@
+# How To Configure Live Provider Execution
+
+Live execution makes authenticated FortyGuard calls through the server. It is
+a maintainer capability: it spends credits, and the public deployment must
+never enable it. This guide covers enabling live mode for local maintainer
+work and for the separately deployed, access-controlled `protected-live`
+instance. The boundary and rationale are in
+[ADR 0009](../adr/0009-separated-public-fixture-and-protected-live-deployments.md);
+the credit cost model is explained in
+[Cost model](../explanation/cost-model.md).
+
+Fixture mode needs none of this. See the
+[tutorial](../tutorials/first-run.md) for the offline path.
+
+## What live mode requires
+
+| Requirement                                 | Local maintainer run              | `protected-live` deployment                  |
+| ------------------------------------------- | --------------------------------- | -------------------------------------------- |
+| `ALLOW_LIVE=true`                           | required                          | required                                     |
+| `FORTYGUARD_API_KEY`                        | required                          | required (secret manager)                    |
+| `APP_PROFILE`                               | `local` (default)                 | `protected-live`                             |
+| `LIVE_AUTH_USERNAME` / `LIVE_AUTH_PASSWORD` | not used                          | required (HTTP Basic)                        |
+| `FORTYGUARD_CALL_BUDGET`                    | optional (record-only when unset) | required, positive                           |
+| `FORTYGUARD_LEDGER_PATH`                    | optional                          | required, absolute path on a persistent disk |
+
+Startup fails fast when any requirement is missing; the checks live in
+`app/settings.py` (`validate_profile_settings`). Setting
+`APP_PROFILE=public-fixture` forbids live execution and the API key entirely.
+
+## Configure a local live run
+
+Put the key in the process environment or a local `.env` file (never commit
+it; `.env` is gitignored and `.env.example` intentionally ships empty
+values):
+
+```bash
+export FORTYGUARD_API_KEY="your-key"
+export ALLOW_LIVE=true
+.venv/bin/uvicorn app.main:app --reload
+```
+
+Check the mode:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:8000/health
+```
+
+`"mode"` becomes `"live"` and `"execution_capability"` becomes
+`"fixture-and-live"`. A request may still explicitly ask for fixture
+execution; `execution_mode` is per request.
+
+Read-only credit reporting is available without enabling anything:
+
+```bash
+python scripts/fortyguard_usage.py
+python scripts/fortyguard_usage.py --start 2026-08-01 --end 2026-08-24
+```
+
+The utility submits the account-level usage request, prints the window, total
+credits, and an activity breakdown, and never prints the key.
+
+## Configure the protected live deployment
+
+The protected instance is a separate paid deployment, never the public
+Blueprint. For each of the following, use the provider's secret manager, not
+committed files:
+
+- `APP_PROFILE=protected-live`
+- `ALLOW_LIVE=true`
+- `FORTYGUARD_API_KEY` (secret)
+- `LIVE_AUTH_USERNAME` / `LIVE_AUTH_PASSWORD` (secrets)
+- `FORTYGUARD_CALL_BUDGET` — a finite, positive all-time call count
+- `FORTYGUARD_LEDGER_PATH` — an absolute path on a persistent disk
+
+Every route except `GET /health` then requires HTTP Basic authentication.
+Run exactly one worker and one instance so the in-process cache and the
+append-only ledger stay coherent. Provisioning steps and rollback are in
+[How to deploy](deploy.md).
+
+## Budgets and the ledger
+
+- Every submitted live activity is appended to the ledger at
+  `FORTYGUARD_LEDGER_PATH` (JSONL). `FORTYGUARD_LEDGER_PATH` set to an empty
+  value selects an in-memory ledger only.
+- `FORTYGUARD_CALL_BUDGET` counts **calls**, not credits: the provider does
+  not price per call, so credit truth comes only from reconciliation. When
+  unset, the ledger records without enforcing.
+- Optional enrichment has its own UTC calendar-day budget:
+  `FORTYGUARD_ENRICHMENT_CALL_BUDGET`. One submitted enrichment activity
+  consumes one unit even if it later fails; cache hits and fixture replay
+  consume none.
+- After acquisition, append the provider's authoritative account total:
+
+  ```bash
+  python scripts/reconcile_ledger.py --start 2026-08-01 --end 2026-08-30
+  ```
+
+## What changes when live is enabled
+
+- **United States geography gate.** A live trip request whose endpoints fall
+  outside the supported US extent receives an explicit
+  `unsupported_geography` unavailable response (HTTP 200 with
+  `state: "unavailable"`), because FortyGuard's documented coverage is
+  US-only.
+- **Degradation chain.** On a live-path failure the execution layer replays
+  an exact cache entry, then a matching fixture (date-relaxed for forecast
+  mode only), otherwise raises an explicit unavailable error. Replays are
+  labelled `source: "cache"` or `"fixture"` with `stale: true` and the true
+  data date, never presented as a current forecast. Budget exhaustion is an
+  HTTP 503 and is never degraded. See
+  [ADR 0004](../adr/0004-fixture-cache-provenance-ledger.md).
+- **Submit-once.** One `POST` per billable submission; transient transport
+  failures are retried as status `GET`s only. See
+  [ADR 0003](../adr/0003-bounded-polling-and-404-tolerance.md).
+
+## Safety rules
+
+1. Never commit `.env`, provider keys, Render keys, or Basic credentials.
+2. Never set `ALLOW_LIVE=true` on the public fixture deployment; the public
+   profile refuses the API key at startup, and bypassing that is a
+   product-boundary violation, not a configuration choice.
+3. Keep a finite `FORTYGUARD_CALL_BUDGET` on any long-lived live instance.
+4. Treat `docs/research/issue-7-san-antonio-provider-validation.md` as the
+   source of truth for observed provider behavior, including the
+   documented-vs-implemented transport mismatch (`api-key` header vs
+   `X-API-Key`).

--- a/docs/how-to/deploy.md
+++ b/docs/how-to/deploy.md
@@ -1,9 +1,10 @@
-# Deploying The Demo
+# How To Deploy The Public Fixture Demo
 
-This is the how-to guide for the public fixture deployment. The repository's
-`Dockerfile` builds the React/Vite frontend with Node 22, then installs the
-Python 3.12 FastAPI runtime in a smaller final stage. The final image contains
-`app`, committed `fixtures`, and `frontend/dist`; it runs one Uvicorn worker on
+This is the how-to guide for deploying the public fixture service (and,
+later, the separate protected live instance). The repository's `Dockerfile`
+builds the React/Vite frontend with Node 22, then installs the Python 3.12
+FastAPI runtime in a smaller final stage. The final image contains `app`,
+committed `fixtures`, and `frontend/dist`; it runs one Uvicorn worker on
 `0.0.0.0` and uses Render's `PORT` value.
 
 ## Free-Tier Boundaries
@@ -154,5 +155,7 @@ Render's deploy history, then rerun health and browser smoke tests. Keep
 `ALLOW_LIVE=false` during recovery. For a persistent provider incident, leave
 the public URL unchanged if possible and use the local recording fallback.
 
-See [ADR 0009](adr/0009-separated-public-fixture-and-protected-live-deployments.md)
+See [ADR 0009](../adr/0009-separated-public-fixture-and-protected-live-deployments.md)
 for the separation, authentication, ledger, Render, and rollback rationale.
+For the maintainer-only live instance requirements, see
+[How to configure live mode](configure-live-mode.md).

--- a/docs/how-to/record-the-demo.md
+++ b/docs/how-to/record-the-demo.md
@@ -1,0 +1,109 @@
+# How To Record The Demo
+
+This is the operational recipe for producing the submission recording. What
+to say while recording — the narration, the deterministic scene order, and
+the fallback handling — is the
+[demo script](../demo-script.md). This guide covers everything around it:
+preparation, environment choice, and post-recording checks.
+
+## Choose the recording environment
+
+Two supported environments, in preference order:
+
+1. **Hosted public fixture deployment**
+   (<https://heat-aware-tourism-guide-demo.onrender.com/>). Judges can also
+   open this URL themselves. Requires wake-up handling (below).
+2. **Local fixture run** — the deterministic fallback. Same fixture data,
+   same product states, no network dependency beyond browser OSM tiles.
+
+Record locally when the hosted service is asleep, degraded, or has a bad
+frontend build; the committed fixtures make the two runs equivalent at the
+product level.
+
+### Known hosted-demo state at time of writing
+
+The hosted curated form pins a fixed request date (currently `2026-08-23`)
+while every committed trip fixture is dated `2024-07-15`. Until the pinned
+date is corrected to match the fixture, submitting the hosted curated trip
+returns the explicit `scenario_unavailable` state, and the hosted UI does not
+offer the alternate scenarios. Before recording against the hosted demo,
+either correct the pinned date in `frontend/src/screens/TripSetupScreen.tsx`
+(`PUBLIC_FIXTURE_DATE`) and redeploy, or record the primary flow locally
+(where the date field is editable — set it to `2024-07-15`). The hotel
+ranking flow is date-independent and works on the hosted demo either way.
+
+## Prepare the environment
+
+1. **Quality gates.** From a clean checkout of the commit being demoed:
+
+   ```bash
+   npm run python:test
+   npm run python:test:integration
+   npm run frontend:test
+   npm run typecheck
+   npm run frontend:build
+   npm run e2e
+   ```
+
+   (`npx --prefix frontend playwright install chromium` once, if needed.)
+
+2. **Local run (if recording locally).** Two terminals:
+
+   ```bash
+   ALLOW_LIVE=false .venv/bin/uvicorn app.main:app --reload
+   ```
+
+   ```bash
+   npm run frontend:dev
+   ```
+
+   Record the browser at `http://127.0.0.1:5173`. Optionally disable all
+   non-loopback traffic in the browser or recording VM: the fixture flow
+   makes no provider requests (the Playwright suite proves this by aborting
+   every non-loopback route).
+
+3. **Hosted run (if recording hosted).** Follow
+   [How to deploy](deploy.md): check keep-warm layers are active, manually
+   warm the service, and rerun the smoke tests. Allow roughly one minute for
+   a sleeping free-tier instance to wake before starting the recording.
+
+4. **Fixtures.** Confirm the canonical date `2024-07-15` and window 08:00 to
+   20:00 reproduce the canonical analysis, and that the three alternate
+   scenarios and the unavailable state behave as scripted.
+
+## Record
+
+1. Start the recording at the trip setup screen; the health banner should
+   read "Fixture replay".
+2. Follow [the demo script](../demo-script.md) scene order exactly — it is
+   deterministic by design.
+3. Do not improvise provider explanations; every claim is worded to match
+   what the data provenance supports (fixture replay, returned alternatives,
+   modeled shade).
+4. Keep the full recording inside roughly five minutes.
+
+## Handle problems during recording
+
+- **Hosted service asleep or slow:** wait out the wake window, or switch to
+  the local flow and note the switch in the recording.
+- **Map tiles missing:** continue; browser OSM tiles are allowed but not a
+  readiness dependency. A missing basemap does not invalidate the fixture
+  demo.
+- **Unexpected unavailable state:** the explicit unavailable contract is a
+  product feature — follow the demo script's fallback scene to show it
+  deliberately, then restore the canonical setup and finish the primary
+  flow.
+- **Budget/503 errors:** impossible in fixture mode. If seen on a maintainer
+  live instance, stop; that environment is not for the public recording.
+
+## Verify after recording
+
+1. The recording shows: trip setup, best-time evidence and recommended hour,
+   hotel ranking with provenance, route comparison with coverage and
+   decision state, one deliberate unavailable state, and the restored
+   canonical result.
+2. No frame shows live provenance, provider credentials, or a claim of
+   global route optimality.
+3. The hosted health check still passes, and keep-warm remains configured
+   for the judging window (see [How to deploy](deploy.md) for disabling it
+   afterwards).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,173 @@
+# Reference: HTTP API
+
+All product routes are served by the FastAPI application (`app/main.py`,
+composed in `app/wiring.py`, routes defined in `app/api.py`). The domain
+schemas behind these payloads are in
+[Domain schemas](domain-schemas.md); the decision logic is explained in
+[Architecture](../explanation/architecture.md) and the ADRs.
+
+Authentication: in the `protected-live` profile, every route except
+`GET /health` requires HTTP Basic authentication (`401` otherwise). In
+`local` and `public-fixture` profiles, no authentication is used.
+
+Error model (three-way split):
+
+- Validation problems (`KeyError`/`TypeError`/`ValueError`) → **HTTP 400**
+  `{"status": "error", "error": "<message>"}`.
+- Budget exhaustion, provider failures, and unavailable scenarios →
+  **HTTP 503** `{"status": "unavailable", "error": "<message>",
+"error_kind": "<kind>"}` (kinds include `budget_exceeded`).
+- Product-level "unavailable" decisions (for example a trip with no matching
+  fixture) are **HTTP 200** responses with `state: "unavailable"` inside the
+  payload, not errors.
+
+## GET /health
+
+Unauthenticated in every profile. Never calls FortyGuard, Overpass, or OSRM.
+
+```json
+{
+  "status": "ok",
+  "deployment_profile": "public-fixture",
+  "mode": "fixture",
+  "execution_capability": "fixture-only"
+}
+```
+
+`mode` is `"live"` or `"fixture"`; `execution_capability` is
+`"fixture-and-live"` or `"fixture-only"`.
+
+## GET /api/places/search?q=<query>
+
+Place search over the built-in San Antonio catalog (Menger Hotel, The Alamo,
+Main Plaza, Historic Market Square (El Mercado), San Fernando Cathedral,
+Spanish Governor's Palace, Briscoe Western Art Museum, Tower of the
+Americas). Queries shorter than two characters return `400`. Returns
+`{"places": [...]}`.
+
+## POST /api/heatmap
+
+Point heatmap analysis. Request body (JSON object):
+
+| Field                     | Required                   | Notes                                                            |
+| ------------------------- | -------------------------- | ---------------------------------------------------------------- |
+| `analytic_type`           | yes                        | `tcm`, `exceedance`, or `persistence`.                           |
+| `latitude`, `longitude`   | yes                        | Finite; must be inside the US extent.                            |
+| `start_date`              | yes                        | ISO date string.                                                 |
+| `forecast`                | no                         | Boolean, default `true`.                                         |
+| `threshold_celsius`       | for exceedance/persistence | Framing threshold in °C.                                         |
+| `direction`               | for exceedance/persistence | `above` or `below`.                                              |
+| `granularity`             | no                         | 60, 80, or 100 (default 60).                                     |
+| `start_hour` / `end_hour` | no                         | Both or neither; window at most 12 hours.                        |
+| `execution_mode`          | no                         | `fixture` (default) or `live`; `live` is rejected when disabled. |
+
+Response: `{"tiles": [Tile...], "provenance": {...}, "activity": {...}?}`.
+Each tile carries identity, geometry, metric, `value_celsius` (tcm) or
+`metric_value` + unit, source, valid time, forecast flag, threshold and
+direction, and activity ID. Provenance `source` is `provider` (live),
+`cache`, or `fixture`; replayed results are marked `stale`.
+
+## POST /api/env-params
+
+Environmental parameter series for one point. Request body:
+
+| Field                        | Required | Notes                                                 |
+| ---------------------------- | -------- | ----------------------------------------------------- |
+| `latitude`, `longitude`      | yes      | Finite; US extent.                                    |
+| `start_date`                 | yes      | ISO date string.                                      |
+| `temperature_anchor_celsius` | yes      | The caller-supplied °C anchor the series is fixed to. |
+| `hour`                       | no       | Single hour 0-23; exclusive with the window pair.     |
+| `start_hour` / `end_hour`    | no       | Window pair; at most 12 hours.                        |
+| `execution_mode`             | no       | `fixture` or `live`.                                  |
+
+Response: `{"entries": [...], "timezone", "forecast", "warning",
+"provenance"}`. Entries are per-hour with `valid_time`, nullable metric
+values (missing stays `null`, never zero), and the canonical parameter map.
+The standing `warning` states that the series is fixed to the caller-supplied
+anchor and is not a real 24-hour forecast.
+
+## POST /api/trip/analyze
+
+The main product endpoint: one complete trip setup in, one
+`trip-contract-v2` product response out. Request body:
+
+| Field                                                                                  | Required | Notes                                 |
+| -------------------------------------------------------------------------------------- | -------- | ------------------------------------- |
+| `mode`                                                                                 | yes      | `curated` or `exploratory`.           |
+| `origin_latitude`, `origin_longitude`, `destination_latitude`, `destination_longitude` | yes      | Finite coordinates.                   |
+| `landmark_name`, `district_name`                                                       | yes      | Non-empty strings.                    |
+| `date`                                                                                 | yes      | ISO date string.                      |
+| `start_hour`, `end_hour`                                                               | yes      | Whole hours; window at most 12 hours. |
+| `cautious`                                                                             | no       | Boolean, default `false`.             |
+| `execution_mode`                                                                       | no       | `fixture` or `live`.                  |
+
+Constraints:
+
+- `hour` is no longer accepted (use `start_hour`/`end_hour`).
+- Server-owned analysis fields (`heat_metric`, `hotels`, `routes`,
+  `provenance`, ...) submitted by the caller are rejected with `400`.
+- Curated mode must use the canonical scenario: landmark `The Alamo`,
+  district `Downtown San Antonio`, origin `29.4245914, -98.4864288`
+  (Menger Hotel), destination `29.425833, -98.485833` (The Alamo).
+- Live execution additionally requires both endpoints inside the supported
+  US extent; otherwise the response is an HTTP 200
+  `state: "unavailable"` with code `unsupported_geography`.
+
+Response envelope (`api`): `request_identity`, `mode`, `execution_mode`,
+`state` (`success` | `degraded` | `unavailable`), and per-state `best_time`,
+`hotels`, `routes`, `unavailable`, `degraded_reasons`, plus
+`result_set_token` when a usable result set exists. The token authorizes
+optional enrichment for fifteen minutes.
+
+The committed fixture set answers these identities (date `2024-07-15`):
+
+| Scenario                                           | Mode        | Window      | Outcome                                                    |
+| -------------------------------------------------- | ----------- | ----------- | ---------------------------------------------------------- |
+| Menger Hotel → The Alamo                           | curated     | 08:00-20:00 | Degraded: hour-only best time, single returned route.      |
+| Main Plaza → Historic Market Square                | exploratory | 10:00-17:00 | Single returned route.                                     |
+| San Fernando Cathedral → Spanish Governor's Palace | exploratory | 10:00-17:00 | Two routes, weak height evidence, no route recommendation. |
+| Briscoe Western Art Museum → Tower of the Americas | exploratory | 10:00-17:00 | Whole-trip unavailable (`provider_data_missing`).          |
+
+Any other identity returns `state: "unavailable"` with code
+`scenario_unavailable`.
+
+## POST /api/hotels/rank
+
+District hotel heat ranking. Request body allows exactly
+`district_name` (required, non-empty), `execution_mode`, and `weights`.
+`weights` must contain exactly `night`, `hot_hours`, `persistence`, `day` —
+finite, non-negative, summing to 1 (tolerance 0.001).
+
+Response: `{"state": "available" | "unavailable", "district_name",
+"execution_mode", "reason", "discovered_count", "usable_count",
+"components", "ranking", "result_set_token"?}`. The ranking contains the
+weights used (`weight_label`: `product defaults` or `custom`), complete
+candidate count, ranked output, and hotel entries with component
+assignments and percentiles. Fewer than five usable hotels is an explicit
+`unavailable` state, not an empty success.
+
+## Optional enrichment
+
+Three drill-down routes operating on an existing result set:
+
+| Route                                     | Kind             | Extra request fields                                             |
+| ----------------------------------------- | ---------------- | ---------------------------------------------------------------- |
+| `POST /api/hotels/{hotel_id}/environment` | environment      | `temperature_anchor_celsius` (required, finite).                 |
+| `POST /api/routes/{route_id}/canopy`      | satellite canopy | —                                                                |
+| `POST /api/routes/{route_id}/street-view` | street view      | optional `point {latitude, longitude}` within 50 m of the route. |
+
+All three require `result_set_token` (from a prior trip or hotel response)
+and accept optional `refresh`. The target must belong to the token's result
+set. Responses: `{"status": "success", "kind", "target_id", "state",
+"reason?", "base_result", "usage", "provenance?", "limitations", "payload"}`.
+Invalid or malformed tokens return `400` (`invalid_result_set_token`);
+expired tokens return `410` (`result_set_expired`); targets outside the
+result set return `400` (`result_not_in_result_set`). Enrichment never
+alters the base result; failure preserves it with an item-level unavailable
+state.
+
+## Static assets and SPA fallback
+
+`GET /assets/*` serves the built frontend; `GET /{path}` falls back to the
+SPA `index.html` for deep links. These exist so one service can serve the
+whole product (see `render.yaml` and the [deployment guide](../how-to/deploy.md)).

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,0 +1,98 @@
+# Reference: Commands
+
+All npm scripts route Python through `scripts/python-tool.mjs`, which
+resolves the repository virtual environment (`.venv/bin/python` on Unix,
+`.venv\Scripts\python.exe` on Windows) — the same interpreter the commands
+below assume when run directly.
+
+## Quality gates
+
+| Command                                          | What it runs                                           |
+| ------------------------------------------------ | ------------------------------------------------------ |
+| `npm run python:format:check`                    | `ruff format --check app tests`                        |
+| `npm run python:lint`                            | `ruff check app tests`                                 |
+| `npm run python:typecheck`                       | `mypy app tests`                                       |
+| `npm run python:test`                            | `pytest -q -m "not integration"` (unit tier)           |
+| `npm run python:test:integration`                | `pytest -q -m integration` (fixture-backed HTTP suite) |
+| `npm run frontend:format:check`                  | `prettier --check frontend`                            |
+| `npm run frontend:lint`                          | ESLint (zero warnings allowed)                         |
+| `npm run frontend:typecheck`                     | `tsc --noEmit`                                         |
+| `npm run frontend:test`                          | Vitest                                                 |
+| `npm run frontend:build`                         | Vite production build                                  |
+| `npm run e2e`                                    | Playwright fixture flow (see below)                    |
+| `npm run format:check`                           | `prettier --check .` (whole repository)                |
+| `npm run format`                                 | `prettier --write .`                                   |
+| `npm run typecheck`                              | Python + frontend typechecks                           |
+| `npm run test`                                   | Python unit + frontend unit tests                      |
+| `.venv/bin/python -m pip_audit`                  | Python dependency audit                                |
+| `npm audit --audit-level=high`                   | Root Node dependency audit                             |
+| `npm audit --prefix frontend --audit-level=high` | Frontend dependency audit                              |
+
+Every automated check sets or retains `ALLOW_LIVE=false` and requires no
+provider credentials.
+
+### End-to-end fixture flow
+
+```bash
+npx --prefix frontend playwright install chromium   # once
+npm run e2e
+```
+
+Playwright starts the fixture-backed backend itself
+(`uvicorn app.main:app` on `127.0.0.1:8000`, `ALLOW_LIVE=false`), blocks
+every non-loopback browser request, and drives all four trip scenarios
+through the visible UI.
+
+## Development servers
+
+| Command                | Serves                                                                                 |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| `npm run backend:dev`  | FastAPI with reload at `http://127.0.0.1:8000`                                         |
+| `npm run frontend:dev` | Vite dev server at `http://127.0.0.1:5173`, proxying `/api` and `/health` to port 8000 |
+
+Equivalent direct invocation:
+
+```bash
+ALLOW_LIVE=false .venv/bin/uvicorn app.main:app --reload
+```
+
+After `npm run frontend:build`, the backend alone serves the whole product
+at `http://127.0.0.1:8000`.
+
+## Maintenance scripts (`scripts/`)
+
+Maintainer acquisition and research tools. The FortyGuard paths are
+credential-gated and billable; see
+[How to acquire fixtures](../how-to/acquire-fixtures.md).
+
+| Command                                                                                          | Network                                            | Purpose                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `python scripts/acquire_fixture.py --scenario <name>`                                            | FortyGuard / OSRM / Overpass (depends on scenario) | Acquire one sanitized fixture pair plus sidecar. Scenarios: `tcm-historical`, `tcm-forecast`, `exceedance-historical`, `env-params-anchor35`, `canonical-menger-alamo`, `main-plaza-market-square`, `cathedral-governors-palace`, `cathedral-governors-palace-buildings`. |
+| `python scripts/acquire_fixture.py --plan-issue-23` / `--execute-issue-23`                       | FortyGuard                                         | Inspect or run the staged nine-activity issue 23 plan.                                                                                                                                                                                                                    |
+| `python scripts/acquire_fixture.py --execute-issue-23-hotels-resume`                             | FortyGuard                                         | Resume the three hotel activities.                                                                                                                                                                                                                                        |
+| `python scripts/acquire_fixture.py --execute-issue-23-canonical-env-recovery --activity-id <id>` | FortyGuard                                         | Status-only recovery of a prior env-params activity (ledger-preserving).                                                                                                                                                                                                  |
+| `python scripts/generate_trip_snapshots.py [--overwrite]`                                        | none                                               | Regenerate `fixtures/trips/*.trip.json` from committed inputs with hash verification.                                                                                                                                                                                     |
+| `python scripts/reconcile_ledger.py [--start D] [--end D]`                                       | FortyGuard account endpoint                        | Append the authoritative credit total for a window to the ledger.                                                                                                                                                                                                         |
+| `python scripts/fortyguard_usage.py [--start D] [--end D]`                                       | FortyGuard account endpoint                        | Read-only credit usage report; prints nothing secret.                                                                                                                                                                                                                     |
+| `python scripts/lidar_corridor_probe.py [--download] [--city …]`                                 | USGS TNM API                                       | Record lidar coverage metadata (and optionally LAZ tiles) for the bounded corridors.                                                                                                                                                                                      |
+| `python scripts/derive_lidar_corridor_stats.py <file.laz>`                                       | none                                               | Research-only LAZ screening stats (needs `laspy[lazrs]` in a local research env).                                                                                                                                                                                         |
+| `python scripts/validate_building_lidar_heights.py <osm.xml> <file.laz> [--route-json …]`        | none                                               | Compare OSM building heights against lidar-derived estimates.                                                                                                                                                                                                             |
+
+Dates are ISO (`YYYY-MM-DD`). `--ledger-path` overrides
+`FORTYGUARD_LEDGER_PATH` for the run.
+
+## Direct backend access
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:8000/health
+```
+
+API request/response shapes for `curl`-level smoke tests are in the
+[API reference](api.md).
+
+## Git hooks
+
+`npm install` enables Husky. Each commit runs lint-staged (Prettier on
+staged files; ruff format/check --fix on staged Python), then the local
+type checks and unit tests. CI additionally runs the integration suite,
+the Playwright flow, and the dependency audits.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,114 @@
+# Reference: Configuration Options
+
+This page maps the product's configurable behavior to where it lives and
+what changing it means. The raw variable table is in
+[Environment variables](environment-variables.md). Anything labeled
+**product policy** is a team decision, not a scientific or provider
+standard — the full list of such policies with citations is in
+[the proposal fact check](../research/proposal-fact-check.md).
+
+## Deployment profiles
+
+Chosen with `APP_PROFILE`; validated at startup.
+
+| Profile          | Purpose                                | Live capability                                                      | Authentication                                                                                   |
+| ---------------- | -------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `local`          | Development and fixture-backed review. | Optional (`ALLOW_LIVE`), credential-gated.                           | None.                                                                                            |
+| `public-fixture` | The public demo deployment.            | Impossible: refuses `FORTYGUARD_API_KEY`, forces `ALLOW_LIVE=false`. | None.                                                                                            |
+| `protected-live` | Maintainer live instance.              | Required.                                                            | HTTP Basic on every route except `/health`, finite call budget, absolute persistent ledger path. |
+
+A profile governs startup guarantees and access; per-result `execution_mode`
+(`fixture`/`live`) governs where an individual result originates. The two
+are deliberately separate ([ADR 0009](../adr/0009-separated-public-fixture-and-protected-live-deployments.md)).
+
+## Execution mode and degradation
+
+`ALLOW_LIVE` enables live execution. On a live-path failure the execution
+layer degrades in order: exact cache entry → matching fixture (date-relaxed
+for forecast mode only) → explicit unavailable error. Every replay is
+labelled and marked stale; budget exhaustion (HTTP 503) is never degraded
+([ADR 0004](../adr/0004-fixture-cache-provenance-ledger.md)).
+
+Polling bounds (interval, max polls, timeout, 404 grace) are configurable;
+transient failures retry as status `GET`s only — billable work is submitted
+once ([ADR 0003](../adr/0003-bounded-polling-and-404-tolerance.md)).
+
+## Heat policy thresholds
+
+| Option                     | Default                                                | Where                             | Notes                                                    |
+| -------------------------- | ------------------------------------------------------ | --------------------------------- | -------------------------------------------------------- |
+| NOAA Heat Index boundaries | 80 / 90 / 105 / 130 °F (≈26.7 / 32.2 / 40.6 / 54.4 °C) | `app/domain/heat_policy.py`       | Verified NOAA/NWS boundaries; fixed, not configurable.   |
+| Provider TCM bands         | 30 / 35 / 40 °C                                        | `app/domain/heat_policy.py`       | Product policy, deliberately separate from NOAA.         |
+| Cautious guidance shift    | one band earlier                                       | `app/domain/heat_policy.py`       | Product safety policy, not a medical transformation.     |
+| Framing threshold          | 35 °C above                                            | acquisition request configuration | Visible in provenance; not presented as a NOAA boundary. |
+
+See [Heat metrics](../explanation/heat-metrics.md) for the interpretation
+semantics.
+
+## Hotel ranking weights
+
+Defaults: night 35 %, hot hours 25 %, persistence 20 %, day 20 %
+(`app/domain/hotel_heat_score.py`). Configurable per request through
+`POST /api/hotels/rank` (`weights` object with exactly those four keys,
+summing to 1). Not environment-configurable. Semantics and caveats are in
+[Hotel weights](../explanation/hotel-weights.md).
+
+## Route analysis options
+
+| Option                        | Default | Env variable                      | Notes                                                                                                                          |
+| ----------------------------- | ------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Representative route distance | 1500 m  | `ROUTE_REPRESENTATIVE_DISTANCE_M` | Routes at or below it reuse the retained landmark TCM; longer routes share one corridor AOI (ADR 0006). Engineering heuristic. |
+| Minimum route heat coverage   | 0.70    | `ROUTE_MINIMUM_HEAT_COVERAGE`     | Per-route tile coverage needed to trust route heat.                                                                            |
+| Area corridor buffer          | 25 m    | `FORTYGUARD_AREA_BUFFER_M`        | Buffer around route geometry for the shared AOI.                                                                               |
+| Area granularity              | 100     | `FORTYGUARD_AREA_GRANULARITY`     | Provider tile granularity (60/80/100).                                                                                         |
+
+## Modeled shade options (ADR 0007)
+
+| Option                           | Default           | Env variable                             | Notes                                                                                  |
+| -------------------------------- | ----------------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| Building search distance         | 250 m             | `SHADE_BUILDING_SEARCH_DISTANCE_M`       | Route corridor for building acquisition.                                               |
+| Minimum building-height coverage | 0.70              | `SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE` | Area-weighted explicit+inferred height coverage needed to trust shade. Product policy. |
+| Metres per level                 | 3.0               | `SHADE_METRES_PER_LEVEL`                 | `building:levels` → height approximation.                                              |
+| Canonical timezone               | `America/Chicago` | `TRIP_CANONICAL_TIMEZONE`                | Exact-time shade evaluation timezone.                                                  |
+
+Shade model identity (`route-shade-v1`, solar model `astral-3.2-apparent`)
+is recorded in results; assumptions are in
+[Shade assumptions](../explanation/shade-assumptions.md).
+
+## Budgets and the ledger
+
+- `FORTYGUARD_CALL_BUDGET` — all-time core call cap; unset = record-only.
+- `FORTYGUARD_ENRICHMENT_CALL_BUDGET` — per-UTC-day enrichment cap.
+- `FORTYGUARD_LEDGER_PATH` — JSONL append-only ledger location.
+
+Credit truth comes only from reconciliation, never from per-call estimates
+([Cost model](../explanation/cost-model.md)).
+
+## Hotel district and place catalog
+
+- `HOTEL_DISTRICT_BBOX` pins the Downtown San Antonio / Alamo Plaza hotel
+  AOI. The fixture hotel service is additionally district-locked to
+  `Downtown San Antonio`.
+- The place catalog (`app/places.py`) fixes the eight searchable San Antonio
+  places and their pinned coordinates. Adding a place is a code change with
+  catalog tests, not a configuration change.
+
+## Fixture sets
+
+Wired explicitly in `app/wiring.py`:
+
+- Root demo fixtures: heatmap variants (including empty/failed/malformed
+  error states), env-params, hotel heat analysis, enrichment payloads.
+- `fixtures/providers/` — genuine issue 23 acquisitions (FortyGuard, OSRM,
+  Overpass).
+- `fixtures/trips/` — four `trip-contract-v2` product snapshots with
+  content-addressed `derived_from` links.
+
+Matching is by sidecar `request_configuration` only; see
+[How to acquire fixtures](../how-to/acquire-fixtures.md).
+
+## Frontend build
+
+The Vite dev server proxies `/api` and `/health` to the backend port 8000;
+in deployment the backend serves the built assets itself. The public
+fixture UI pins the curated scenario (places, hours, and a fixed date).

--- a/docs/reference/domain-schemas.md
+++ b/docs/reference/domain-schemas.md
@@ -1,0 +1,118 @@
+# Reference: Domain Schemas
+
+The product's contracts live in `app/domain/` — pure dataclasses and enums
+with no I/O — so fixture replay, live execution, and HTTP responses all share
+one validated shape. This page is the reading guide for the enums and the
+response models you meet in the API and the fixtures. Provenance rules are
+in [ADR 0004](../adr/0004-fixture-cache-provenance-ledger.md); the snapshot
+codec is [ADR 0010](../adr/0010-trip-v2-product-snapshots.md).
+
+## Core enums (`app/domain/contracts.py`)
+
+| Enum                    | Values                                                                                                                                                                                                                                   | Meaning                                                                                                                       |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `TripMode`              | `curated`, `exploratory`                                                                                                                                                                                                                 | Fixed canonical trip vs traveler-chosen places.                                                                               |
+| `ExecutionMode`         | `fixture`, `live`                                                                                                                                                                                                                        | Where a result comes from, per request.                                                                                       |
+| `ResultState`           | `series_ready`, `success`, `degraded`, `unavailable`, `error`                                                                                                                                                                            | Product response state; trip-contract-v2 permits only `success`, `degraded`, `unavailable`.                                   |
+| `HeatStatus`            | `elevated`, `not_elevated`                                                                                                                                                                                                               | Whether the applicable heat interpretation crosses the action threshold.                                                      |
+| `RouteSetState`         | `alternatives_returned`, `single_route`, `no_suitable_returned_route`                                                                                                                                                                    | What the routing provider returned.                                                                                           |
+| `RouteDecisionState`    | `mild_shortest_recommended`, `shade_required`, `shade_shadiest_recommended`, `shade_only_route_recommended`, `nighttime_coolest_recommended`, `insufficient_shade_comparison_required`, `heat_unavailable`, `no_suitable_returned_route` | The route comparison's explicit decision (ADR 0006/0007).                                                                     |
+| `TemporalEvidenceState` | `exact`, `inconsistent`, `unavailable`                                                                                                                                                                                                   | Whether best-time evidence is an exact timestamp.                                                                             |
+| `RouteHeatSource`       | `landmark_reuse`, `shared_corridor`                                                                                                                                                                                                      | Whether route heat reuses the landmark TCM or comes from a shared corridor AOI.                                               |
+| `Confidence`            | `sufficient`, `insufficient`                                                                                                                                                                                                             | Evidence confidence for recommendations.                                                                                      |
+| `MetricLabel`           | `provider_tcm`, `noaa_heat_index`                                                                                                                                                                                                        | Which metric the interpretation used.                                                                                         |
+| `HeatBand`              | `below_caution`, `caution`, `extreme_caution`, `danger`, `extreme_danger`, `provider_lower`, `provider_moderate`, `provider_higher`, `provider_very_high`                                                                                | NOAA Heat Index bands (first five) vs product-only TCM bands (last four). See [Heat metrics](../explanation/heat-metrics.md). |
+| `GuidancePolicy`        | `standard`, `cautious`                                                                                                                                                                                                                   | Whether the action threshold shifts one band earlier.                                                                         |
+| `EnrichmentState`       | `available`, `unavailable`, `not_requested`                                                                                                                                                                                              | Optional enrichment outcome.                                                                                                  |
+
+## Provenance
+
+Service-level provenance (`app/domain/provenance.py`): `source`
+(`provider`/`cache`/`fixture`), `retrieved_at`, `data_date`, `stale`,
+`forecast`, optional `activity_id`, sanitized `raw_payload`, and
+`transformations` (named, versioned inference steps such as
+`tcm_unit_celsius` or `live_envelope_unwrapped`). Cache and fixture replays
+are always marked `stale: true` with the true data date.
+
+The acquisition sidecar `AcquisitionRecord` carries the full match identity:
+`source` (`provider` or `synthesized`), provider identity, endpoint,
+`request_configuration`, retrieval time, data date, status, schema version,
+provider configuration version, safe activity ID, `derived_from` references
+(fixture path, role, payload and sidecar SHA-256), and transformations.
+
+## Heat interpretation
+
+`HeatInterpretation` is the typed classification attached to best-time and
+route results: metric, °C value, band, band label, action threshold band,
+guidance policy, whether the value is an actual heat index, NOAA
+availability, `action_required`, and the applied policy string. Provider TCM
+values never claim to be NOAA Heat Index.
+
+## Best time
+
+`BestTimeResult`: hourly entries with metric values, `recommendation_hour`,
+`recommendation_reason`, metric label, provenance, `hourly_coverage`,
+`heat_interpretation`, optional `environmental_concerns`,
+`recommended_hour_tcm_celsius`, framing `exceedance_hours` /
+`persistence_hours` with the declared 35 °C threshold and direction,
+optional `recommendation_time` + timezone, and `temporal_evidence`. The
+environmental concern profile assesses all requested parameters per hour
+against declared NOAA, EPA, physiological, and product thresholds; missing
+parameters are `not_reported`, never assumed safe.
+
+## Hotel ranking
+
+`HotelRankingResult`: ranked hotels with four components (`night`,
+`hot_hours`, `persistence`, `day`), score, percentile, and tie groups;
+weights actually used; usable and discovered counts; provenance; optional
+enrichment; component units (°C or hours); component temporal metadata with
+the `date_level_not_interval_maximum` caveat. Scoring semantics are in
+[Hotel weights](../explanation/hotel-weights.md).
+
+## Route comparison
+
+`RouteOption` per returned route: identity, distance, duration, heat value
+and status, optional `modeled_shade_percent` with confidence and model
+label, building coverage (explicit/inferred/unknown fractions and counts),
+recommendation flag and reason, geometry, heat coverage and source, heat
+interpretation, and shade limitations.
+
+`RouteComparisonResult`: alternatives, `recommended_id`, reason, heat
+status, corridor heat value, metric and unit, coverage, confidence,
+comparison scope (`returned alternatives`), provenance, fallback reason,
+route-set and decision states, plus routing/heat/building/solar provenance.
+
+## Trip response and the v2 codec
+
+`TripAnalysisResponse` enforces per-state invariants: `success` carries
+best time, hotels, and routes; `degraded` additionally carries non-empty
+`degraded_reasons` keyed by `best_time`/`hotels`/`routes`; `unavailable`
+carries `unavailable` with reason, recoverable flag, code (default
+`scenario_unavailable`), and optional action.
+
+`app/services/trip_contract_v2.py` is the strict shared codec
+(`SCHEMA_VERSION = "trip-contract-v2"`). `encode_trip_analysis_v2` produces
+the snapshot shape (`schema_version`, `state`, `best_time`, `hotels`,
+`routes`, `unavailable`, `degraded_reasons`); the API envelope adds
+`request_identity`, `mode`, `execution_mode`. The decoder validates exact
+key sets, types, finite numbers, and ISO datetimes, and re-checks request
+alignment. The same codec is used for live, fixture, and HTTP responses;
+v1 compatibility is intentionally absent. Product snapshots under
+`fixtures/trips/` are generated offline from normalized acquisitions and are
+never hand-authored.
+
+## Result-set tokens
+
+`app/domain/result_tokens.py` issues HMAC-SHA256-signed, URL-safe tokens
+(default TTL 15 minutes) embedding the request identity, trusted base
+result IDs, and route geometry. They authorize optional enrichment without
+recomputing the base result or trusting caller-supplied coordinates
+([ADR 0008](../adr/0008-optional-enrichment-budgets-and-boundaries.md)).
+
+## Credit ledger records
+
+`data/ledger.jsonl` holds two record kinds (`app/domain/ledger.py`): `call`
+records (activity ID, endpoint, `credits_used` when the provider prices it,
+completion time, status, core/enrichment scope) and `reconciliation`
+records (authoritative account totals for a date window). Reload is
+idempotent. See [Cost model](../explanation/cost-model.md).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,108 @@
+# Reference: Environment Variables
+
+Settings are loaded by `app/settings.py` from the process environment and an
+optional `.env` file at the repository root. The process environment always
+wins over the file; an explicitly set empty value unsets whatever the file
+provided. `.env.example` documents the common subset and contains no secret
+values.
+
+## Deployment and execution mode
+
+| Variable                  | Default                      | Meaning                                                                                                                                      |
+| ------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `APP_PROFILE`             | `local`                      | Deployment profile: `local`, `public-fixture`, or `protected-live`. Drives startup validation, authentication, and capability guarantees.    |
+| `ALLOW_LIVE`              | `false`                      | Enables live provider execution. Must be `false` for `public-fixture`, `true` for `protected-live`.                                          |
+| `FORTYGUARD_API_KEY`      | (unset)                      | Provider key. Required when `ALLOW_LIVE=true` (except `public-fixture`, which forbids it). Secret — never commit.                            |
+| `FORTYGUARD_BASE_URL`     | `https://api.fortyguard.com` | Provider base URL.                                                                                                                           |
+| `RESULT_SET_TOKEN_SECRET` | (unset)                      | HMAC secret for signing result-set tokens. When unset, tokens are unsigned (acceptable for local fixture use; required on `protected-live`). |
+
+## Live authentication (`protected-live` only)
+
+| Variable             | Default | Meaning                                                                                             |
+| -------------------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `LIVE_AUTH_USERNAME` | (unset) | HTTP Basic username. Required for `protected-live`.                                                 |
+| `LIVE_AUTH_PASSWORD` | (unset) | HTTP Basic password. Required for `protected-live`. Secrets — store in the provider secret manager. |
+
+## FortyGuard polling (ADR 0003)
+
+| Variable                           | Default | Meaning                                                               |
+| ---------------------------------- | ------- | --------------------------------------------------------------------- |
+| `FORTYGUARD_POLL_INTERVAL_SECONDS` | `5.0`   | Delay between status polls. Positive number.                          |
+| `FORTYGUARD_MAX_POLLS`             | `24`    | Hard cap on polls per activity. Positive integer.                     |
+| `FORTYGUARD_TIMEOUT_SECONDS`       | `30.0`  | Per-request HTTP timeout.                                             |
+| `FORTYGUARD_404_GRACE_CHECKS`      | `3`     | Tolerated consecutive 404 status checks immediately after submission. |
+
+## Cost ledger and budgets (ADR 0004)
+
+| Variable                                   | Default             | Meaning                                                                                                                                          |
+| ------------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `FORTYGUARD_CALL_BUDGET`                   | (unset)             | All-time cap on submitted live core calls. Unset means record-only. Enforced unit is calls, not credits. Required positive for `protected-live`. |
+| `FORTYGUARD_LEDGER_PATH`                   | `data/ledger.jsonl` | Append-only JSONL ledger path. Empty value selects an in-memory ledger. Must be an absolute path on a persistent disk for `protected-live`.      |
+| `FORTYGUARD_ENRICHMENT_CALL_BUDGET`        | (unset)             | Separate per-UTC-calendar-day cap on submitted enrichment activities. Unset means record-only.                                                   |
+| `FORTYGUARD_ENVIRONMENT_ESTIMATED_CREDITS` | (unset)             | Estimated credits per environment enrichment submission (display only).                                                                          |
+| `FORTYGUARD_SATELLITE_ESTIMATED_CREDITS`   | (unset)             | Same, satellite canopy.                                                                                                                          |
+| `FORTYGUARD_STREETVIEW_ESTIMATED_CREDITS`  | (unset)             | Same, street view.                                                                                                                               |
+
+## Area heatmap requests
+
+| Variable                           | Default | Meaning                                        |
+| ---------------------------------- | ------- | ---------------------------------------------- |
+| `FORTYGUARD_AREA_BUFFER_M`         | `25.0`  | Corridor buffer around route geometry, metres. |
+| `FORTYGUARD_AREA_GRANULARITY`      | `100`   | Tile granularity (60, 80, or 100).             |
+| `FORTYGUARD_AREA_USE_BOUNDING_BOX` | `true`  | Use the bounding rectangle as the AOI polygon. |
+| `FORTYGUARD_AREA_MAX_VERTICES`     | `200`   | Maximum AOI polygon vertices.                  |
+
+## OSRM routing
+
+| Variable                          | Default                                                 | Meaning                                                                                  |
+| --------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `OSRM_BASE_URL`                   | `https://routing.openstreetmap.de/routed-foot/route/v1` | FOSSGIS pedestrian OSRM instance.                                                        |
+| `OSRM_PROFILE`                    | `foot`                                                  | Routing profile.                                                                         |
+| `OSRM_USER_AGENT`                 | `HeatAwareTourismGuide/0.1 (contact: …)`                | Descriptive User-Agent.                                                                  |
+| `OSRM_TIMEOUT_SECONDS`            | `15.0`                                                  | Request timeout.                                                                         |
+| `OSRM_PROVIDER_INSTANCE`          | `fossgis-routed-foot`                                   | Provider instance identity used in cache keys and sidecars.                              |
+| `ROUTE_REPRESENTATIVE_DISTANCE_M` | `1500.0`                                                | Short/long route threshold: routes at or below it reuse the retained landmark TCM value. |
+| `ROUTE_MINIMUM_HEAT_COVERAGE`     | `0.70`                                                  | Minimum per-route tile coverage for trusting route heat. At most 1.                      |
+
+## Overpass (hotels, buildings)
+
+| Variable                       | Default                                   | Meaning                                                                             |
+| ------------------------------ | ----------------------------------------- | ----------------------------------------------------------------------------------- |
+| `OVERPASS_ENDPOINT`            | `https://overpass-api.de/api/interpreter` | Overpass API endpoint.                                                              |
+| `OVERPASS_USER_AGENT`          | `HeatAwareTourismGuide/0.1 (contact: …)`  | Descriptive User-Agent.                                                             |
+| `OVERPASS_TIMEOUT_SECONDS`     | `30.0`                                    | Query timeout.                                                                      |
+| `OVERPASS_MAX_ATTEMPTS`        | `2`                                       | Bounded attempts per query.                                                         |
+| `OVERPASS_RETRY_DELAY_SECONDS` | `30.0`                                    | Delay before retry (HTTP 429 handling).                                             |
+| `HOTEL_DISTRICT_BBOX`          | `29.421,-98.490,29.429,-98.482`           | Hotel district AOI as `south,west,north,east` (Downtown San Antonio / Alamo Plaza). |
+
+## Modeled shade (ADR 0007)
+
+| Variable                                 | Default                       | Meaning                                                                                                    |
+| ---------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `SHADE_BUILDING_SEARCH_DISTANCE_M`       | `250.0`                       | Route corridor width for building acquisition.                                                             |
+| `SHADE_MINIMUM_BUILDING_HEIGHT_COVERAGE` | `0.70`                        | Area-weighted building-height coverage needed to trust modeled shade. Product policy, not an OSM standard. |
+| `SHADE_METRES_PER_LEVEL`                 | `3.0`                         | Approximation used to infer height from `building:levels`.                                                 |
+| `TRIP_CANONICAL_TIMEZONE`                | `America/Chicago`             | Canonical trip timezone (IANA name).                                                                       |
+| `SHADE_BUILDING_SCHEMA_VERSION`          | `building-v1`                 | Building fixture schema version.                                                                           |
+| `SHADE_PROVIDER_CONFIG_VERSION`          | `overpass-building-config-v1` | Provider configuration identity.                                                                           |
+| `SHADE_MODEL_VERSION`                    | `route-shade-v1`              | Shade model identity.                                                                                      |
+
+## CI and repository variables
+
+| Variable           | Where               | Meaning                                                                          |
+| ------------------ | ------------------- | -------------------------------------------------------------------------------- |
+| `ALLOW_LIVE=false` | CI workflow env     | All automated checks run fixture-only; no credentials present.                   |
+| `KEEP_WARM_URL`    | Repository variable | Override target for the keep-warm workflow (defaults to the demo `/health` URL). |
+
+## Profile enforcement summary
+
+| Check                    | `local`           | `public-fixture` | `protected-live`                      |
+| ------------------------ | ----------------- | ---------------- | ------------------------------------- |
+| `ALLOW_LIVE`             | optional          | must be `false`  | must be `true`                        |
+| `FORTYGUARD_API_KEY`     | required iff live | forbidden        | required                              |
+| Basic auth               | off               | off              | required, all routes except `/health` |
+| `FORTYGUARD_CALL_BUDGET` | optional          | n/a              | required, positive                    |
+| `FORTYGUARD_LEDGER_PATH` | optional          | n/a              | required, absolute                    |
+
+Validation happens at startup (`SettingsError`) and is re-enforced at the
+composition boundary (`validate_profile_settings`).

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -1,0 +1,174 @@
+# Tutorial: From Clone To First Fixture-Backed Run
+
+This tutorial takes a new contributor from a fresh clone to a working,
+fixture-backed run of the Heat-Aware Tourism Guide in about fifteen minutes.
+Everything here runs offline: no provider credentials, no FortyGuard account,
+and no billable API calls. Live provider execution is a separate maintainer
+operation described in
+[How to configure live mode](../how-to/configure-live-mode.md).
+
+You will:
+
+- install the Python and Node toolchains,
+- start the FastAPI backend and the React/Vite frontend,
+- run the canonical Menger Hotel to The Alamo trip against committed
+  fixtures,
+- try one alternate scenario and one explicit unavailable state,
+- run the offline quality gates.
+
+## What you need first
+
+- **Git.**
+- **Python 3.12.** The Docker runtime image pins Python 3.12; use the same
+  version locally.
+- **Node.js 22.** The frontend build and the repository tooling (Prettier,
+  Husky, lint-staged, Playwright) run on Node 22.
+- A POSIX shell. Paths below use `.venv/bin/python`; the npm scripts wrap
+  this and also resolve `.venv\Scripts\python.exe` on Windows.
+
+No API keys. The default execution mode is fixture replay, enforced by
+`ALLOW_LIVE=false`.
+
+## Step 1: Clone and create the virtual environment
+
+```bash
+git clone https://github.com/alshawai/heat-aware-tourism-guide.git
+cd heat-aware-tourism-guide
+python3 -m venv .venv
+.venv/bin/python -m pip install -e '.[dev]'
+```
+
+This installs the FastAPI application and its dev tooling (pytest, ruff,
+mypy) into the repository virtual environment. Always invoke this interpreter
+directly (`.venv/bin/python`); the npm scripts do the same through
+`scripts/python-tool.mjs`.
+
+## Step 2: Install the Node tooling
+
+```bash
+npm ci
+npm ci --prefix frontend
+```
+
+The root install provides the shared quality-gate tooling; the frontend
+install provides Vite, ESLint, TypeScript, Vitest, and Playwright. Installing
+at the root also enables the Husky pre-commit hook.
+
+## Step 3: Start the backend
+
+```bash
+ALLOW_LIVE=false .venv/bin/uvicorn app.main:app --reload
+```
+
+The API now serves at `http://127.0.0.1:8000`. Confirm it is healthy and in
+fixture mode:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:8000/health
+```
+
+The response reports `"mode": "fixture"` and
+`"execution_capability": "fixture-only"`. `ALLOW_LIVE=false` is the default;
+stating it explicitly documents intent. With no `FORTYGUARD_API_KEY`
+configured, live execution is impossible, not merely discouraged.
+
+## Step 4: Start the frontend
+
+In a second terminal:
+
+```bash
+npm run frontend:dev
+```
+
+Open `http://127.0.0.1:5173`. The Vite development server proxies `/api` and
+`/health` to the backend on port 8000, so no other configuration is needed.
+
+Prefer one service? Build the frontend once and let FastAPI serve it:
+
+```bash
+npm run frontend:build
+```
+
+Then use `http://127.0.0.1:8000` directly; the backend serves the built
+assets and falls back to the SPA index for deep links. This is the same
+layout the public deployment uses.
+
+## Step 5: Run the canonical trip
+
+The page opens on the trip setup screen with the curated trip already
+selected: Menger Hotel to The Alamo, 08:00 to 20:00.
+
+**Set Date to `2024-07-15`.** This matters: every committed trip fixture was
+acquired for `2024-07-15`, and the fixture adapter matches the exact request
+identity, including the date. The form's default date does not match any
+fixture, so leaving it untouched returns an explicit unavailable state rather
+than a wrong answer. See [How fixtures are matched](#how-fixtures-are-matched)
+below.
+
+Click **Analyze trip**. You should see, in order:
+
+1. The **trip analysis** summary with a "Fixture replay" execution banner and
+   the fixture data date in the provenance footer.
+2. **Best time**: hourly heat evidence for the window and the recommended
+   visit hour, with an hour-only recommendation note (the environment series'
+   provider timezone is inconsistent with `America/Chicago`, so the product
+   recommends an hour, not an exact timestamp).
+3. **Hotel ranking**: ranked Downtown San Antonio hotels with component
+   values and percentiles.
+4. **Route comparison**: one returned walking route on the map. The canonical
+   routing request genuinely returned a single route, so the product shows it
+   with limited-comparison wording instead of inventing a second route.
+
+No network request to FortyGuard, Overpass, or OSRM was made. Every result
+came from `fixtures/` through the same domain schema the live path uses.
+
+## Step 6: Try an alternate scenario and an unavailable state
+
+Still on the trip setup screen, click **Explore another trip**. Search and set
+**San Fernando Cathedral** as origin and **Spanish Governor's Palace** as
+destination. Selecting this place pair pins the fixture's date and hours
+(`2024-07-15`, 10:00-17:00). Analyze again: this scenario returns two routes,
+and because the building-height evidence along the corridor is weak, the
+product shows both routes with all metrics but **no route recommendation**.
+That is the intended weak-evidence behavior, not a failure.
+
+Finally, change the date to any other value and analyze once more. The
+response is an explicit `scenario_unavailable` state with recovery guidance —
+never an empty success. Restore `2024-07-15` when done.
+
+## Step 7: Run the offline quality gates
+
+Confirm your clone passes the same checks CI runs:
+
+```bash
+npm run python:test
+npm run python:test:integration
+npm run frontend:test
+npm run typecheck
+npm run frontend:build
+```
+
+The full command list, including Playwright browser installation for the
+end-to-end fixture flow, is in the
+[commands reference](../reference/commands.md). All automated checks run with
+`ALLOW_LIVE=false` and require no credentials.
+
+## How fixtures are matched
+
+The fixture adapter matches a trip request against each committed fixture's
+sidecar `request_configuration` — mode, landmark and district names, date,
+start and end hour, cautious flag, and origin/destination coordinates
+(compared with a tolerance of `1e-7` degrees). Filenames are never matching
+identity. Zero matches return `scenario_unavailable`; duplicate matches are a
+hard error. The full rules, including provenance sidecar structure, are in
+[ADR 0004](../adr/0004-fixture-cache-provenance-ledger.md) and the
+[fixture acquisition guide](../how-to/acquire-fixtures.md).
+
+## Where to go next
+
+- [How to record the demo](../how-to/record-the-demo.md) and the
+  [demo script](../demo-script.md) with narration.
+- [How to deploy](../how-to/deploy.md) the public fixture service.
+- [Environment variables](../reference/environment-variables.md) and the
+  [API reference](../reference/api.md).
+- [Why the product is built this way](../explanation/architecture.md).


### PR DESCRIPTION
Closes #26

## What this does

Implements the complete Diataxis documentation structure, the narrated demo script, and the submission-artifact polish required by issue #26.

### Structure

- **README** rewritten as a concise landing page: purpose, status, public demo URL, architecture diagram, prerequisites, quality gates, and links into the docs.
- **`docs/README.md`** — new Diataxis map/index.
- **Tutorial:** `docs/tutorials/first-run.md` — clone → first fixture-backed run (canonical trip on `2024-07-15`, alternates, unavailable state, quality gates).
- **How-to guides:** `configure-live-mode`, `acquire-fixtures`, `deploy` (moved from `docs/deployment.md`), `record-the-demo`.
- **Reference:** `environment-variables`, `api`, `domain-schemas`, `commands`, `configuration`.
- **Explanation:** `architecture` (with ADR index), `cost-model`, `heat-metrics`, `hotel-weights`, `shade-assumptions`, `limitations`.
- **`docs/demo-script.md`** expanded with scene-by-scene narration, a deterministic scene order, and fallback handling.

### Accuracy notes

- All claims are worded to match provenance: fixture/live/cache execution modes, returned-alternatives-only routing, modeled-not-measured shade, product-policy-not-NOAA thresholds, no safety/comfort claims, US-only live coverage.
- Research notes are linked where their evidence backs product claims (proposal fact check, issue 7/23/40 notes, lidar feasibility).
- `.env.example` verified secret-free (unchanged).

### Known issue documented, not fixed

The hosted curated form pins `PUBLIC_FIXTURE_DATE = "2026-08-23"` while every committed trip fixture is dated `2024-07-15`, so the hosted curated submission currently returns `scenario_unavailable` (verified live; the hosted API answers correctly for `2024-07-15`). Per maintainer decision this PR keeps the change docs-only: the tutorial, demo script, and record-the-demo guide document entering the fixture date explicitly and call out the pin for correction before recording. The hotel-ranking flow is date-independent and works hosted.

## Verification

- `npm run format:check` — clean
- `npm run typecheck` — clean (mypy 111 files, tsc)
- `npm run test` — 716 Python + 37 frontend tests pass
- `npm run python:test:integration` — 11 pass
- Pre-commit hook (lint-staged + typecheck + tests) passed on commit
- Relative-link check across all docs: no broken links in new/changed files (pre-existing coordinate-as-link artifacts in immutable research notes untouched)