### PR TITLE
fix(live): publish a degraded live analysis instead of HTTP 400

### DIFF
--- a/app/services/trip_adapters.py
+++ b/app/services/trip_adapters.py
@@ -306,19 +306,17 @@ class TemporalTripAnalysisAdapter:
                 route_reason = _route_degradation_reason(routes)
 
         degraded_reasons = {"hotels": "hotel ranking is not implemented on the temporal live path"}
+        best_time_reason = _best_time_degradation_reason(best_time, hourly_failures)
+        if best_time_reason is not None:
+            degraded_reasons["best_time"] = best_time_reason
         if route_reason is not None:
             degraded_reasons["routes"] = route_reason
-        return _round_trip(
-            TripAnalysisResponse(
-                request_identity=_request_identity(request),
-                mode=request.mode,
-                execution_mode=execution_mode,
-                state=ResultState.DEGRADED,
-                best_time=best_time,
-                routes=routes,
-                degraded_reasons=degraded_reasons,
-            ),
+        return _publish(
             request,
+            execution_mode,
+            best_time=best_time,
+            routes=routes,
+            degraded_reasons=degraded_reasons,
         )
 
     def _budget_refusal(
@@ -417,6 +415,15 @@ class TemporalTripAnalysisAdapter:
 
 
 def _route_degradation_reason(routes: RouteComparisonResult) -> str | None:
+    """Name the route limitation, for every condition the contract can see.
+
+    ``TripAnalysisResponse`` requires a reason for each *present* section whose
+    own fields show it is degraded, and rejects a reason for a section that
+    reads as whole; a mismatch either way raises ``degraded reasons must match
+    missing sections``. The conditions below are therefore exactly the ones the
+    contract inspects for ``routes``: every listed decision state, a
+    single-route set, and insufficient confidence.
+    """
     if routes.decision_state is RouteDecisionState.SHADE_REQUIRED:
         return "route heat is elevated; shade analysis is required before recommendation"
     if routes.decision_state is RouteDecisionState.INSUFFICIENT_SHADE_COMPARISON_REQUIRED:
@@ -425,9 +432,45 @@ def _route_degradation_reason(routes: RouteComparisonResult) -> str | None:
         return "shared corridor heat is unavailable"
     if routes.decision_state is RouteDecisionState.NO_SUITABLE_RETURNED_ROUTE:
         return "no returned route has sufficient evidence for recommendation"
+    if routes.decision_state is RouteDecisionState.SHADE_SHADIEST_RECOMMENDED:
+        return "the shadiest route is recommended from modeled building shade, not measured shade"
+    if routes.decision_state is RouteDecisionState.SHADE_ONLY_ROUTE_RECOMMENDED:
+        return "only one route carries shade evidence, so the comparison is limited"
+    if routes.decision_state is RouteDecisionState.NIGHTTIME_COOLEST_RECOMMENDED:
+        return "shade does not apply after dark; the coolest corridor is recommended instead"
     if routes.route_set_state is RouteSetState.SINGLE_ROUTE:
         return "only one pedestrian route was returned; comparison is limited"
+    if routes.confidence is Confidence.INSUFFICIENT:
+        return "route evidence is insufficient for a confident recommendation"
     return None
+
+
+def _best_time_degradation_reason(
+    best_time: BestTimeResult, hourly_failures: Mapping[int, str]
+) -> str | None:
+    """Name the best-time limitation, matching the same contract conditions.
+
+    Partial hourly coverage is deliberately not a condition of its own: the
+    contract does not treat a complete decision over fewer hours as a degraded
+    section, so claiming one here would raise the very error this avoids. The
+    lost hours are already reported in ``recommendation_reason`` and in the
+    provenance's ``unavailable_hours``; they only join this reason when the
+    section is degraded for a reason the contract does recognise.
+    """
+    clauses: list[str] = []
+    if best_time.temporal_evidence is TemporalEvidenceState.INCONSISTENT:
+        clauses.append(
+            "provider timestamps do not line up with the requested local hours; "
+            "the recommendation is hour-only"
+        )
+    if best_time.provenance.confidence is Confidence.INSUFFICIENT:
+        clauses.append("supporting heat evidence is insufficient for a confident recommendation")
+    if not clauses:
+        return None
+    if hourly_failures:
+        missing = ", ".join(f"{hour:02d}:00" for hour in sorted(hourly_failures))
+        clauses.append(f"hourly coverage is partial ({missing} unavailable)")
+    return "; ".join(clauses)
 
 
 def _best_time_result(
@@ -726,6 +769,49 @@ def _round_trip(
     return decode_trip_analysis_v2(
         encode_trip_analysis_v2(response, envelope="snapshot"), request, ExecutionMode.LIVE
     )
+
+
+def _publish(
+    request: TripAnalysisRequest,
+    execution_mode: ExecutionMode,
+    *,
+    best_time: BestTimeResult | None,
+    routes: RouteComparisonResult | None,
+    degraded_reasons: dict[str, str],
+) -> TripAnalysisResponse:
+    """Build and round-trip a degraded live response, degrading rather than raising.
+
+    Both the ``TripAnalysisResponse`` invariants and the strict codec are
+    inside the guard: a response we cannot express is our defect, not a bad
+    request, and the provider calls behind it are already spent.
+    ``_error_response`` in ``app/api.py`` maps a ``ValueError`` here to HTTP 400
+    "Bad Request", which tells the traveler nothing and invites a retry that
+    spends the window again. The product already has a state for "the analysis
+    cannot be shown", so answer in it and name the contract as the cause.
+    """
+    try:
+        return _round_trip(
+            TripAnalysisResponse(
+                request_identity=_request_identity(request),
+                mode=request.mode,
+                execution_mode=execution_mode,
+                state=ResultState.DEGRADED,
+                best_time=best_time,
+                routes=routes,
+                degraded_reasons=degraded_reasons,
+            ),
+            request,
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        return _round_trip(
+            _unavailable_response(
+                request,
+                execution_mode,
+                f"the analysis could not be published in the product contract: {error}",
+                code="contract_violation",
+            ),
+            request,
+        )
 
 
 class ModeDispatchTripAnalysisAdapter:

--- a/frontend/src/app/AppState.tsx
+++ b/frontend/src/app/AppState.tsx
@@ -8,6 +8,8 @@ import {
   type ReactNode,
 } from "react";
 import { dataClient } from "../services/dataClient";
+import { CANONICAL_FIXTURE_SCENARIO } from "../features/trip/fixtureScenarios";
+import { todayIso } from "../features/trip/timeWindow";
 import type {
   HealthResponse,
   HotelRankResponse,
@@ -78,12 +80,25 @@ const DEFAULT_TRIP_SETUP: TripSetup = {
   origin: CANONICAL_ORIGIN,
   destination: CANONICAL_DESTINATION,
   // The date and window the canonical walk was acquired with, so a fixture run
-  // matches the committed scenario without the traveler having to know it.
-  date: "2024-07-15",
-  startHour: 8,
-  endHour: 20,
+  // matches the committed scenario without the traveler having to know it. Live
+  // execution needs the opposite prefill and gets it below, once the health
+  // probe has said which mode is actually running.
+  date: CANONICAL_FIXTURE_SCENARIO.date,
+  startHour: CANONICAL_FIXTURE_SCENARIO.startHour,
+  endHour: CANONICAL_FIXTURE_SCENARIO.endHour,
   cautious: false,
 };
+
+/** Whether the traveler has left the prefilled trip exactly as it arrived. */
+function isPrefilledSetup(setup: TripSetup): boolean {
+  return (
+    setup.date === DEFAULT_TRIP_SETUP.date &&
+    setup.startHour === DEFAULT_TRIP_SETUP.startHour &&
+    setup.endHour === DEFAULT_TRIP_SETUP.endHour &&
+    setup.cautious === DEFAULT_TRIP_SETUP.cautious &&
+    isCanonicalTrip(setup)
+  );
+}
 
 /**
  * The analysis the map, route cards, and route detail should render.
@@ -148,6 +163,20 @@ export function AppProvider({ children }: { children: ReactNode }) {
           mode: value.mode,
           execution_capability: value.execution_capability,
         },
+        // Move the prefilled date to today once live execution is confirmed.
+        // The prefill has to serve fixture replay first, because
+        // `_fixture_matches` compares the date and only the acquired one can
+        // match. Live execution would answer that same date with readings from
+        // two years ago — an honest answer to a request no traveler meant — so
+        // live starts on today instead. Only an untouched prefill moves, and
+        // only while no analysis is on screen, so a chosen historical date
+        // survives a later re-check and no rendered result changes underneath.
+        tripSetup:
+          value.mode === "live" &&
+          current.tripResults === null &&
+          isPrefilledSetup(current.tripSetup)
+            ? { ...current.tripSetup, date: todayIso() }
+            : current.tripSetup,
       }));
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;

--- a/frontend/src/features/trip/TripScreens.test.tsx
+++ b/frontend/src/features/trip/TripScreens.test.tsx
@@ -407,6 +407,23 @@ const fixtureHealth = {
   execution_capability: "fixture-only",
 };
 
+const liveHealth = {
+  status: "ok",
+  deployment_profile: "protected-live",
+  mode: "live",
+  execution_capability: "fixture-and-live",
+};
+
+/**
+ * Local dates derived without the helpers under test, so a wrong helper cannot
+ * agree with a wrong assertion. `en-CA` formats as `YYYY-MM-DD`.
+ */
+function localDate(offsetDays = 0) {
+  return new Date(Date.now() + offsetDays * 86_400_000).toLocaleDateString(
+    "en-CA"
+  );
+}
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -603,6 +620,46 @@ describe("trip setup", () => {
     expect(await screen.findByText("Live data")).toBeInTheDocument();
     expect(date).toHaveValue("2026-09-01");
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("starts a live trip on today and bounds the date to the provider's span", async () => {
+    const fetchMock = mockFetch(jsonResponse(liveHealth));
+    const user = userEvent.setup();
+
+    await openSetup(user);
+
+    expect(screen.getByText("Live data")).toBeInTheDocument();
+    // The committed fixture date is the prefill fixture replay needs; live
+    // execution would answer it with readings from two years ago, so live mode
+    // starts on today.
+    const date = screen.getByLabelText("Date");
+    expect(date).toHaveValue(localDate());
+    expect(date).toHaveAttribute("min", "2019-01-01");
+    expect(date).toHaveAttribute("max", localDate(1));
+    expect(
+      screen.getByText(/Live readings run from 2019-01-01 to tomorrow/)
+    ).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a date live data cannot reach before spending an analysis", async () => {
+    const fetchMock = mockFetch(jsonResponse(liveHealth));
+    const user = userEvent.setup();
+
+    const analyze = await openSetup(user);
+    const date = screen.getByLabelText("Date");
+    await user.clear(date);
+    await user.type(date, localDate(10));
+    await user.click(analyze);
+
+    expect(
+      screen.getByText(
+        "Live readings reach only tomorrow's forecast. Choose today or tomorrow."
+      )
+    ).toBeInTheDocument();
+    // Only the health probe: an analysis the provider cannot serve is not spent.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(date).toHaveFocus();
   });
 
   it("locks public fixture facts while keeping cautious guidance selectable", async () => {

--- a/frontend/src/features/trip/TripScreens.tsx
+++ b/frontend/src/features/trip/TripScreens.tsx
@@ -47,8 +47,11 @@ import {
   INVALID_DATE_MESSAGE,
   isValidDate,
   lastHour,
+  LIVE_EARLIEST_DATE,
+  liveLatestDate,
   SAME_ENDPOINTS_MESSAGE,
   START_HOUR_OPTIONS,
+  validateLiveDate,
   validateTimeWindow,
 } from "./timeWindow";
 import { UnavailableNotice } from "./UnavailableNotice";
@@ -174,6 +177,9 @@ export function TripSetupScreen() {
   const effective = effectiveSetup(tripSetup, health);
   const fixtureMode =
     health.status === "available" && health.mode === "fixture";
+  // Live execution reaches only the provider's own span, so the date field is
+  // bounded and validated against it rather than against the calendar.
+  const liveMode = health.status === "available" && health.mode === "live";
   const fixtureScenario = fixtureMode
     ? fixtureScenarioFor(effective.origin, effective.destination)
     : undefined;
@@ -222,7 +228,13 @@ export function TripSetupScreen() {
 
   async function submit(event?: FormEvent) {
     event?.preventDefault();
-    const invalidDate = !isValidDate(effective.date);
+    // In live mode the calendar is not the constraint the provider is: a date
+    // outside its span cannot produce readings, so it must not be spendable.
+    const dateProblem = liveMode
+      ? validateLiveDate(effective.date)
+      : isValidDate(effective.date)
+        ? null
+        : INVALID_DATE_MESSAGE;
     const windowError = validateTimeWindow(
       effective.startHour,
       effective.endHour
@@ -233,7 +245,7 @@ export function TripSetupScreen() {
       effective.origin.latitude === effective.destination.latitude &&
       effective.origin.longitude === effective.destination.longitude;
 
-    setDateError(invalidDate ? INVALID_DATE_MESSAGE : "");
+    setDateError(dateProblem ?? "");
     // An out-of-order window is reported on both selects, because either one
     // can be the field the traveler wants to change.
     setStartError(
@@ -246,8 +258,8 @@ export function TripSetupScreen() {
     );
     setEndpointError(sameEndpoints ? SAME_ENDPOINTS_MESSAGE : "");
 
-    if (invalidDate || windowError || sameEndpoints) {
-      if (invalidDate) dateRef.current?.focus();
+    if (dateProblem || windowError || sameEndpoints) {
+      if (dateProblem) dateRef.current?.focus();
       else if (invalidOrder) startRef.current?.focus();
       else if (windowError) endRef.current?.focus();
       else document.getElementById("endpoint-origin")?.focus();
@@ -301,6 +313,8 @@ export function TripSetupScreen() {
                 id="trip-date"
                 type="date"
                 value={effective.date}
+                min={liveMode ? LIVE_EARLIEST_DATE : undefined}
+                max={liveMode ? liveLatestDate() : undefined}
                 disabled={busy || publicFixture}
                 aria-invalid={Boolean(dateError)}
                 aria-describedby={dateError ? "date-error" : undefined}
@@ -393,6 +407,14 @@ export function TripSetupScreen() {
               and hours follow the committed scenario. Another date returns the
               server&apos;s no-matching-fixture answer rather than invented
               data.
+            </p>
+          )}
+          {liveMode && (
+            <p className="fixture-facts" role="note">
+              Live readings run from {LIVE_EARLIEST_DATE} to tomorrow&apos;s
+              forecast ({liveLatestDate()}); anything past tomorrow has not been
+              measured or forecast yet. Each hour in the window is a separate
+              provider request, so a shorter window costs less.
             </p>
           )}
 

--- a/frontend/src/features/trip/timeWindow.ts
+++ b/frontend/src/features/trip/timeWindow.ts
@@ -93,3 +93,56 @@ export function validateTimeWindow(
 
 export const INVALID_DATE_MESSAGE = "Enter a valid date.";
 export const SAME_ENDPOINTS_MESSAGE = "Choose two different endpoints.";
+
+/**
+ * Live-mode date rules, mirrored from the provider adapter.
+ *
+ * `HeatmapRequest.__post_init__` (`app/integrations/fortyguard/contracts.py`)
+ * treats any date from today onwards as a forecast and rejects one past
+ * tomorrow outright, and `HISTORICAL_EARLIEST` in
+ * `app/integrations/fortyguard/live.py` is the documented historical floor. A
+ * date outside that span cannot produce readings, so it must not be spendable.
+ */
+export const LIVE_EARLIEST_DATE = "2019-01-01";
+
+function isoDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+/** Today in the traveler's own timezone, which is the date they mean. */
+export function todayIso(reference: Date = new Date()): string {
+  const local = new Date(
+    reference.getTime() - reference.getTimezoneOffset() * 60_000
+  );
+  return isoDate(local);
+}
+
+/** The latest date live provider data reaches: tomorrow's forecast. */
+export function liveLatestDate(reference: Date = new Date()): string {
+  const local = new Date(
+    reference.getTime() - reference.getTimezoneOffset() * 60_000
+  );
+  local.setUTCDate(local.getUTCDate() + 1);
+  return isoDate(local);
+}
+
+/**
+ * Why a live analysis cannot be spent on this date, or `null` when it can.
+ *
+ * Fixture replay is not checked here: it answers only the dates its committed
+ * scenarios were acquired with, and the server's own refusal is the honest
+ * answer for anything else.
+ */
+export function validateLiveDate(
+  value: string,
+  reference: Date = new Date()
+): string | null {
+  if (!isValidDate(value)) return INVALID_DATE_MESSAGE;
+  if (value > liveLatestDate(reference)) {
+    return "Live readings reach only tomorrow's forecast. Choose today or tomorrow.";
+  }
+  if (value < LIVE_EARLIEST_DATE) {
+    return `Live readings start at ${LIVE_EARLIEST_DATE}.`;
+  }
+  return null;
+}

--- a/tests/test_temporal_trip_orchestration.py
+++ b/tests/test_temporal_trip_orchestration.py
@@ -15,6 +15,7 @@ from app.domain.contracts import (
     ExecutionMode,
     ResultState,
     RouteDecisionState,
+    TemporalEvidenceState,
     TripAnalysisRequest,
     TripMode,
 )
@@ -23,7 +24,7 @@ from app.integrations.fortyguard.contracts import EnvParamsRequest, HeatmapReque
 from app.services.execution import EnvParamsExecution, HeatmapExecution
 from app.services.route_analysis import RouteAnalysisService
 from app.services.routing import RouteExecution
-from app.services.trip_adapters import TemporalTripAnalysisAdapter
+from app.services.trip_adapters import TemporalTripAnalysisAdapter, _publish
 from app.settings import AppSettings
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -267,6 +268,176 @@ def test_one_failing_hour_keeps_the_remaining_series_and_records_the_gap(tmp_pat
     assert response.best_time.provenance.note is not None
     assert "13:00" in response.best_time.provenance.note
     assert "13:00" in response.best_time.recommendation_reason
+
+
+def _shifted_hour_payload(hour: int, value: float) -> dict[str, object]:
+    """A single-hour response stamped in the provider's own offset, not ours.
+
+    Recorded provider behaviour: the acquired canonical scenario came back
+    stamped GMT-7 for a San Antonio request (America/Chicago, GMT-5 in August),
+    so the timestamp cannot confirm the requested local hour and
+    ``_best_time_result`` reads it as ``INCONSISTENT``. Live analyses hit this
+    routinely, so it must publish as a limitation rather than an error.
+    """
+    return {
+        "mode": "historical",
+        "features": [
+            {
+                "geometry": {"type": "Point", "coordinates": [-98.485833, 29.425833]},
+                "properties": {
+                    "id": f"tcm-{hour:02d}",
+                    "value": value,
+                    "unit": "C",
+                    "valid_time": f"2026-08-23T{hour:02d}:00:00-07:00",
+                },
+            }
+        ],
+    }
+
+
+def _shifted_adapter(tmp_path: Path, *, failing_hour: int | None = None) -> Any:
+    def load_heatmap(request: HeatmapRequest) -> Mapping[str, object]:
+        if request.analytic_type.value != "tcm":
+            return _framing_payload(1.0)
+        assert request.start_hour is not None
+        if request.start_hour == failing_hour:
+            raise ConnectionError(f"hour {failing_hour} unavailable")
+        return _shifted_hour_payload(request.start_hour, 30.0 + request.start_hour)
+
+    return TemporalTripAnalysisAdapter(
+        HeatmapExecution(fixture_path=tmp_path / "heatmap.json", live_loader=load_heatmap),
+        EnvParamsExecution(
+            fixture_path=tmp_path / "env.json",
+            live_loader=lambda request: _env_payload(),
+        ),
+    )
+
+
+def test_conflicting_provider_timezone_publishes_a_best_time_limitation(
+    tmp_path: Path,
+) -> None:
+    """The live "Bad Request": a timezone conflict is a limitation, not an error.
+
+    ``TripAnalysisResponse`` requires a reason for a present section whose own
+    fields show it is degraded, and ``INCONSISTENT`` temporal evidence is one of
+    those fields. Assembling the response without that reason raised
+    ``degraded reasons must match missing sections``, which ``app/api.py`` maps
+    to HTTP 400 — after every provider call in the window was already spent.
+    """
+    response = _shifted_adapter(tmp_path).analyze(_request(), ExecutionMode.LIVE)
+
+    assert response.state is ResultState.DEGRADED
+    assert response.best_time is not None
+    assert response.best_time.temporal_evidence is TemporalEvidenceState.INCONSISTENT
+    assert response.degraded_reasons is not None
+    assert "hour-only" in response.degraded_reasons["best_time"]
+    assert tuple(entry.hour for entry in response.best_time.hourly) == tuple(range(8, 20))
+
+
+def test_a_lost_hour_alone_is_not_a_best_time_limitation(tmp_path: Path) -> None:
+    """The same invariant from the other side: no reason for a whole section.
+
+    A complete decision over fewer hours is still whole, so the lost hour is
+    reported in the recommendation and the provenance only. Claiming a
+    ``best_time`` limitation here would raise the very same error.
+    """
+
+    def load_heatmap(request: HeatmapRequest) -> Mapping[str, object]:
+        if request.analytic_type.value != "tcm":
+            return _framing_payload(1.0)
+        assert request.start_hour is not None
+        if request.start_hour == 13:
+            raise ConnectionError("hour 13 unavailable")
+        return _hour_payload(request.start_hour, 30.0 + request.start_hour)
+
+    adapter = TemporalTripAnalysisAdapter(
+        HeatmapExecution(fixture_path=tmp_path / "heatmap.json", live_loader=load_heatmap),
+        EnvParamsExecution(
+            fixture_path=tmp_path / "env.json",
+            live_loader=lambda request: _env_payload(),
+        ),
+    )
+
+    response = adapter.analyze(_request(), ExecutionMode.LIVE)
+
+    assert response.state is ResultState.DEGRADED
+    assert response.best_time is not None
+    assert response.best_time.temporal_evidence is TemporalEvidenceState.EXACT
+    assert response.degraded_reasons is not None
+    assert "best_time" not in response.degraded_reasons
+    assert "13:00" in response.best_time.recommendation_reason
+
+
+def test_timezone_conflict_and_lost_hour_are_reported_in_one_reason(
+    tmp_path: Path,
+) -> None:
+    response = _shifted_adapter(tmp_path, failing_hour=13).analyze(_request(), ExecutionMode.LIVE)
+
+    assert response.degraded_reasons is not None
+    reason = response.degraded_reasons["best_time"]
+    assert "hour-only" in reason
+    assert "13:00" in reason
+    assert response.best_time is not None
+    assert 13 not in {entry.hour for entry in response.best_time.hourly}
+
+
+def test_a_response_the_contract_rejects_is_unavailable_not_a_bad_request(
+    tmp_path: Path,
+) -> None:
+    """Any future mismatch degrades legibly instead of billing for a 400."""
+    analyzed = _shifted_adapter(tmp_path).analyze(_request(), ExecutionMode.LIVE)
+    assert analyzed.best_time is not None
+
+    published = _publish(
+        _request(),
+        ExecutionMode.LIVE,
+        best_time=analyzed.best_time,
+        routes=None,
+        degraded_reasons={
+            "hotels": "hotel ranking is not implemented on the temporal live path",
+            "routes": "route comparison is not configured on the temporal live path",
+        },
+    )
+
+    assert published.state is ResultState.UNAVAILABLE
+    assert published.unavailable is not None
+    assert published.unavailable.code == "contract_violation"
+    assert published.unavailable.recoverable is True
+    assert "degraded reasons must match missing sections" in published.unavailable.reason
+
+
+def test_live_endpoint_answers_a_timezone_conflict_with_200(tmp_path: Path) -> None:
+    _copy_hotel_fixture(tmp_path)
+    client = TestClient(
+        create_app(
+            tmp_path / "heatmap.json",
+            allow_live=True,
+            trip_adapter=_shifted_adapter(tmp_path),
+        )
+    )
+
+    response = client.post(
+        "/api/trip/analyze",
+        json={
+            "origin_latitude": 29.4245914,
+            "origin_longitude": -98.4864288,
+            "destination_latitude": 29.425833,
+            "destination_longitude": -98.485833,
+            "mode": "curated",
+            "landmark_name": "The Alamo",
+            "district_name": "Downtown San Antonio",
+            "date": "2026-08-23",
+            "start_hour": 8,
+            "end_hour": 20,
+            "execution_mode": "live",
+        },
+    )
+
+    assert response.status_code == 200
+    body: dict[str, Any] = response.json()
+    assert body["state"] == "degraded"
+    assert "hour-only" in body["degraded_reasons"]["best_time"]
+    assert body["best_time"]["temporal_evidence"] == "inconsistent"
 
 
 def test_preflight_budget_guard_refuses_without_spending_a_call(tmp_path: Path) -> None:


### PR DESCRIPTION
## The bug

Every live `POST /api/trip/analyze` answered **400 Bad Request** — after the whole
window's provider calls were already spent — while `/health` and
`/api/hotels/rank` were fine.

Root cause: `TripAnalysisResponse` requires a degraded reason for each *present*
section whose own fields show it is degraded, and refuses one for a section that
reads as whole; a mismatch either way raises `degraded reasons must match missing
sections`, which `app/api.py::_error_response` maps to 400. The live path emitted
reasons for `hotels` and `routes` only, so any analysis whose `best_time` carried
`INCONSISTENT` temporal evidence raised from the constructor. That is not an edge
case: the provider stamps its tiles GMT-7 for a GMT-5 request, so live hits it
every time.

## The fix

- Derive the `best_time` reason from the same conditions the contract inspects,
  and give `_route_degradation_reason` the three decision states it had no
  sentence for (`SHADE_SHADIEST_RECOMMENDED`, `SHADE_ONLY_ROUTE_RECOMMENDED`,
  `NIGHTTIME_COOLEST_RECOMMENDED`) plus generic insufficient confidence.
  Partial hourly coverage deliberately stays out of it — a complete decision over
  fewer hours is whole, and claiming a limitation there raises the same error
  from the other side.
- Assemble and round-trip the response inside `_publish`, so any future mismatch
  answers with the product's `unavailable` state and a legible reason instead of
  billing a traveler for a 400.

## Live prefill

The committed `2024-07-15` is what lets a fixture run match `_fixture_matches` at
all, but live would answer it with readings from two years ago. Live mode now
starts on today, bounds the date field to the provider's `2019-01-01..tomorrow`
span, refuses an unreachable date before spending an analysis, and says so on the
setup screen. Only an untouched prefill moves, and only while no analysis is on
screen, so a chosen historical date survives a health re-check.

## Verification

- `npm run python:test` — 728 passed (5 new: the timezone conflict, the
  no-reason-for-a-whole-section direction, both together, the `_publish` guard,
  and a 200 at the HTTP boundary)
- `npm run typecheck`, `npm run format:check` — clean
- `npx vitest run` — 38 passed (2 new live-mode tests)
- `E2E_PORT=8099 npx playwright test` — 4/4 fixture scenarios
- **Live confirmation** (6 billable calls): `today 12:00–15:00` → HTTP 200,
  `state: degraded`, three real hours — 12:00 39.4 °C, 13:00 38.1 °C,
  14:00 37.5 °C (`noaa_heat_index`), `unavailable_hours: []`. Live also confirms
  `temporal_evidence: inconsistent`, exactly the case that used to 400.

Still open and unchanged: `routes` returns
`insufficient_shade_comparison_required` on this corridor — the building-height
coverage problem awaiting the LiDAR scope decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)